### PR TITLE
Add double quotes to synchronous standby name

### DIFF
--- a/roles/setup_replication/tasks/primary_synchronous_param.yml
+++ b/roles/setup_replication/tasks/primary_synchronous_param.yml
@@ -2,7 +2,7 @@
 
 - name: Set synchronous_standby_names
   set_fact:
-    synchronous_standby_names: "{{ ' ' + synchronous_standbys|length|string() + '(' + synchronous_standbys | join(',') + ')' }}"
+    synchronous_standby_names: "{{ ' ' + synchronous_standbys|length|string() + '(' + synchronous_standbys| map('to_json') | join(',') + ')' }}"
 
 - name: Add standby quorum string
   set_fact:


### PR DESCRIPTION
To allow special char usage in standby name.