### PR TITLE
Update PG_rhel8_install.yml

### DIFF
--- a/roles/install_dbserver/tasks/PG_rhel8_install.yml
+++ b/roles/install_dbserver/tasks/PG_rhel8_install.yml
@@ -8,6 +8,7 @@
   register: disable_builtin_postgres
   changed_when: disable_builtin_postgres.rc == 0
   failed_when: disable_builtin_postgres.rc != 0
+  ignore_errors: yes
   become: yes
 
 - name: Install Postgres


### PR DESCRIPTION
Creating the PR for fixing an issue wherein CentOS8 and RHEL8 `dnf -qy module disable postgresql` command fails.