### PR TITLE
PgBouncer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,29 @@ This role helps in setting PEM Server and deployment of PEM Agent on the PG/EPAS
 For more information on the role, please refer roles README
 [README.md](./roles/setup_pem/README.md)
 
-
 ### manage_dbserver
 
 This role helps in managing the HA cluster and covers common tasks.
 For more information on the role, please refer roles README
 [README.md](./roles/manage_dbserver/README.md)
 
+### setup_pgbouncer
+
+This role install and configure a new PgBouncer connection pooler.
+For more information on the role, please refer roles README
+[README.md](./roles/setup_pgbouncer/README.md)
+
+### manage_pgbouncer_databases
+
+This role helps in managing PgBouncer connection pools list.
+For more information on the role, please refer roles README
+[README.md](./roles/manage_pgbouncer_databases/README.md)
+
+### manage_pgbouncer_users
+
+This role helps in managing PgBouncer credentials list.
+For more information on the role, please refer roles README
+[README.md](./roles/manage_pgbouncer_users/README.md)
 
 ## Pre-Requisites
 
@@ -181,23 +197,29 @@ Content of the `hosts.yml` file:
           node_type: pemserver
           public_ip: xxx.xxx.xxx.xxx
           private_ip: xxx.xxx.xxx.xxx
+        pooler:
+          node_type: pgbouncer
+          public_ip: xxx.xxx.xxx.xxx
         primary1:
           node_type: primary
           public_ip: xxx.xxx.xxx.xxx
           private_ip: xxx.xxx.xxx.xxx
-          pem_agent: True
+          pem_agent: true
+          pgbouncer: true
         standby11:
           node_type: standby
           public_ip: xxx.xxx.xxx.xxx
           private_ip: xxx.xxx.xxx.xxx
           replication_type: synchronous
-          pem_agent: True
+          pem_agent: true
+          pgbouncer: true
         standby12:
           node_type: standby
           public_ip: xxx.xxx.xxx.xxx
           private_ip: xxx.xxx.xxx.xxx
           replication_type: asynchronous
-          pem_agent: True
+          pem_agent: true
+          pgbouncer: true
 ```
 
 
@@ -234,13 +256,18 @@ Below is an example of how to include roles for a deployment in a playbook:
        - setup_efm
        - setup_pem
        - manage_dbserver
+       - setup_pgbouncer
+       - manage_pgbouncer_users
+       - manage_pgbouncer_databases
 ```
 
 Defining and adding variables can be done in the `set_fact` of the `pre-tasks`.
 
 You can customize the above example to install Postgres, EPAS, EFM or PEM or
 limit what roles you would like to execute: `setup_repo`, `install_dbserver`,
-`init_dbserver`, `setup_replication`, `setup_efm`, `setup_pem` or `manage_dbserver`.
+`init_dbserver`, `setup_replication`, `setup_efm`, `setup_pem`,
+`manage_dbserver`, `setup_pgbouncer`, `manage_pgbouncer_users` or
+`manage_pgbouncer_databases`.
 
 
 ## Default user and passwords

--- a/roles/manage_pgbouncer_databases/README.md
+++ b/roles/manage_pgbouncer_databases/README.md
@@ -1,0 +1,160 @@
+# manage_pgbouncer_databases
+
+This role is for managing PgBouncer database list (connection pools).
+PgBouncer is a lightweight connection pooler for PostgreSQL.
+
+## Requirements
+
+Following are the dependencies and requirement of this role.
+  1. Ansible
+  2. `edb-devops.postgres` -> `setup_pgbouncer` role for setting up PgBouncer
+     on the systems.
+
+## Role Variables
+
+When executing the role via ansible these are the required variables:
+
+  * ***os***
+
+    Operating Systems supported are: CentOS7, CentOS8, RHEL7 and RHEL8
+
+The rest of the variables can be configured and are available in the:
+* [roles/manage_pgbouncer_databases/defaults/main.yml](./defaults/main.yml)
+
+Below is the documentation of the rest of the variables:
+
+### `pgbouncer_user`
+
+System user account that runs PgBouncer process and owns its configuration
+files. Default: `pgbouncer`
+
+Example:
+```yaml
+pgbouncer_user: "pgbouncer"
+```
+
+### `pgbouncer_group`
+
+System group that PgBouncer system user is part of. Default: `pgbouncer`
+
+Example:
+```yaml
+pgbouncer_group: "pgbouncer"
+```
+
+### `pgbouncer_pid_file`
+
+PID file path. Default: `/run/pgbouncer/pgbouncer.pid`
+
+Example:
+```yaml
+pgbouncer_pid_file: "/run/pgbouncer/pgbouncer.pid"
+```
+
+### `pgbouncer_databases_file`
+
+Configuration file path that contains databases (connection pools)
+configuration.
+Default: `/etc/pgbouncer/databases.ini`
+
+Example:
+```yaml
+pgbouncer_databases_file: "/etc/pgbouncer/databases.ini"
+```
+
+### `pgbouncer_databases_list`
+
+List of databases (connection pools).
+Default:
+```yaml
+  - dbname: "*"
+    host: "127.0.0.1"
+    port: 5432
+    pool_size: 20
+    pool_mode: "session"
+    max_db_connections: 100
+    reserve_pool: 0
+```
+
+Example:
+```yaml
+pgbouncer_databases_list:
+  - dbname: "my_db"
+    host: "xxx.xxx.xxx.xxx"
+    port: 5432
+    pool_size: 50
+    pool_mode: "transaction"
+    max_db_connections: 100
+    reserve_pool: 10
+```
+
+## Dependencies
+
+This role does not have any dependencies, but a PgBouncer instance should have
+been deployed beforehand with the `setup_pgbouncer` role.
+
+## Example Playbook
+
+### Hosts file content
+
+To manage PgBouncer as a standalone application on a dedicated host,
+`node_type` should be set up to `pgbouncer`. When managing PgBouncer alongside
+a Postgres instance, the key `pgbouncer` should be set up to `true`.
+
+`hosts.yml` content example:
+```yaml
+---
+servers:
+  pooler:
+    node_type: pgbouncer
+    public_ip: xxx.xxx.xxx.xxx
+  main:
+    node_type:  primary
+    public_ip: xxx.xxx.xxx.xxx
+    private_ip: xxx.xxx.xxx.xxx
+    pgbouncer: true
+```
+
+### How to include the `manage_pgbouncer_databases` role in your Playbook
+
+Below is an example of how to include the `manage_pgbouncer_databases` role:
+```yaml
+---
+- hosts: localhost
+  name: Manage PgBouncer databases
+  become: true
+  gather_facts: no
+
+  collections:
+    - edb_devops.edb_postgres
+
+  vars_files:
+    - hosts.yml
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        os: "CentOS8"
+        pgbouncer_databases_list:
+          - dbname: "db1"
+            host: "xxx.xxx.xxx.xxx"
+            port: 5432
+            pool_size: 50
+            pool_mode: "transaction"
+            max_db_connections: 100
+            reserve_pool: 10
+          - dbname: "db2"
+            host: "xxx.xxx.xxx.xxx"
+            port: 5432
+            pool_size: 10
+            pool_mode: "session"
+            max_db_connections: 100
+            reserve_pool: 0
+
+  roles:
+    - manage_pgbouncer_databases
+```
+
+## License
+
+BSD

--- a/roles/manage_pgbouncer_databases/defaults/main.yml
+++ b/roles/manage_pgbouncer_databases/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# PgBouncer system user & group
+pgbouncer_user: "pgbouncer"
+pgbouncer_group: "pgbouncer"
+# PID file
+pgbouncer_pid_file: "/run/pgbouncer/pgbouncer.pid"
+# Databases configuration file
+pgbouncer_databases_file: "/etc/pgbouncer/databases.ini"
+
+# Databases configuration
+pgbouncer_databases_list:
+  - dbname: "*"
+    host: "127.0.0.1"
+    port: 5432
+    pool_size: 20
+    pool_mode: "session"
+    max_db_connections: 100
+    reserve_pool: 0
+
+supported_os:
+  - CentOS7
+  - CentOS8
+  - RHEL7
+  - RHEL8

--- a/roles/manage_pgbouncer_databases/tasks/main.yml
+++ b/roles/manage_pgbouncer_databases/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# Tasks file for manage_pgbouncer_databases Role
+
+# Check if the Operating System is supported
+- name: Check support for Operating System
+  fail:
+    msg: "Operating System = {{ os }} not supported."
+  when: os not in supported_os
+
+- name: Include the pgbouncer_set_databases
+  include_tasks: pgbouncer_set_databases.yml
+  when: item.value.pgbouncer is true or item.value.node_type == 'pgbouncer'
+  with_dict:  "{{ servers }}"

--- a/roles/manage_pgbouncer_databases/tasks/pgbouncer_set_databases.yml
+++ b/roles/manage_pgbouncer_databases/tasks/pgbouncer_set_databases.yml
@@ -1,0 +1,14 @@
+---
+- name: Generate PgBouncer databases configuration file {{ pgbouncer_databases_file }}
+  template:
+    backup: yes
+    dest: "{{ pgbouncer_databases_file }}"
+    owner: "{{ pgbouncer_user }}"
+    group: "{{ pgbouncer_group }}"
+    src: databases.ini.template
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Reload PgBouncer configuration
+  shell:
+    cmd: kill -HUP $(cat {{ pgbouncer_pid_file }})
+  delegate_to: "{{ item.value.public_ip }}"

--- a/roles/manage_pgbouncer_databases/templates/databases.ini.template
+++ b/roles/manage_pgbouncer_databases/templates/databases.ini.template
@@ -1,0 +1,7 @@
+[databases]
+{% if pgbouncer_databases_list is defined %}
+{% for db_item in pgbouncer_databases_list %}
+{{ db_item.dbname }} = {% if db_item.host is defined %}host={{ db_item.host }}{% endif %}{% if db_item.port is defined %} port={{ db_item.port }}{% endif %}{% if db_item.pool_size is defined %} pool_size={{ db_item.pool_size }}{% endif %}{% if db_item.pool_mode is defined %} pool_mode={{ db_item.pool_mode }}{% endif %}{% if db_item.max_db_connections is defined %} max_db_connections={{ db_item.max_db_connections }}{% endif %}{% if db_item.reserve_pool is defined %} reserve_pool={{ db_item.reserve_pool }}{% endif %}
+
+{% endfor %}
+{% endif %}

--- a/roles/manage_pgbouncer_users/README.md
+++ b/roles/manage_pgbouncer_users/README.md
@@ -1,0 +1,141 @@
+# manage_pgbouncer_users
+
+This role is for managing PgBouncer users.
+PgBouncer is a lightweight connection pooler for PostgreSQL.
+
+## Requirements
+
+Following are the dependencies and requirement of this role.
+  1. Ansible
+  2. `edb-devops.postgres` -> `setup_pgbouncer` role for setting up PgBouncer
+     on the systems.
+
+## Role Variables
+
+When executing the role via ansible these are the required variables:
+
+  * ***os***
+
+    Operating Systems supported are: CentOS7, CentOS8, RHEL7 and RHEL8
+
+The rest of the variables can be configured and are available in the:
+* [roles/manage_pgbouncer_users/defaults/main.yml](./defaults/main.yml)
+
+Below is the documentation of the rest of the variables:
+
+### `pgbouncer_user`
+
+System user account that runs PgBouncer process and owns its configuration
+files. Default: `pgbouncer`
+
+Example:
+```yaml
+pgbouncer_user: "pgbouncer"
+```
+
+### `pgbouncer_group`
+
+System group that PgBouncer system user is part of. Default: `pgbouncer`
+
+Example:
+```yaml
+pgbouncer_group: "pgbouncer"
+```
+
+### `pgbouncer_pid_file`
+
+PID file path. Default: `/run/pgbouncer/pgbouncer.pid`
+
+Example:
+```yaml
+pgbouncer_pid_file: "/run/pgbouncer/pgbouncer.pid"
+```
+
+### `pgbouncer_auth_file`
+
+The path of the file to load user names and passwords from.
+Default: `/etc/pgbouncer/userlist.txt`
+
+Example:
+```yaml
+pgbouncer_auth_file: "/etc/pgbouncer/userlist.txt"
+```
+
+### `pgbouncer_auth_user_list`
+
+List of user names and passwords residing in the authentication file.
+Default: `[]`
+
+Example:
+```yaml
+pgbouncer_auth_user_list:
+  - username: "my_user"
+    password: "SCRAM-SHA-256$4096:xxx...xxx"
+  - username: "pgbouncer_admin"
+    password: "xxxxxx"
+  - username: "pgbouncer_stats"
+    password: "xxxxxx"
+```
+
+## Dependencies
+
+This role does not have any dependencies, but a PgBouncer instance should have
+been deployed beforehand with the `setup_pgbouncer` role.
+
+## Example Playbook
+
+### Hosts file content
+
+To manage PgBouncer as a standalone application on a dedicated host,
+`node_type` should be set up to `pgbouncer`. When managing PgBouncer alongside
+a Postgres instance, the key `pgbouncer` should be set up to `true`.
+
+`hosts.yml` content example:
+```yaml
+---
+servers:
+  pooler:
+    node_type: pgbouncer
+    public_ip: xxx.xxx.xxx.xxx
+  main:
+    node_type:  primary
+    public_ip: xxx.xxx.xxx.xxx
+    private_ip: xxx.xxx.xxx.xxx
+    pgbouncer: true
+```
+
+### How to include the `manage_pgbouncer_users` role in your Playbook
+
+Below is an example of how to include the `manage_pgbouncer_users` role:
+```yaml
+---
+- hosts: localhost
+  name: Manage PgBouncer users
+  become: true
+  gather_facts: no
+
+  collections:
+    - edb_devops.edb_postgres
+
+  vars_files:
+    - hosts.yml
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        os: "CentOS8"
+        pgbouncer_auth_user_list:
+          - username: "my_user"
+            password: "SCRAM-SHA-256$4096:xxx...xxx"
+          - username: "pgbouncer_admin"
+            password: "xxxxxx"
+          - username: "pgbouncer_stats"
+            password: "xxxxxx"
+
+  roles:
+    - manage_pgbouncer_users
+```
+
+## License
+
+BSD

--- a/roles/manage_pgbouncer_users/defaults/main.yml
+++ b/roles/manage_pgbouncer_users/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# PgBouncer system user & group
+pgbouncer_user: "pgbouncer"
+pgbouncer_group: "pgbouncer"
+
+# Authentication file path
+pgbouncer_auth_file: "/etc/pgbouncer/userlist.txt"
+# User names & passwords list
+pgbouncer_auth_user_list: []
+
+# PID file
+pgbouncer_pid_file: "/run/pgbouncer/pgbouncer.pid"
+
+supported_os:
+  - CentOS7
+  - CentOS8
+  - RHEL7
+  - RHEL8

--- a/roles/manage_pgbouncer_users/tasks/main.yml
+++ b/roles/manage_pgbouncer_users/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# Tasks file for manage_pgbouncer_users Role
+
+# Check if the Operating System is supported
+- name: Check support for Operating System
+  fail:
+    msg: "Operating System = {{ os }} not supported."
+  when: os not in supported_os
+
+- name: Include the pgbouncer_set_userlist
+  include_tasks: pgbouncer_set_userlist.yml
+  when: item.value.pgbouncer is true or item.value.node_type == 'pgbouncer'
+  with_dict:  "{{ servers }}"

--- a/roles/manage_pgbouncer_users/tasks/pgbouncer_set_userlist.yml
+++ b/roles/manage_pgbouncer_users/tasks/pgbouncer_set_userlist.yml
@@ -1,0 +1,15 @@
+---
+- name: Generate PgBouncer auth. file {{ pgbouncer_auth_file }}
+  template:
+    backup: yes
+    dest: "{{ pgbouncer_auth_file }}"
+    owner: "{{ pgbouncer_user }}"
+    group: "{{ pgbouncer_group }}"
+    mode: 0600
+    src: userlist.txt.template
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Reload PgBouncer configuration
+  shell:
+    cmd: kill -HUP $(cat {{ pgbouncer_pid_file }})
+  delegate_to: "{{ item.value.public_ip }}"

--- a/roles/manage_pgbouncer_users/templates/userlist.txt.template
+++ b/roles/manage_pgbouncer_users/templates/userlist.txt.template
@@ -1,0 +1,5 @@
+{% if pgbouncer_auth_user_list is defined %}
+{% for user_item in pgbouncer_auth_user_list %}
+"{{ user_item.username }}" "{{ user_item.password }}"
+{% endfor %}
+{% endif %}

--- a/roles/setup_pgbouncer/README.md
+++ b/roles/setup_pgbouncer/README.md
@@ -1,0 +1,295 @@
+# setup_pgbouncer
+
+This role is for installing and configuring PgBouncer. PgBouncer is a
+lightweight connection pooler for PostgreSQL.
+
+## Requirements
+
+Following are the dependencies and requirement of this role.
+  1. Ansible
+  2. `edb-devops.postgres` -> `setup_repo` role for setting the repository on
+     the systems.
+
+## Role Variables
+
+When executing the role via ansible these are the required variables:
+
+  * ***os***
+
+    Operating Systems supported are: CentOS7, CentOS8, RHEL7 and RHEL8
+
+The rest of the variables can be configured and are available in the:
+* [roles/setup_pgbouncer/defaults/main.yml](./defaults/main.yml)
+
+Below is the documentation of the rest of the variables:
+
+### `pgbouncer_listen_port`
+
+Which port to listen on. Applies to both TCP and Unix sockets. Default: `6432`
+
+Example:
+```yaml
+pgbouncer_listen_port: 6432
+```
+
+### `pgbouncer_listen_addr`
+
+Specifies a list of addresses where to listen for TCP connections. You may also
+use `*` meaning “listen on all addresses”. Addresses can be specified
+numerically (IPv4/IPv6) or by name. Default: `*`
+
+Example:
+```yaml
+pgbouncer_listen_addr: "*"
+```
+
+### `pgbouncer_user`
+
+System user account that runs PgBouncer process and owns its configuration
+files. Default: `pgbouncer`
+
+Example:
+```yaml
+pgbouncer_user: "pgbouncer"
+```
+
+### `pgbouncer_group`
+
+System group that PgBouncer system user is part of. Default: `pgbouncer`
+
+Example:
+```yaml
+pgbouncer_group: "pgbouncer"
+```
+
+### `pgbouncer_default_pool_size`
+
+How many server connections to allow per user/database pair. Can be overridden
+in the per-database configuration. Default: `20`
+
+Example:
+```yaml
+pgbouncer_default_pool_size: 20
+```
+
+### `pgbouncer_max_client_conn`
+
+Maximum number of client connections allowed. Default: `100`
+
+Example:
+```yaml
+pgbouncer_max_client_conn: 100
+```
+
+### `pgbouncer_fd_limit`
+
+File descriptor limits. Default: `2048`
+
+Example:
+```yaml
+pgbouncer_fd_limit: 2048
+```
+
+### `pgbouncer_pool_mode`
+
+Pooling mode. Could be `session`, `transaction` or `statement`.
+Default: `session`
+
+Example:
+```yaml
+pgbouncer_pool_mode: "session"
+```
+
+### `pgbouncer_server_reset_query`
+
+Query sent to server on connection release, before making it available to
+other clients. Default: `DISCARD ALL`
+
+Example:
+```yaml
+pgbouncer_server_reset_query: "DISCARD ALL"
+```
+
+### `pgbouncer_admin_users`
+
+Comma-separated list of database users that are allowed to connect and run all
+commands on the console. Default: `pgbouncer_admin`
+
+Example:
+```yaml
+pgbouncer_admin_users: "pgbouncer_admin"
+```
+
+### `pgbouncer_stats_users`
+
+Comma-separated list of database users that are allowed to connect and run
+read-only queries on the console. Default: `pgbouncer_stats`
+
+Example:
+```yaml
+pgbouncer_stats_users: "pgbouncer_stats"
+```
+
+### `pgbouncer_auth_type`
+
+How to authenticate users. Could be `pam`, `hba`, `cert`, `md5`,
+`scram-sha-256`, `plain`, `trust` or `any`. Default: `scram-sha-256`
+
+Example:
+```yaml
+pgbouncer_auth_type: "scram-sha-256"
+```
+
+### `pgbouncer_auth_file`
+
+The path of the file to load user names and passwords from.
+Default: `/etc/pgbouncer/userlist.txt`
+
+Example:
+```yaml
+pgbouncer_auth_file: "/etc/pgbouncer/userlist.txt"
+```
+
+### `pgbouncer_auth_user`
+
+PostgreSQL user used to run the query `auth_query` in the database when the
+user is not found in the authentication file.
+Default: `not defined`
+
+Example:
+```yaml
+pgbouncer_auth_user: "pgbouncer"
+```
+
+### `pgbouncer_auth_query`
+
+Query to load user’s password from database. Default: `not defined`
+
+Example:
+```yaml
+pgbouncer_auth_query: "SELECT usename, passwd FROM pg_shadow WHERE usename = $1"
+```
+
+### `pgbouncer_config_file`
+
+Main configuration file path. Default: `/etc/pgbouncer/pgbouncer.ini`
+
+Example:
+```yaml
+pgbouncer_config_file: "/etc/pgbouncer/pgbouncer.ini"
+```
+
+### `pgbouncer_pid_file`
+
+PID file path. Default: `/run/pgbouncer/pgbouncer.pid`
+
+Example:
+```yaml
+pgbouncer_pid_file: "/run/pgbouncer/pgbouncer.pid"
+```
+
+### `pgbouncer_log_file`
+
+Log file path. Default: `/var/log/pgbouncer/pgbouncer.log`
+
+Example:
+```yaml
+pgbouncer_log_file: "/var/log/pgbouncer/pgbouncer.log"
+```
+
+### `pgbouncer_syslog`
+
+Toggles syslog on/off. Default: `0`
+
+Example:
+```yaml
+pgbouncer_syslog: 0
+```
+
+### `pgbouncer_syslog_ident`
+
+Under what name to send logs to syslog. Default: `pgbouncer`
+
+Example:
+```yaml
+pgbouncer_syslog_ident: "pgbouncer"
+```
+
+### `pgbouncer_databases_file`
+
+Configuration file path that contains databases (connection pools)
+configuration.
+Default: `/etc/pgbouncer/databases.ini`
+
+Example:
+```yaml
+pgbouncer_databases_file: "/etc/pgbouncer/databases.ini"
+```
+
+### `pgbouncer_systemd_unit_file`
+
+Systemd unit configuration file path.
+Default: `/etc/systemd/system/pgbouncer.service.d/pgbouncer.conf`
+
+Example:
+```yaml
+pgbouncer_systemd_unit_file: "/etc/systemd/system/pgbouncer.service.d/pgbouncer.conf"
+```
+
+## Dependencies
+
+This role does not have any dependencies, but packages repositories should have
+been configured beforehand with the `setup_repo` role.
+
+## Example Playbook
+
+### Hosts file content
+
+To deploy PgBouncer as a standalone application on a dedicated host,
+`node_type` should be set up to `pgbouncer`. When deploying PgBouncer alongside
+a Postgres instance, the key `pgbouncer` should be set up to `true`.
+
+`hosts.yml` content example:
+```yaml
+---
+servers:
+  pooler:
+    node_type: pgbouncer
+    public_ip: xxx.xxx.xxx.xxx
+  main:
+    node_type:  primary
+    public_ip: xxx.xxx.xxx.xxx
+    private_ip: xxx.xxx.xxx.xxx
+    pgbouncer: true
+```
+
+### How to include the `setup_pgbouncer` role in your Playbook
+
+Below is an example of how to include the `setup_pgbouncer` role:
+```yaml
+---
+- hosts: localhost
+  name: Setup PgBouncer connection pooler
+  become: true
+  gather_facts: no
+
+  collections:
+    - edb_devops.edb_postgres
+
+  vars_files:
+    - hosts.yml
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        os: "CentOS8"
+        pg_version: 13
+        pg_type: "PG"
+
+  roles:
+    - setup_pgbouncer
+```
+
+## License
+
+BSD

--- a/roles/setup_pgbouncer/defaults/main.yml
+++ b/roles/setup_pgbouncer/defaults/main.yml
@@ -1,0 +1,71 @@
+---
+# RPM package name
+pgbouncer_package_name: "pgbouncer"
+
+# PgBouncer listen port & address
+pgbouncer_listen_port: 6432
+pgbouncer_listen_addr: "*"
+
+# PgBouncer system user & group
+pgbouncer_user: "pgbouncer"
+pgbouncer_group: "pgbouncer"
+
+# Pool size and maximum  number of client connections
+pgbouncer_default_pool_size: 20
+pgbouncer_max_client_conn: 100
+
+# Maximum limit of file descriptors that pgbouncer can open
+pgbouncer_fd_limit: 2048
+
+# Pool mode
+pgbouncer_pool_mode: "session"
+
+# Reset query
+pgbouncer_server_reset_query: "DISCARD ALL"
+
+# PgBouncer administration & statistics users
+pgbouncer_admin_users: "pgbouncer_admin"
+pgbouncer_stats_users: "pgbouncer_stats"
+
+# PgBouncer authentication part
+pgbouncer_auth_type: "scram-sha-256"
+pgbouncer_auth_file: "/etc/pgbouncer/userlist.txt"
+
+# User authentication with auth_query
+# pgbouncer_auth_user: "pgbouncer"
+# pgbouncer_auth_query: "SELECT usename, passwd FROM pg_shadow WHERE usename = $1"
+
+# Configuration file
+pgbouncer_config_file: "/etc/pgbouncer/pgbouncer.ini"
+# PID file
+pgbouncer_pid_file: "/run/pgbouncer/pgbouncer.pid"
+# Log file
+pgbouncer_log_file: "/var/log/pgbouncer/pgbouncer.log"
+pgbouncer_syslog: 0
+pgbouncer_syslog_ident: "pgbouncer"
+
+# Databases configuration file
+pgbouncer_databases_file: "/etc/pgbouncer/databases.ini"
+# Systemd unit file
+pgbouncer_systemd_unit_file: "/etc/systemd/system/pgbouncer.service.d/pgbouncer.conf"
+
+available_pool_mode:
+  - transaction
+  - session
+  - query
+
+available_auth_type:
+  - pam
+  - hba
+  - cert
+  - md5
+  - scram-sha-256
+  - plain
+  - trust
+  - any
+
+supported_os:
+  - CentOS7
+  - CentOS8
+  - RHEL7
+  - RHEL8

--- a/roles/setup_pgbouncer/tasks/main.yml
+++ b/roles/setup_pgbouncer/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+# Tasks file for setup_pgbouncer Role
+
+# Check if the Operating System is supported
+- name: Check support for Operating System
+  fail:
+    msg: "Operating System = {{ os }} not supported."
+  when: os not in supported_os
+
+# Check if global pool_mode is valid
+- name: Check PgBouncer pool_mode configuration value
+  fail:
+    msg: "PgBouncer pooling mode = {{ pgbouncer_pool_mode }} not valid.
+         Available pooling modes are {{ available_pool_mode }}"
+  when: pgbouncer_pool_mode not in available_pool_mode
+
+# Check if global auth_type is valid
+- name: Check PgBouncer auth_type configuration value
+  fail:
+    msg: "PgBouncer authentication type = {{ pgbouncer_auth_type }} not valid.
+         Available authentication types are {{ available_auth_type }}"
+  when: pgbouncer_auth_type not in available_auth_type
+
+- name: Include the pgbouncer_install
+  include_tasks: pgbouncer_install.yml
+  when: item.value.pgbouncer is true or item.value.node_type == 'pgbouncer'
+  with_dict:  "{{ servers }}"
+
+- name: Include the pgbouncer_setup
+  include_tasks: pgbouncer_setup.yml
+  when: item.value.pgbouncer is true or item.value.node_type == 'pgbouncer'
+  with_dict:  "{{ servers }}"

--- a/roles/setup_pgbouncer/tasks/pgbouncer_install.yml
+++ b/roles/setup_pgbouncer/tasks/pgbouncer_install.yml
@@ -1,0 +1,14 @@
+---
+- name: Install PgBouncer package on CentOS7 or RHEL7
+  yum:
+    name: "{{ pgbouncer_package_name }}"
+  when: os in ['CentOS7', 'RHEL7']
+  become: yes
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Install PgBouncer package on CentOS8 or RHEL8
+  dnf:
+    name: "{{ pgbouncer_package_name }}"
+  when: os in ['CentOS8', 'RHEL8']
+  become: yes
+  delegate_to: "{{ item.value.public_ip }}"

--- a/roles/setup_pgbouncer/tasks/pgbouncer_setup.yml
+++ b/roles/setup_pgbouncer/tasks/pgbouncer_setup.yml
@@ -1,0 +1,107 @@
+---
+- name: Create PgBouncer system group {{ pgbouncer_group }}
+  group:
+    name: "{{ pgbouncer_group }}"
+    state: present
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Create PgBouncer system user {{ pgbouncer_user }}
+  user:
+    name: "{{ pgbouncer_user }}"
+    system: true
+    group: "{{ pgbouncer_group }}"
+    state: present
+    create_home: false
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Create configuration directories
+  file:
+    path: "{{ dir_item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  loop:
+    - "{{ pgbouncer_config_file | dirname }}"
+    - "{{ pgbouncer_databases_file | dirname }}"
+    - "{{ pgbouncer_systemd_unit_file | dirname }}"
+  loop_control:
+    loop_var: dir_item
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Create logging directory {{ pgbouncer_log_file | dirname }}
+  file:
+    path: "{{ pgbouncer_log_file | dirname }}"
+    state: directory
+    owner: "{{ pgbouncer_user }}"
+    group: "{{ pgbouncer_group }}"
+    mode: 0755
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Create running directory {{ pgbouncer_pid_file | dirname }}
+  file:
+    path: "{{ pgbouncer_pid_file | dirname }}"
+    state: directory
+    owner: "{{ pgbouncer_user }}"
+    group: "{{ pgbouncer_group }}"
+    mode: 0700
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Generate PgBouncer configuration file {{ pgbouncer_config_file }}
+  template:
+    backup: yes
+    dest: "{{ pgbouncer_config_file }}"
+    owner: "{{ pgbouncer_user }}"
+    group: "{{ pgbouncer_group }}"
+    src: ./templates/pgbouncer.ini.template
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Create empty databases file {{ pgbouncer_databases_file }}
+  copy:
+    content: ""
+    dest: "{{ pgbouncer_databases_file }}"
+    force: no
+    group: "{{ pgbouncer_group }}"
+    owner: "{{ pgbouncer_user }}"
+    mode: 0600
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Create empty authentication file {{ pgbouncer_auth_file }}
+  copy:
+    content: ""
+    dest: "{{ pgbouncer_auth_file }}"
+    force: no
+    group: "{{ pgbouncer_group }}"
+    owner: "{{ pgbouncer_user }}"
+    mode: 0600
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Generate PgBouncer systemd unit file {{ pgbouncer_systemd_unit_file }}
+  template:
+    backup: yes
+    dest: "{{ pgbouncer_systemd_unit_file }}"
+    src: ./templates/pgbouncer.unit.conf.template
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Open TCP port {{ pgbouncer_listen_port }}
+  firewalld:
+    port: "{{ pgbouncer_listen_port }}/tcp"
+    permanent: yes
+    state: enabled
+    immediate: true
+  delegate_to: "{{ item.value.public_ip }}"
+  when: os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
+
+- name: Stop PgBouncer service
+  systemd:
+    name: pgbouncer
+    state: stopped
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Enable and start PgBouncer service
+  systemd:
+    name: pgbouncer
+    enabled: true
+    daemon_reload: yes
+    state: started
+  delegate_to: "{{ item.value.public_ip }}"

--- a/roles/setup_pgbouncer/templates/pgbouncer.ini.template
+++ b/roles/setup_pgbouncer/templates/pgbouncer.ini.template
@@ -1,0 +1,24 @@
+[pgbouncer]
+pidfile = {{ pgbouncer_pid_file }}
+
+logfile = {{ pgbouncer_log_file }}
+syslog = {{ pgbouncer_syslog }}
+syslog_ident = {{ pgbouncer_syslog_ident }}
+
+listen_addr = {{ pgbouncer_listen_addr }}
+listen_port = {{ pgbouncer_listen_port }}
+
+auth_type = {{ pgbouncer_auth_type }}
+auth_file = {{ pgbouncer_auth_file }}
+{% if pgbouncer_auth_user is defined %}auth_user = {{ pgbouncer_auth_user }}{% endif %}
+{% if pgbouncer_auth_query is defined %}auth_query = {{ pgbouncer_auth_query }}{% endif %}
+
+admin_users = {{ pgbouncer_admin_users }}
+stats_users = {{ pgbouncer_stats_users }}
+
+pool_mode = {{ pgbouncer_pool_mode }}
+server_reset_query = {{ pgbouncer_server_reset_query }}
+max_client_conn = {{ pgbouncer_max_client_conn }}
+default_pool_size = {{ pgbouncer_default_pool_size }}
+
+%include {{ pgbouncer_databases_file }}

--- a/roles/setup_pgbouncer/templates/pgbouncer.unit.conf.template
+++ b/roles/setup_pgbouncer/templates/pgbouncer.unit.conf.template
@@ -1,0 +1,9 @@
+[Service]
+User={{ pgbouncer_user }}
+Group={{ pgbouncer_group }}
+
+# Path to the init file
+Environment=BOUNCERCONF={{ pgbouncer_config_file }}
+
+PIDFile={{ pgbouncer_pid_file }}
+LimitNOFILE={{ pgbouncer_fd_limit }}


### PR DESCRIPTION
This commit introduces PgBouncer support by bringing 3 new roles:
  * setup_pgbouncer: this role is in charge of installing and
    configuring PgBouncer.
  * manage_pgbouncer_users: manage PgBouncer user list.
  * manage_pgbouncer_databases: manage PgBouncer pool connection
    list.