### PR TITLE
Replace special chars in primary_slot_name by an underscore

### DIFF
--- a/roles/init_dbserver/tasks/pg_set_superuser_password.yml
+++ b/roles/init_dbserver/tasks/pg_set_superuser_password.yml
@@ -31,6 +31,6 @@
   vars:
     pg_postgres_conf_params:
         - name: primary_slot_name
-          value: "{{ item.key }}"
+          value: "{{ item.key | regex_replace('[^a-zA-Z0-9_]', '_') }}"
   when:
     - pg_version|int > 11


### PR DESCRIPTION
To prevent this kind of error when the hostname contains special chars that are not allowed in a slot name:
```
TASK [manage_dbserver : Check user defined parameters and update] ********************************************************************************************************************************************************************************************
failed: [primary-centos8.home.virt -> 192.168.122.33] (item={'name': 'primary_slot_name', 'value': 'primary-centos8'}) => {"ansible_loop_var": "line_item", "changed": false, "line_item": {"name": "primary_slot_name", "value": "primary-centos8"}, "msg": "Unable to get primary_slot_name value due to : invalid value for parameter \"primary_slot_name\": \"primary-centos8\"\n"}
```