### PR TITLE
Load firewalld rules immediately

### DIFF
--- a/playbook-examples/rhel_firewalld_rule.yml
+++ b/playbook-examples/rhel_firewalld_rule.yml
@@ -25,6 +25,7 @@
         port: 5444/tcp
         permanent: yes
         state: enabled
+        immediate: true
       delegate_to: "{{ item.value.public_ip }}"
       with_dict: "{{ servers }}"
 
@@ -33,6 +34,7 @@
         port: 5432/tcp
         permanent: yes
         state: enabled
+        immediate: true
       delegate_to: "{{ item.value.public_ip }}"
       with_dict: "{{ servers }}"
 
@@ -41,5 +43,6 @@
         port: 7800-7810/tcp
         permanent: yes
         state: enabled
+        immediate: true
       delegate_to: "{{ item.value.public_ip }}"
       with_dict: "{{ servers }}"


### PR DESCRIPTION
Ansible `firewalld`module permits to load the new rule immediately, meaning that if used we don't have to reload `firewalld` manually to apply the new rules.