### PR TITLE
Define pg_data in setup_pem

### DIFF
--- a/roles/setup_pem/vars/EPAS.yml
+++ b/roles/setup_pem/vars/EPAS.yml
@@ -7,6 +7,7 @@ pg_user: "enterprisedb"
 
 # pem data dir
 pg_home: "/usr/edb/as{{ pg_version }}" 
+pg_data: "/var/lib/edb/as{{ pg_version }}/data"
 pg_bin_path: "{{ pg_home }}/bin"
 pg_ssl: true
 

--- a/roles/setup_pem/vars/PG.yml
+++ b/roles/setup_pem/vars/PG.yml
@@ -6,6 +6,7 @@ pg_version: ""
 pg_user: "postgres"
 # pem data dir
 pg_home: "/usr/pgsql-{{ pg_version }}"
+pg_data: "/var/lib/pgsql/{{ pg_version }}/data"
 pg_bin_path: "{{ pg_home }}/bin"
 pg_ssl: true
 


### PR DESCRIPTION
To avoid this kind of error when the `setup_pem` role is executed alone: `The task includes an option with an undefined variable. The error was: 'pg_data' is undefined`