### PR TITLE
PgpoolII support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ This role helps in managing PgBouncer credentials list.
 For more information on the role, please refer roles README
 [README.md](./roles/manage_pgbouncer_users/README.md)
 
+### setup_pgpool2
+
+This role install and configure a new PgpoolII connection pooler.
+For more information on the role, please refer roles README
+[README.md](./roles/setup_pgpool2/README.md)
+
+### manage_pgpool2
+
+This role helps in managing Pgpool II user list and configuration.
+For more information on the role, please refer roles README
+[README.md](./roles/manage_pgpool2/README.md)
+
 ## Pre-Requisites
 
 For correctly installed and configuration of the cluster following are requirements:
@@ -293,8 +305,8 @@ Defining and adding variables can be done in the `set_fact` of the `pre-tasks`.
 You can customize the above example to install Postgres, EPAS, EFM or PEM or
 limit what roles you would like to execute: `setup_repo`, `install_dbserver`,
 `init_dbserver`, `setup_replication`, `setup_efm`, `setup_pem`,
-`manage_dbserver`, `setup_pgbouncer`, `manage_pgbouncer_users` or
-`manage_pgbouncer_databases`.
+`manage_dbserver`, `setup_pgbouncer`, `manage_pgbouncer_users`,
+`manage_pgbouncer_databases`, `setup_pgpool2` or `manage_pgpool2`.
 
 ## Default user and passwords
 

--- a/roles/manage_pgpool2/README.md
+++ b/roles/manage_pgpool2/README.md
@@ -1,0 +1,165 @@
+# manage_pgpool2
+
+This role is for managing PgpoolII configuration parameters and user list.
+
+## Requirements
+
+Following are the dependencies and requirement of this role.
+  1. Ansible
+  2. `edb_devops.postgres` -> `setup_pgpool2` - role for setting up PgpoolII
+     on the systems.
+
+## Role Variables
+
+When executing the role via ansible these are the required variables:
+
+  * ***os***
+
+    Operating Systems supported are: CentOS7, CentOS8, RHEL7 and RHEL8
+
+  * ***pg_version***
+
+  Postgres Versions supported are: 10, 11, 12 and 13
+
+  * ***pg_type***
+
+  Database Engine supported are: PG and EPAS
+
+
+The rest of the variables can be configured and are available in the:
+
+  * [roles/manage_pgpool2/vars/PG.yml](./vars/PG.yml)
+  * [roles/manage_pgpool2/vars/EPAS.yml](./vars/EPAS.yml)
+
+Below is the documentation of the rest of the variables:
+
+### pgpool2_configuration
+
+This is the list of the configuration parameters to be changed in PgpoolII
+configuration file.
+
+Example:
+```yaml
+pgpool2_configuration:
+  - key: "port"
+    value: 6432
+    state: present
+  - key: "socket"
+    value: "/tmp"
+    # Add quotes around the value
+    quoted: true
+    state: present
+  - key: "ssl_ca_cert"
+    state: absent
+```
+
+Note: The PgpoolII parameters taking a string value must be quoted in the
+configuration file, this behavior can be achieved by setting to `quoted`
+attribute to `true`. Default value is `false`.
+
+The `state` attribute defines if the parameter must be present or not in the
+configuration file. Default value is `present`.
+
+### pgpool2_users
+
+This is the list of PgpoolII user account to managed.
+
+Example:
+```yaml
+pgpool2_users:
+  - name: "my_user1"
+    pass: "password"
+    auth: scram
+  - name: "my_user2"
+    pass: "password"
+    auth: md5
+  - name: "my_user_to_be_removed"
+    state: absent
+```
+
+Two authentication methods are supported: `scram` and `md5`.
+
+The `state` attribute defines if the user must be present or not in the
+authentication file. Default value is `present`.
+
+## Dependencies
+
+This role does not have any dependencies, but a PgpoolII instance should have
+been deployed beforehand with the `setup_pgpool2` role.
+
+## Example Playbook
+
+### Hosts file content
+
+To manage PgpoolII instance, `node_type` should be set up to `pgpool2`.
+
+`hosts.yml` content example:
+```yaml
+---
+servers:
+  pooler:
+    node_type: pgpool2
+    public_ip: xxx.xxx.xxx.xxx
+```
+
+### How to include the `manage_pgpool2` role in your Playbook
+
+Below is an example of how to include the `manage_pgpool2` role:
+```yaml
+---
+- hosts: localhost
+  name: Manage PgpoolII configuration and users
+  become: true
+  gather_facts: no
+
+  collections:
+    - edb_devops.edb_postgres
+
+  vars_files:
+    - hosts.yml
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        os: "CentOS8"
+        pg_type: "PG"
+        pg_version: 13
+
+        pgpool2_configuration:
+          - key: "port"
+            value: 6432
+            state: present
+          - key: "socket"
+            value: "/tmp"
+            # Add quotes around the value
+            quoted: true
+            state: present
+          - key: "ssl_ca_cert"
+            state: absent
+
+        pgpool2_users:
+          - name: "my_user1"
+            pass: "password"
+            auth: scram
+          - name: "my_user2"
+            pass: "password"
+            auth: md5
+          - name: "my_user_to_be_removed"
+            state: absent
+
+  roles:
+    - manage_pgpool2
+```
+
+## License
+
+BSD
+
+## Author information
+
+Author:
+
+  * Julien Tachoires
+  * Vibhor Kumar (Reviewer)
+  * EDB Postgres
+  * julien.tachoires@enterprisedb.com www.enterprisedb.com

--- a/roles/manage_pgpool2/defaults/main.yml
+++ b/roles/manage_pgpool2/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+supported_os:
+  - CentOS7
+  - CentOS8
+  - RHEL7
+  - RHEL8
+
+supported_pg_version:
+  - 10
+  - 11
+  - 12
+  - 13
+
+supported_node_type:
+  - pgpool2
+
+supported_pgpool2_version:
+  - 4.1

--- a/roles/manage_pgpool2/meta/main.yml
+++ b/roles/manage_pgpool2/meta/main.yml
@@ -1,0 +1,51 @@
+---
+galaxy_info:
+  author: EDB
+  description: Manage Pgpool II user list and configuration
+  company: "EnterpriseDB"
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: BSD
+
+  min_ansible_version: 2.8
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 7
+        - 8
+    - name: Red Hat
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - database
+    - postgresql
+    - postgres
+    - pgpool
+    - pooler
+    - connection
+    - edb
+    - edbinitialize
+
+dependencies: []

--- a/roles/manage_pgpool2/tasks/main.yml
+++ b/roles/manage_pgpool2/tasks/main.yml
@@ -32,7 +32,8 @@
     - pgpool2_version not in supported_pgpool2_version
 
 # Set service name accordingly to pg_type
-- set_fact:
+- name: Set service name
+  set_fact:
     pgpool2_service_name: >-
       {% if pg_type == 'EPAS' %}edb-pgpool-{{ pgpool2_version }}{% elif pg_type == 'PG' %}pgpool-II-{{ pg_version }}{% endif %}
 

--- a/roles/manage_pgpool2/tasks/main.yml
+++ b/roles/manage_pgpool2/tasks/main.yml
@@ -1,0 +1,73 @@
+---
+# Tasks file for manage_pgpool2 Role
+
+# reference EPAS/PG variables
+- name: Reference pg_type variables
+  include_vars: "{{ pg_type }}.yml"
+
+# Include EPAS/PG variables from the initdb_server role
+- name: Reference pg_type variables
+  include_vars: "../../init_dbserver/vars/{{ pg_type }}.yml"
+
+# Check if the Operating System is supported
+- name: Check support for Operating System
+  fail:
+    msg: "Operating System = {{ os }} not supported."
+  when: os not in supported_os
+
+# Check if the Database Version is supported
+- name: Check supported versions for Database engine
+  fail:
+    msg: "Database Engine Version = {{ pg_version }} not supported.
+          Supported versions are {{ supported_pg_version }}"
+  when: pg_version|int not in supported_pg_version
+
+# Check if the pgpoolII version is supported when working with EPAS env.
+- name: Check supported versions for pgpoolII
+  fail:
+    msg: "pgpoolII Version = {{ pgpool2_version }} not supported.
+          Supported versions are {{ supported_pgpool2_version }}"
+  when:
+    - pg_type == "EPAS"
+    - pgpool2_version not in supported_pgpool2_version
+
+# Set service name accordingly to pg_type
+- set_fact:
+    pgpool2_service_name: >-
+      {% if pg_type == 'EPAS' %}edb-pgpool-{{ pgpool2_version }}{% elif pg_type == 'PG' %}pgpool-II-{{ pg_version }}{% endif %}
+
+- name: Include the pgpool2_manage_configuration
+  include_tasks:
+    file: pgpool2_manage_configuration.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
+  when:
+    - server.value.node_type in supported_node_type
+    - pgpool2_configuration|length > 0
+  with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
+
+- name: Include the pgpool2_manage_users
+  include_tasks:
+    file: pgpool2_manage_users.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
+  when:
+    - server.value.node_type in supported_node_type
+    - pgpool2_users|length > 0
+  with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
+
+- name: Reload pgpoolII service
+  systemd:
+    name: "{{ pgpool2_service_name }}"
+    state: reloaded
+  delegate_to: "{{ server.value.public_ip }}"
+  with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
+  when:
+    - pgpool2_user|length > 0 or pgpool2_configuration|length > 0
+    - server.value.node_type in supported_node_type

--- a/roles/manage_pgpool2/tasks/main.yml
+++ b/roles/manage_pgpool2/tasks/main.yml
@@ -47,6 +47,8 @@
   with_dict:  "{{ servers }}"
   loop_control:
     loop_var: server
+  vars:
+    pgpool2_configuration_lines: "{{ pgpool2_configuration }}"
 
 - name: Include the pgpool2_manage_users
   include_tasks:

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
@@ -14,4 +14,4 @@
   with_items: "{{ pgpool2_configuration }}"
   loop_control:
     loop_var: conf_item
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
@@ -3,14 +3,13 @@
   lineinfile:
     path: "{{ pgpool2_configuration_file }}"
     line: >-
-      {{ conf_item.key }} = {% if conf_item.quoted %}'{% endif %}{{ conf_item.value }}{% if conf_item.quoted %}'{% endif %}
+      {{ conf_item.key }} = {% if conf_item.quoted | default(false) %}'{% endif %}{{ conf_item.value }}{% if conf_item.quoted | default(false) %}'{% endif %}
     regexp: "^{{ conf_item.key | regex_escape() }}\\s*="
     state: "{{ conf_item.state | default('present') }}"
     create: yes
     mode: 0600
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
-  when: pgpool2_configuration|length > 0
   with_items: "{{ pgpool2_configuration_lines }}"
   loop_control:
     loop_var: conf_item

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
@@ -13,3 +13,4 @@
   with_items: "{{ pgpool2_configuration_lines }}"
   loop_control:
     loop_var: conf_item
+  become: yes

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
@@ -1,0 +1,17 @@
+---
+- name: Manage pgpool2 configuration file content in {{ pgpool2_configuration_file }}
+  lineinfile:
+    path: "{{ pgpool2_configuration_file }}"
+    line: >-
+      {{ conf_item.key }} = {% if conf_item.quoted %}'{% endif %}{{ conf_item.value }}{% if conf_item.quoted %}'{% endif %}
+    regexp: "^{{ conf_item.key | regex_escape() }}\\s*="
+    state: "{{ conf_item.state | default('present') }}"
+    create: yes
+    mode: 0600
+    owner: "{{ pgpool2_user }}"
+    group: "{{ pgpool2_group }}"
+  when: pgpool2_configuration|length > 0
+  with_items: "{{ pgpool2_configuration }}"
+  loop_control:
+    loop_var: conf_item
+  delegate_to: "{{ item.value.public_ip }}"

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
@@ -11,7 +11,6 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
   when: pgpool2_configuration|length > 0
-  with_items: "{{ pgpool2_configuration }}"
+  with_items: "{{ pgpool2_configuration_lines }}"
   loop_control:
     loop_var: conf_item
-  delegate_to: "{{ server.value.public_ip }}"

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_users.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_users.yml
@@ -13,6 +13,7 @@
     - pgpool2_users|length > 0
     - user_item.state is defined
     - user_item.state == 'absent'
+  become: yes
 
 - name: Add users with SCRAM authentication
   shell:

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_users.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_users.yml
@@ -1,0 +1,45 @@
+---
+- name: Remove users from pool_passwd
+  lineinfile:
+    path: "{{ pgpool2_pool_passwd_path }}"
+    line: >-
+      {{ user_item.name }}:
+    regexp: "^{{ user_item.name | regex_escape() }}\\:"
+    state: "absent"
+  loop: "{{ pgpool2_users }}"
+  loop_control:
+    loop_var: user_item
+  when:
+    - pgpool2_users|length > 0
+    - user_item.state is defined
+    - user_item.state == 'absent'
+
+- name: Add users with SCRAM authentication
+  shell:
+    cmd: >-
+      script -q -c '{{ pgpool2_bin_path }}/pg_enc -k ~/.pgpoolkey -f {{pgpool2_configuration_path}} -u {{user_item.name}} -p -m'
+    stdin: "{{ user_item.pass }}"
+  become: yes
+  become_user: "{{ pg_owner }}"
+  loop: "{{ pgpool2_users }}"
+  loop_control:
+    loop_var: user_item
+  when:
+    - pgpool2_users|length > 0
+    - user_item.state is not defined or user_item.state == 'present'
+    - user_item.auth == 'scram'
+
+- name: Add users with MD5 authentication
+  shell:
+    cmd: >-
+      script -q -c '{{ pgpool2_bin_path }}/pg_md5 -f {{pgpool2_configuration_path}} -u {{user_item.name}} -p -m'
+    stdin: "{{ user_item.pass }}"
+  become: yes
+  become_user: "{{ pg_owner }}"
+  loop: "{{ pgpool2_users }}"
+  loop_control:
+    loop_var: user_item
+  when:
+    - pgpool2_users|length > 0
+    - user_item.state is not defined or user_item.state == 'present'
+    - user_item.auth == 'md5'

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_users.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_users.yml
@@ -1,7 +1,7 @@
 ---
 - name: Remove users from pool_passwd
   lineinfile:
-    path: "{{ pgpool2_pool_passwd_path }}"
+    path: "{{ pgpool2_pool_passwd_file }}"
     line: >-
       {{ user_item.name }}:
     regexp: "^{{ user_item.name | regex_escape() }}\\:"
@@ -17,7 +17,7 @@
 - name: Add users with SCRAM authentication
   shell:
     cmd: >-
-      script -q -c '{{ pgpool2_bin_path }}/pg_enc -k ~/.pgpoolkey -f {{pgpool2_configuration_path}} -u {{user_item.name}} -p -m'
+      script -q -c '{{ pgpool2_bin_path }}/pg_enc -k ~/.pgpoolkey -f {{pgpool2_configuration_file}} -u {{user_item.name}} -p -m'
     stdin: "{{ user_item.pass }}"
   become: yes
   become_user: "{{ pg_owner }}"
@@ -32,7 +32,7 @@
 - name: Add users with MD5 authentication
   shell:
     cmd: >-
-      script -q -c '{{ pgpool2_bin_path }}/pg_md5 -f {{pgpool2_configuration_path}} -u {{user_item.name}} -p -m'
+      script -q -c '{{ pgpool2_bin_path }}/pg_md5 -f {{pgpool2_configuration_file}} -u {{user_item.name}} -p -m'
     stdin: "{{ user_item.pass }}"
   become: yes
   become_user: "{{ pg_owner }}"

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_users.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_users.yml
@@ -16,9 +16,9 @@
   become: yes
 
 - name: Add users with SCRAM authentication
-  shell:
+  command:
     cmd: >-
-      script -q -c '{{ pgpool2_bin_path }}/pg_enc -k ~/.pgpoolkey -f {{pgpool2_configuration_file}} -u {{user_item.name}} -p -m'
+      script -q -c '{{ pgpool2_bin_path }}/pg_enc -k ~/.pgpoolkey -f {{ pgpool2_configuration_file }} -u {{ user_item.name }} -p -m'
     stdin: "{{ user_item.pass }}"
   become: yes
   become_user: "{{ pg_owner }}"
@@ -31,9 +31,9 @@
     - user_item.auth == 'scram'
 
 - name: Add users with MD5 authentication
-  shell:
+  command:
     cmd: >-
-      script -q -c '{{ pgpool2_bin_path }}/pg_md5 -f {{pgpool2_configuration_file}} -u {{user_item.name}} -p -m'
+      script -q -c '{{ pgpool2_bin_path }}/pg_md5 -f {{ pgpool2_configuration_file }} -u {{ user_item.name }} -p -m'
     stdin: "{{ user_item.pass }}"
   become: yes
   become_user: "{{ pg_owner }}"

--- a/roles/manage_pgpool2/vars/EPAS.yml
+++ b/roles/manage_pgpool2/vars/EPAS.yml
@@ -1,8 +1,10 @@
 ---
-
 pgpool2_version: 4.1
 pgpool2_configuration_path: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pgpool.conf"
+pgpool2_pool_passwd_path: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pool_passwd"
 pgpool2_user: "enterprisedb"
 pgpool2_group: "enterprisedb"
+pgpool2_bin_path: "/usr/edb/pgpool{{ pgpool2_version }}/bin"
 
 pgpool2_configuration: []
+pgpool2_users: []

--- a/roles/manage_pgpool2/vars/EPAS.yml
+++ b/roles/manage_pgpool2/vars/EPAS.yml
@@ -1,7 +1,7 @@
 ---
 pgpool2_version: 4.1
-pgpool2_configuration_path: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pgpool.conf"
-pgpool2_pool_passwd_path: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pool_passwd"
+pgpool2_configuration_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pgpool.conf"
+pgpool2_pool_passwd_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pool_passwd"
 pgpool2_user: "enterprisedb"
 pgpool2_group: "enterprisedb"
 pgpool2_bin_path: "/usr/edb/pgpool{{ pgpool2_version }}/bin"

--- a/roles/manage_pgpool2/vars/EPAS.yml
+++ b/roles/manage_pgpool2/vars/EPAS.yml
@@ -1,0 +1,8 @@
+---
+
+pgpool2_version: 4.1
+pgpool2_configuration_path: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pgpool.conf"
+pgpool2_user: "enterprisedb"
+pgpool2_group: "enterprisedb"
+
+pgpool2_configuration: []

--- a/roles/manage_pgpool2/vars/PG.yml
+++ b/roles/manage_pgpool2/vars/PG.yml
@@ -1,7 +1,9 @@
 ---
-
 pgpool2_configuration_path: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
+pgpool2_pool_passwd_path: "/etc/pgpool-II-{{ pg_version }}/pool_passwd"
 pgpool2_user: "enterprisedb"
 pgpool2_group: "enterprisedb"
+pgpool2_bin_path: "/usr/pgpool-{{ pg_version }}/bin"
 
 pgpool2_configuration: []
+pgpool2_users: []

--- a/roles/manage_pgpool2/vars/PG.yml
+++ b/roles/manage_pgpool2/vars/PG.yml
@@ -1,6 +1,6 @@
 ---
-pgpool2_configuration_file: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
-pgpool2_pool_passwd_file: "/etc/pgpool-II-{{ pg_version }}/pool_passwd"
+pgpool2_configuration_file: "/etc/pgpool-II_{{ pg_version }}/pgpool.conf"
+pgpool2_pool_passwd_file: "/etc/pgpool-II_{{ pg_version }}/pool_passwd"
 pgpool2_user: "postgres"
 pgpool2_group: "postgres"
 pgpool2_bin_path: "/usr/pgpool-{{ pg_version }}/bin"

--- a/roles/manage_pgpool2/vars/PG.yml
+++ b/roles/manage_pgpool2/vars/PG.yml
@@ -1,0 +1,7 @@
+---
+
+pgpool2_configuration_path: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
+pgpool2_user: "enterprisedb"
+pgpool2_group: "enterprisedb"
+
+pgpool2_configuration: []

--- a/roles/manage_pgpool2/vars/PG.yml
+++ b/roles/manage_pgpool2/vars/PG.yml
@@ -1,6 +1,6 @@
 ---
-pgpool2_configuration_file: "/etc/pgpool-II_{{ pg_version }}/pgpool.conf"
-pgpool2_pool_passwd_file: "/etc/pgpool-II_{{ pg_version }}/pool_passwd"
+pgpool2_configuration_file: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
+pgpool2_pool_passwd_file: "/etc/pgpool-II-{{ pg_version }}/pool_passwd"
 pgpool2_user: "postgres"
 pgpool2_group: "postgres"
 pgpool2_bin_path: "/usr/pgpool-{{ pg_version }}/bin"

--- a/roles/manage_pgpool2/vars/PG.yml
+++ b/roles/manage_pgpool2/vars/PG.yml
@@ -1,8 +1,8 @@
 ---
-pgpool2_configuration_path: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
-pgpool2_pool_passwd_path: "/etc/pgpool-II-{{ pg_version }}/pool_passwd"
-pgpool2_user: "enterprisedb"
-pgpool2_group: "enterprisedb"
+pgpool2_configuration_file: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
+pgpool2_pool_passwd_file: "/etc/pgpool-II-{{ pg_version }}/pool_passwd"
+pgpool2_user: "postgres"
+pgpool2_group: "postgres"
 pgpool2_bin_path: "/usr/pgpool-{{ pg_version }}/bin"
 
 pgpool2_configuration: []

--- a/roles/setup_pgpool2/README.md
+++ b/roles/setup_pgpool2/README.md
@@ -1,0 +1,192 @@
+# setup_pgpool2
+
+This role is for installing and configuring PgpoolII. PgpoolII is a
+connection pooler for PostgreSQL.
+
+## Requirements
+
+Following are the requirements of this role.
+  1. Ansible
+  2. `edb_devops.postgres` -> `setup_repo` role for setting the repository on
+     the systems.
+
+## Role Variables
+
+When executing the role via ansible these are the required variables:
+
+  * ***os***
+
+    Operating Systems supported are: CentOS7, CentOS8, RHEL7 and RHEL8
+
+  * ***pg_version***
+
+  Postgres Versions supported are: 10, 11, 12 and 13
+
+  * ***pg_type***
+
+  Database Engine supported are: PG and EPAS
+
+These and other variables can be assigned in the `pre_tasks` definition of the
+section: *How to include the `setup_pgpool2` role in your Playbook*
+
+The rest of the variables can be configured and are available in the:
+
+  * [roles/setup_pgpool2/defaults/main.yml](./defaults/main.yml)
+  * [roles/setup_pgpool2/vars/PG.yml](./vars/PG.yml)
+  * [roles/setup_pgpool2/vars/EPAS.yml](./vars/EPAS.yml)
+
+Below is the documentation of the rest of the main variables:
+
+### `pgpool2_watchdog`
+
+Enable PgpoolII High Availability capability when deploying a PgpoolII multi
+node cluster. Default: `false`
+
+Example:
+```yaml
+pgpool2_watchdog: true
+```
+
+### `pgpool2_vip`
+
+Thie is the virtual IP address to put on the Pgpool2 primary node when
+deploying a PgpoolII multi node cluster. Watchdog feature must be enabled.
+Default: empty.
+
+Example:
+```yaml
+pgpool2_vip: "10.0.0.123"
+```
+
+### `pgpool2_vip_dev`
+
+System's network device to attach the virtual IP address. Default: empty.
+
+Example:
+```yaml
+pgpool2_vip_dev: "eth0"
+```
+
+### `pgpool2_load_balancing`
+
+Enable read only queries load balancing across all the Postgres nodes.
+Default: `true`.
+
+Example:
+```yaml
+pgpool_load_balancing: true
+```
+
+### `pgpool2_ssl`
+
+Enable SSL support. Default: `true`.
+
+Example:
+```yaml
+pgpool2_ssl: true
+```
+
+### `pgpool2_configuration`
+
+Configuration parameter values overiding default values. The default
+configuration values have been defined in the `pgpool2_default_configuration`.
+Please do not change values from the `pgpool2_default_configuration` variables
+and please use the `pgpool2_configuration` variable. Default: `[]`
+
+Example:
+```yaml
+pgpool2_configuration:
+  - key: "port"
+    value: 6432
+```
+
+Please refer to the `manage_pgpool2` roles' README file for more information.
+
+## Dependencies
+
+This role does not have any dependencies, but packages repositories should have
+been configured beforehand with the `setup_repo` role.
+
+## Example Playbook
+
+### Hosts file content
+
+To deploy PgpoolII as a standalone application on a dedicated host, `node_type`
+should be set up to `pgpool2`.
+
+`hosts.yml` content example:
+```yaml
+---
+servers:
+  pooler1:
+    node_type: pgpool2
+    public_ip: xxx.xxx.xxx.xxx
+    private_ip: xxx.xxx.xxx.xxx
+  pooler2:
+    node_type: pgpool2
+    public_ip: xxx.xxx.xxx.xxx
+    private_ip: xxx.xxx.xxx.xxx
+  main:
+    node_type: primary
+    public_ip: xxx.xxx.xxx.xxx
+    private_ip: xxx.xxx.xxx.xxx
+  standby:
+    node_type: standby
+    public_ip: xxx.xxx.xxx.xxx
+    private_ip: xxx.xxx.xxx.xxx
+```
+
+### How to include the `setup_pgpool2` role in your Playbook
+
+Below is an example of how to include the `setup_pgpool2` role:
+```yaml
+---
+- hosts: localhost
+  name: Setup Pgpool2 connection pooler
+  become: true
+  gather_facts: no
+
+  collections:
+    - edb_devops.edb_postgres
+
+  vars_files:
+    - hosts.yml
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        os: "CentOS8"
+        pg_version: 13
+        pg_type: "PG"
+
+        # PgpoolII settings
+
+        # Enable read only queries load balancing
+        pgpool2_load_balancing: true
+        # Enable HA
+        pgpool2_watchdog: true
+        pgpool2_vip: "10.0.0.123"
+        pgpool2_vip_dev: "eth0"
+        # Enable SSL support
+        pgpool2_ssl: true
+        # Change listening port to 6432
+        pgpool2_configuration:
+          - key: "port"
+            value: 6432
+
+  roles:
+    - setup_pgpool2
+```
+
+## License
+
+BSD
+
+## Author information
+
+Author:
+
+  * Julien Tachoires
+  * Vibhor Kumar (Reviewer)
+  * EDB Postgres
+  * julien.tachoires@enterprisedb.com www.enterprisedb.com

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -1,3 +1,8 @@
+---
+pgpool2_vip: ""
+pgpool2_vip_dev: ""
+pgpool2_watchdog: false
+
 supported_os:
   - CentOS7
   - CentOS8

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -1,0 +1,17 @@
+supported_os:
+  - CentOS7
+  - CentOS8
+  - RHEL7
+  - RHEL8
+
+supported_pg_version:
+  - 10
+  - 11
+  - 12
+  - 13
+
+supported_node_type:
+  - pgpool2
+
+supported_pgpool2_version:
+  - 4.1

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -3,6 +3,17 @@ pgpool2_vip: ""
 pgpool2_vip_dev: ""
 pgpool2_watchdog: false
 
+# Enable load balancing
+pgpool2_load_balancing: true
+
+# Postgres user that pgpool2 will use to check Postgres nodes roles in load
+# balance mode
+pgpool2_sr_check_user: "pgpool2"
+# If empty or not defined, a random password will be generated
+pgpool2_sr_check_password: ""
+
+pgpool2_configuration: []
+
 supported_os:
   - CentOS7
   - CentOS8

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -14,6 +14,20 @@ pgpool2_sr_check_password: ""
 
 pgpool2_configuration: []
 
+# Enable SSL
+pgpool2_ssl: true
+# Directory containing SSL keys and certs
+pgpool2_ssl_dir: ""
+
+pgpool2_ssl_csr_dn:
+  CN: "pgpool-server.fqdn"
+  O: ""
+  OU: ""
+  L: ""
+  ST: ""
+  C: ""
+  EMAIL: "example@mail.com"
+
 supported_os:
   - CentOS7
   - CentOS8

--- a/roles/setup_pgpool2/meta/main.yml
+++ b/roles/setup_pgpool2/meta/main.yml
@@ -1,0 +1,51 @@
+---
+galaxy_info:
+  author: EDB
+  description: Installation and setup of Pgpool II connection pooler
+  company: "EnterpriseDB"
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: BSD
+
+  min_ansible_version: 2.8
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 7
+        - 8
+    - name: Red Hat
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - database
+    - postgresql
+    - postgres
+    - pgpool
+    - pooler
+    - connection
+    - edb
+    - edbinitialize
+
+dependencies: []

--- a/roles/setup_pgpool2/tasks/main.yml
+++ b/roles/setup_pgpool2/tasks/main.yml
@@ -36,23 +36,26 @@
     msg: "Watchdog settings not valid: pgpool2_vip = '{{ pgpool2_vip }}',
           pgpool2_vip_dev = '{{ pgpool2_vip_dev }}'"
   when:
-    - pgpool2_watchdog == true
+    - pgpool2_watchdog is true
     - (pgpool2_vip is not defined or pgpool2_vip|length == 0) or
       (pgpool2_vip_dev is not defined or pgpool2_vip_dev|length == 0)
 
 # Set service name accordingly to pg_type
-- set_fact:
+- name: Set the service name
+  set_fact:
     pgpool2_service_name: >-
       {% if pg_type == 'EPAS' %}edb-pgpool-{{ pgpool2_version }}{% elif pg_type == 'PG' %}pgpool-II-{{ pg_version }}{% endif %}
 
 # Initialize variables used to configure load balancing and backends
-- set_fact:
+- name: Initialize local variables
+  set_fact:
     pgpool2_backends: []
     pgpool2_nodes: []
     pgpool2_primary_backend: ""
 
 # Build the list of postgres backends
-- set_fact:
+- name: Build the list of Postgres backends
+  set_fact:
     pgpool2_backends: "{{ pgpool2_backends }} + [ '{{ server.value.public_ip }}' ]"
   when:
     - server.value.node_type == 'primary' or server.value.node_type == 'standby'
@@ -60,7 +63,8 @@
   loop_control:
     loop_var: server
 
-- set_fact:
+- name: Set the pgpool2_primary_backend variable
+  set_fact:
     pgpool2_primary_backend: "{{ server.value.public_ip }}"
   when:
     - server.value.node_type == 'primary'
@@ -69,7 +73,8 @@
     loop_var: server
 
 # Build the list of pgpool2 nodes
-- set_fact:
+- name: Build the list of pgpool2 nodes
+  set_fact:
     pgpool2_nodes: "{{ pgpool2_nodes }} + [ '{{ server.value.public_ip }}' ]"
   when:
     - server.value.node_type in supported_node_type
@@ -78,10 +83,12 @@
     loop_var: server
 
 # Merge pgpool2_default_configuration and pgpool2_configuration
-- set_fact:
+- name: Initialize the pgpool2_full_configuration variable
+  set_fact:
     pgpool2_full_configuration: "{{ pgpool2_configuration }}"
 
-- set_fact:
+- name: Merge pgpool2_default_configuration and pgpool2_configuration
+  set_fact:
     pgpool2_full_configuration: >-
       {{ pgpool2_full_configuration | default([]) + [
           merge_item |
@@ -172,7 +179,7 @@
       delegate_to: "{{ server.value.public_ip }}"
   when:
     - server.value.node_type in supported_node_type
-    - pgpool2_ssl == true
+    - pgpool2_ssl is true
   with_dict:  "{{ servers }}"
   loop_control:
     loop_var: server
@@ -184,7 +191,7 @@
       delegate_to: "{{ server.value.public_ip }}"
   when:
     - server.value.node_type in supported_node_type
-    - pgpool2_load_balancing == true
+    - pgpool2_load_balancing is true
   with_dict:  "{{ servers }}"
   loop_control:
     loop_var: server
@@ -210,7 +217,7 @@
       delegate_to: "{{ server.value.public_ip }}"
   when:
     - server.value.node_type in supported_node_type
-    - pgpool2_watchdog == true
+    - pgpool2_watchdog is true
   vars:
     pgpool2_node_list: "{{ pgpool2_nodes }}"
     pgpool2_current_node: "{{ server.value.public_ip }}"

--- a/roles/setup_pgpool2/tasks/main.yml
+++ b/roles/setup_pgpool2/tasks/main.yml
@@ -5,6 +5,10 @@
 - name: Reference pg_type variables
   include_vars: "{{ pg_type }}.yml"
 
+# Include EPAS/PG variables from the initdb_server role
+- name: Reference pg_type variables
+  include_vars: "../../init_dbserver/vars/{{ pg_type }}.yml"
+
 # Check if the Operating System is supported
 - name: Check support for Operating System
   fail:
@@ -27,16 +31,112 @@
     - pg_type == "EPAS"
     - pgpool2_version not in supported_pgpool2_version
 
+# Set service name accordingly to pg_type
+- set_fact:
+    pgpool2_service_name: >-
+      {% if pg_type == 'EPAS' %}edb-pgpool-{{ pgpool2_version }}{% elif pg_type == 'PG' %}pgpool-II-{{ pg_version }}{% endif %}
+  when:
+
+# Initialize variables used to configure load balancing and backends
+- set_fact:
+    pgpool2_backends: []
+    pgpool2_nodes: []
+    pgpool2_primary_backend: ""
+
+# Build the list of postgres backends
+- set_fact:
+    pgpool2_backends: "{{ pgpool2_backends }} + [ '{{ server.value.public_ip }}' ]"
+  when:
+    - server.value.node_type == 'primary' or server.value.node_type == 'standby'
+  with_dict: "{{ servers }}"
+  loop_control:
+    loop_var: server
+
+- set_fact:
+    pgpool2_primary_backend: "{{ server.value.public_ip }}"
+  when:
+    - server.value.node_type == 'primary'
+  with_dict: "{{ servers }}"
+  loop_control:
+    loop_var: server
+
+# Build the list of pgpool2 nodes
+- set_fact:
+    pgpool2_nodes: "{{ pgpool2_nodes }} + [ '{{ server.value.public_ip }}' ]"
+  when:
+    - server.value.node_type in supported_node_type
+  with_dict: "{{ servers }}"
+  loop_control:
+    loop_var: server
+
 - name: Include the pgpool2_install
-  include_tasks: pgpool2_install.yml
+  include_tasks:
+    file: pgpool2_install.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
   when: server.value.node_type in supported_node_type
   with_dict:  "{{ servers }}"
   loop_control:
     loop_var: server
 
 - name: Include the pgpool2_setup
-  include_tasks: pgpool2_setup.yml
+  include_tasks:
+    file: pgpool2_setup.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
   when: server.value.node_type in supported_node_type
+  with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
+
+- name: Include the pgpool2_configure_backends
+  include_tasks:
+    file: pgpool2_configure_backends.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
+  when:
+    - server.value.node_type in supported_node_type
+    - pgpool2_backends|length > 0
+    - pgpool2_primary_backend|length > 0
+  with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
+
+- name: Include the pgpool2_setup_sr_mode
+  include_tasks:
+    file: pgpool2_setup_sr_mode.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
+  when:
+    - server.value.node_type in supported_node_type
+    - pgpool2_backends|length > 0
+    - pgpool2_primary_backend|length > 0
+  with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
+
+- name: Include the pgpool2_configure_loadbalancing
+  include_tasks:
+    file: pgpool2_configure_loadbalancing.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
+  when:
+    - server.value.node_type in supported_node_type
+    - pgpool2_load_balancing == true
+  with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
+
+- name: Include the pgpool2_configure_backend_pg_hba
+  include_tasks:
+    file: pgpool2_configure_backend_pg_hba.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
+  when:
+    - server.value.node_type in ['primary', 'standby']
+    - pgpool2_nodes|length > 0
+  vars:
+    pgpool2_node_list: "{{ pgpool2_nodes }}"
   with_dict:  "{{ servers }}"
   loop_control:
     loop_var: server

--- a/roles/setup_pgpool2/tasks/main.yml
+++ b/roles/setup_pgpool2/tasks/main.yml
@@ -31,3 +31,8 @@
   include_tasks: pgpool2_install.yml
   when: item.value.node_type in supported_node_type
   with_dict:  "{{ servers }}"
+
+- name: Include the pgpool2_setup
+  include_tasks: pgpool2_setup.yml
+  when: item.value.node_type in supported_node_type
+  with_dict:  "{{ servers }}"

--- a/roles/setup_pgpool2/tasks/main.yml
+++ b/roles/setup_pgpool2/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# Tasks file for setup_pgpool2 Role
+
+# reference EPAS/PG variables
+- name: Reference pg_type variables
+  include_vars: "{{ pg_type }}.yml"
+
+# Check if the Operating System is supported
+- name: Check support for Operating System
+  fail:
+    msg: "Operating System = {{ os }} not supported."
+  when: os not in supported_os
+
+# Check if the Database Version is supported
+- name: Check supported versions for Database engine
+  fail:
+    msg: "Database Engine Version = {{ pg_version }} not supported.
+          Supported versions are {{ supported_pg_version }}"
+  when: pg_version|int not in supported_pg_version
+
+# Check if the pgpoolII version is supported when working with EPAS env.
+- name: Check supported versions for pgpoolII
+  fail:
+    msg: "pgpoolII Version = {{ pgpool2_version }} not supported.
+          Supported versions are {{ supported_pgpool2_version }}"
+  when:
+    - pg_type == "EPAS"
+    - pgpool2_version not in supported_pgpool2_version
+
+- name: Include the pgpool2_install
+  include_tasks: pgpool2_install.yml
+  when: item.value.node_type in supported_node_type
+  with_dict:  "{{ servers }}"

--- a/roles/setup_pgpool2/tasks/main.yml
+++ b/roles/setup_pgpool2/tasks/main.yml
@@ -68,6 +68,35 @@
   loop_control:
     loop_var: server
 
+# Merge pgpool2_default_configuration and pgpool2_configuration
+- set_fact:
+    pgpool2_full_configuration: "{{ pgpool2_configuration }}"
+
+- set_fact:
+    pgpool2_full_configuration: >-
+      {{ pgpool2_full_configuration | default([]) + [
+          merge_item |
+          combine(
+            pgpool2_full_configuration |
+            selectattr('key', 'match', merge_item.key) |
+            list
+          )
+        ] }}
+  loop: "{{ pgpool2_default_configuration | default([]) }}"
+  loop_control:
+    loop_var: merge_item
+
+# Generate configuration parameters dictionary
+- name: Generate configuration parameters dictionary
+  set_fact:
+    pgpool2_config_dict: >-
+      {{ pgpool2_config_dict|default({}) | combine( {ci.key: ci.value} ) }}
+  with_items: "{{ pgpool2_full_configuration }}"
+  loop_control:
+    loop_var: ci
+  when:
+    - ci.state == 'present'
+
 - name: Include the pgpool2_install
   include_tasks:
     file: pgpool2_install.yml
@@ -83,10 +112,13 @@
     file: pgpool2_setup.yml
     apply:
       delegate_to: "{{ server.value.public_ip }}"
-  when: server.value.node_type in supported_node_type
+  when:
+    - server.value.node_type in supported_node_type
   with_dict:  "{{ servers }}"
   loop_control:
     loop_var: server
+  vars:
+    config_dict: "{{ pgpool2_config_dict }}"
 
 - name: Include the pgpool2_setup_user_auth
   include_tasks:

--- a/roles/setup_pgpool2/tasks/main.yml
+++ b/roles/setup_pgpool2/tasks/main.yml
@@ -29,10 +29,14 @@
 
 - name: Include the pgpool2_install
   include_tasks: pgpool2_install.yml
-  when: item.value.node_type in supported_node_type
+  when: server.value.node_type in supported_node_type
   with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
 
 - name: Include the pgpool2_setup
   include_tasks: pgpool2_setup.yml
-  when: item.value.node_type in supported_node_type
+  when: server.value.node_type in supported_node_type
   with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server

--- a/roles/setup_pgpool2/tasks/main.yml
+++ b/roles/setup_pgpool2/tasks/main.yml
@@ -31,6 +31,15 @@
     - pg_type == "EPAS"
     - pgpool2_version not in supported_pgpool2_version
 
+- name: Check watchdog settings
+  fail:
+    msg: "Watchdog settings not valid: pgpool2_vip = '{{ pgpool2_vip }}',
+          pgpool2_vip_dev = '{{ pgpool2_vip_dev }}'"
+  when:
+    - pgpool2_watchdog == true
+    - (pgpool2_vip is not defined or pgpool2_vip|length == 0) or
+      (pgpool2_vip_dev is not defined or pgpool2_vip_dev|length == 0)
+
 # Set service name accordingly to pg_type
 - set_fact:
     pgpool2_service_name: >-
@@ -178,6 +187,22 @@
     - pgpool2_nodes|length > 0
   vars:
     pgpool2_node_list: "{{ pgpool2_nodes }}"
+  with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
+
+- name: Include the pgpool2_setup_watchdog
+  include_tasks:
+    file: pgpool2_setup_watchdog.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
+  when:
+    - server.value.node_type in supported_node_type
+    - pgpool2_watchdog == true
+  vars:
+    pgpool2_node_list: "{{ pgpool2_nodes }}"
+    pgpool2_current_node: "{{ server.value.public_ip }}"
+    config_dict: "{{ pgpool2_config_dict }}"
   with_dict:  "{{ servers }}"
   loop_control:
     loop_var: server

--- a/roles/setup_pgpool2/tasks/main.yml
+++ b/roles/setup_pgpool2/tasks/main.yml
@@ -165,6 +165,18 @@
   loop_control:
     loop_var: server
 
+- name: Include the pgpool2_setup_ssl
+  include_tasks:
+    file: pgpool2_setup_ssl.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
+  when:
+    - server.value.node_type in supported_node_type
+    - pgpool2_ssl == true
+  with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
+
 - name: Include the pgpool2_configure_loadbalancing
   include_tasks:
     file: pgpool2_configure_loadbalancing.yml

--- a/roles/setup_pgpool2/tasks/main.yml
+++ b/roles/setup_pgpool2/tasks/main.yml
@@ -35,7 +35,6 @@
 - set_fact:
     pgpool2_service_name: >-
       {% if pg_type == 'EPAS' %}edb-pgpool-{{ pgpool2_version }}{% elif pg_type == 'PG' %}pgpool-II-{{ pg_version }}{% endif %}
-  when:
 
 # Initialize variables used to configure load balancing and backends
 - set_fact:
@@ -82,6 +81,16 @@
 - name: Include the pgpool2_setup
   include_tasks:
     file: pgpool2_setup.yml
+    apply:
+      delegate_to: "{{ server.value.public_ip }}"
+  when: server.value.node_type in supported_node_type
+  with_dict:  "{{ servers }}"
+  loop_control:
+    loop_var: server
+
+- name: Include the pgpool2_setup_user_auth
+  include_tasks:
+    file: pgpool2_setup_user_auth.yml
     apply:
       delegate_to: "{{ server.value.public_ip }}"
   when: server.value.node_type in supported_node_type

--- a/roles/setup_pgpool2/tasks/pgpool2_configure_backend_pg_hba.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_configure_backend_pg_hba.yml
@@ -1,0 +1,20 @@
+---
+# Add HBA entries allowing connections from pgpoolII server to Postgres node
+- set_fact:
+   hba_entries: >-
+    [
+      {
+        'contype': 'host',
+        'source': '{{ pgpool2_node_ip }}/32'
+      }
+    ]
+  loop: "{{ pgpool2_node_list }}"
+  loop_control:
+    loop_var: pgpool2_node_ip
+
+- name: Allow access to pgpoolII servers
+  include_role:
+    name: manage_dbserver
+    tasks_from: manage_hba_conf
+  vars:
+    pg_hba_ip_addresses: "{{ hba_entries }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_configure_backend_pg_hba.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_configure_backend_pg_hba.yml
@@ -1,6 +1,7 @@
 ---
 # Add HBA entries allowing connections from pgpoolII server to Postgres node
-- set_fact:
+- name: Initialize the hba_entries variable
+  set_fact:
    hba_entries: >-
     {{ hba_entries | default([]) }} + [
       {

--- a/roles/setup_pgpool2/tasks/pgpool2_configure_backend_pg_hba.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_configure_backend_pg_hba.yml
@@ -2,7 +2,7 @@
 # Add HBA entries allowing connections from pgpoolII server to Postgres node
 - set_fact:
    hba_entries: >-
-    [
+    {{ hba_entries | default([]) }} + [
       {
         'contype': 'host',
         'source': '{{ pgpool2_node_ip }}/32'

--- a/roles/setup_pgpool2/tasks/pgpool2_configure_backends.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_configure_backends.yml
@@ -9,37 +9,37 @@
           'value': '{{ backend_item }}',
           'state': 'present',
           'quoted': true
-        }, 
+        },
         {
           'key': 'backend_port{{ ansible_loop.index0 }}',
           'value': '{{ pg_port }}',
           'state': 'present',
           'quoted': false
-        }, 
+        },
         {
           'key': 'backend_data_directory{{ ansible_loop.index0 }}',
           'value': '{{ pg_data }}',
           'state': 'present',
           'quoted': true
-        }, 
+        },
         {
           'key': 'backend_weight{{ ansible_loop.index0 }}',
           'value': '1',
           'state': 'present',
           'quoted': false
-        }, 
+        },
         {
           'key': 'backend_application_name{{ ansible_loop.index0 }}',
           'value': 'server{{ ansible_loop.index0 }}',
           'state': 'present',
           'quoted': true
-        }, 
+        },
         {
           'key': 'backend_flag{{ ansible_loop.index0 }}',
           'value': 'ALLOW_TO_FAILOVER',
           'state': 'present',
           'quoted': true
-        } 
+        }
       ]
   loop: "{{ pgpool2_backends }}"
   loop_control:

--- a/roles/setup_pgpool2/tasks/pgpool2_configure_backends.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_configure_backends.yml
@@ -58,3 +58,4 @@
   systemd:
     name: "{{ pgpool2_service_name }}"
     state: restarted
+  become: yes

--- a/roles/setup_pgpool2/tasks/pgpool2_configure_backends.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_configure_backends.yml
@@ -1,0 +1,60 @@
+---
+# Configure pgpoolII backends
+- name: Build backends configuration
+  set_fact:
+    pgpool2_backends_configuration: >-
+      {{ pgpool2_backends_configuration | default([]) }} + [
+        {
+          'key': 'backend_hostname{{ ansible_loop.index0 }}',
+          'value': '{{ backend_item }}',
+          'state': 'present',
+          'quoted': true
+        }, 
+        {
+          'key': 'backend_port{{ ansible_loop.index0 }}',
+          'value': '{{ pg_port }}',
+          'state': 'present',
+          'quoted': false
+        }, 
+        {
+          'key': 'backend_data_directory{{ ansible_loop.index0 }}',
+          'value': '{{ pg_data }}',
+          'state': 'present',
+          'quoted': true
+        }, 
+        {
+          'key': 'backend_weight{{ ansible_loop.index0 }}',
+          'value': '1',
+          'state': 'present',
+          'quoted': false
+        }, 
+        {
+          'key': 'backend_application_name{{ ansible_loop.index0 }}',
+          'value': 'server{{ ansible_loop.index0 }}',
+          'state': 'present',
+          'quoted': true
+        }, 
+        {
+          'key': 'backend_flag{{ ansible_loop.index0 }}',
+          'value': 'ALLOW_TO_FAILOVER',
+          'state': 'present',
+          'quoted': true
+        } 
+      ]
+  loop: "{{ pgpool2_backends }}"
+  loop_control:
+    extended: yes
+    loop_var:
+      backend_item
+
+# Apply configuration changes
+- include_role:
+    name: manage_pgpool2
+    tasks_from: pgpool2_manage_configuration
+  vars:
+    pgpool2_configuration_lines: "{{ pgpool2_backends_configuration }}"
+
+- name: Restart pgpoolII service
+  systemd:
+    name: "{{ pgpool2_service_name }}"
+    state: restarted

--- a/roles/setup_pgpool2/tasks/pgpool2_configure_loadbalancing.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_configure_loadbalancing.yml
@@ -23,3 +23,4 @@
   systemd:
     name: "{{ pgpool2_service_name }}"
     state: restarted
+  become: yes

--- a/roles/setup_pgpool2/tasks/pgpool2_configure_loadbalancing.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_configure_loadbalancing.yml
@@ -1,0 +1,25 @@
+---
+# Tasks for setting up pgpool2 load balancing
+- name: Enable load balance mode
+  set_fact:
+    pgpool2_lb_configuration: >-
+      [
+        {
+          'key': 'load_balance_mode',
+          'value': 'on',
+          'state': 'present',
+          'quoted': false
+        }
+      ]
+
+# Apply configuration changes
+- include_role:
+    name: manage_pgpool2
+    tasks_from: pgpool2_manage_configuration
+  vars:
+    pgpool2_configuration_lines: "{{ pgpool2_lb_configuration }}"
+
+- name: Restart pgpoolII service
+  systemd:
+    name: "{{ pgpool2_service_name }}"
+    state: restarted

--- a/roles/setup_pgpool2/tasks/pgpool2_install.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_install.yml
@@ -16,7 +16,7 @@
     name: "openssl"
   when:
     - os in ['CentOS7', 'RHEL7']
-    - pgpool2_ssl == true
+    - pgpool2_ssl is true
   become: yes
 
 - name: Install openssl package on CentOS8 or RHEL8
@@ -24,5 +24,5 @@
     name: "openssl"
   when:
     - os in ['CentOS8', 'RHEL8']
-    - pgpool2_ssl == true
+    - pgpool2_ssl is true
   become: yes

--- a/roles/setup_pgpool2/tasks/pgpool2_install.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_install.yml
@@ -10,3 +10,19 @@
     name: "{{ pgpool2_package_name }}"
   when: os in ['CentOS8', 'RHEL8']
   become: yes
+
+- name: Install openssl package on CentOS7 or RHEL7
+  yum:
+    name: "openssl"
+  when:
+    - os in ['CentOS7', 'RHEL7']
+    - pgpool2_ssl == true
+  become: yes
+
+- name: Install openssl package on CentOS8 or RHEL8
+  dnf:
+    name: "openssl"
+  when:
+    - os in ['CentOS8', 'RHEL8']
+    - pgpool2_ssl == true
+  become: yes

--- a/roles/setup_pgpool2/tasks/pgpool2_install.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_install.yml
@@ -4,11 +4,9 @@
     name: "{{ pgpool2_package_name }}"
   when: os in ['CentOS7', 'RHEL7']
   become: yes
-  delegate_to: "{{ server.value.public_ip }}"
 
 - name: Install pgpoolII package on CentOS8 or RHEL8
   dnf:
     name: "{{ pgpool2_package_name }}"
   when: os in ['CentOS8', 'RHEL8']
   become: yes
-  delegate_to: "{{ server.value.public_ip }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_install.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_install.yml
@@ -1,0 +1,14 @@
+---
+- name: Install pgpoolII package on CentOS7 or RHEL7
+  yum:
+    name: "{{ pgpool2_package_name }}"
+  when: os in ['CentOS7', 'RHEL7']
+  become: yes
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Install pgpoolII package on CentOS8 or RHEL8
+  dnf:
+    name: "{{ pgpool2_package_name }}"
+  when: os in ['CentOS8', 'RHEL8']
+  become: yes
+  delegate_to: "{{ item.value.public_ip }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_install.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_install.yml
@@ -4,11 +4,11 @@
     name: "{{ pgpool2_package_name }}"
   when: os in ['CentOS7', 'RHEL7']
   become: yes
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
 
 - name: Install pgpoolII package on CentOS8 or RHEL8
   dnf:
     name: "{{ pgpool2_package_name }}"
   when: os in ['CentOS8', 'RHEL8']
   become: yes
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -14,11 +14,6 @@
   loop_control:
     loop_var: merge_item
 
-# Set service name accordingly to pg_type
-- set_fact:
-    pgpool2_service_name: >-
-      {% if pg_type == 'EPAS' %}edb-pgpool-{{ pgpool2_version }}{% elif pg_type == 'PG' %}pgpool-II-{{ pg_version }}{% endif %}
-
 # Generate configuration parameters dictionary
 - name: Generate configuration parameters dictionary
   set_fact:
@@ -34,7 +29,6 @@
   group:
     name: "{{ pgpool2_group }}"
     state: present
-  delegate_to: "{{ server.value.public_ip }}"
 
 - name: Create pgpoolII system user {{ pgpool2_user }}
   user:
@@ -43,7 +37,6 @@
     group: "{{ pgpool2_group }}"
     state: present
     create_home: false
-  delegate_to: "{{ server.value.public_ip }}"
 
 - name: Create configuration directory {{ pgpool2_configuration_file | dirname }}
   file:
@@ -52,7 +45,6 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
     mode: 0755
-  delegate_to: "{{ server.value.public_ip }}"
 
 - name: Create logging directory {{ config_dict.logdir | default('') }}
   file:
@@ -61,7 +53,6 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
     mode: 0755
-  delegate_to: "{{ server.value.public_ip }}"
   when: config_dict.logdir is defined
 
 - name: Create running directory {{ config_dict.pid_file_name | default('') | dirname }}
@@ -71,7 +62,6 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
     mode: 0700
-  delegate_to: "{{ server.value.public_ip }}"
   when: config_dict.pid_file_name is defined
 
 - name: Create oiddir directory {{ config_dict.memqcache_oiddir | default('') }}
@@ -81,13 +71,14 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
     mode: 0700
-  delegate_to: "{{ server.value.public_ip }}"
   when: config_dict.memqcache_oiddir is defined
 
 # Build the configuration file
 - include_role:
     name: manage_pgpool2
     tasks_from: pgpool2_manage_configuration
+  vars:
+    pgpool2_configuration_lines: "{{ pgpool2_configuration }}"
 
 - name: Open listening TCP port {{ config_dict.port | default('') }}
   firewalld:
@@ -95,7 +86,6 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.port is defined
@@ -106,7 +96,6 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.pcp_port is defined
@@ -117,7 +106,6 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.pcp_port is defined
@@ -128,7 +116,6 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_port is defined
@@ -140,7 +127,6 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_port is defined
@@ -152,7 +138,6 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined
@@ -164,7 +149,6 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined
@@ -177,7 +161,6 @@
     owner: "root"
     group: "root"
     mode: 0700
-  delegate_to: "{{ server.value.public_ip }}"
   when:
     - pg_type == 'PG'
 
@@ -187,7 +170,6 @@
     dest: "{{ pgpool2_systemd_unit_file }}"
     src: ./templates/pgpool-II.unit.conf.template
     mode: 0644
-  delegate_to: "{{ server.value.public_ip }}"
   when:
     - pg_type == 'PG'
 
@@ -195,7 +177,6 @@
   systemd:
     name: "{{ pgpool2_service_name }}"
     state: stopped
-  delegate_to: "{{ server.value.public_ip }}"
 
 - name: Enable and start pgpoolII service
   systemd:
@@ -203,4 +184,3 @@
     enabled: true
     daemon_reload: yes
     state: started
-  delegate_to: "{{ server.value.public_ip }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -14,7 +14,7 @@
   group:
     name: "{{ pgpool2_group }}"
     state: present
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
 
 - name: Create pgpoolII system user {{ pgpool2_user }}
   user:
@@ -23,7 +23,7 @@
     group: "{{ pgpool2_group }}"
     state: present
     create_home: false
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
 
 - name: Create configuration directory {{ pgpool2_configuration_file | dirname }}
   file:
@@ -32,7 +32,7 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
     mode: 0755
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
 
 - name: Create logging directory {{ config_dict.logdir | default('') }}
   file:
@@ -41,7 +41,7 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
     mode: 0755
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
   when: config_dict.logdir is defined
 
 - name: Create running directory {{ config_dict.pid_file_name | default('') | dirname }}
@@ -51,7 +51,7 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
     mode: 0700
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
   when: config_dict.pid_file_name is defined
 
 - name: Create oiddir directory {{ config_dict.memqcache_oiddir | default('') }}
@@ -61,7 +61,7 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
     mode: 0700
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
   when: config_dict.memqcache_oiddir is defined
 
 # Build the configuration file
@@ -76,7 +76,7 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.port is defined
@@ -87,7 +87,7 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.pcp_port is defined
@@ -98,7 +98,7 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.pcp_port is defined
@@ -109,7 +109,7 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_port is defined
@@ -121,7 +121,7 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_port is defined
@@ -133,7 +133,7 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined
@@ -145,7 +145,7 @@
     permanent: yes
     state: enabled
     immediate: true
-  delegate_to: "{{ item.value.public_ip }}"
+  delegate_to: "{{ server.value.public_ip }}"
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -69,3 +69,84 @@
     name: manage_pgpool2
     tasks_from: pgpool2_manage_configuration
   with_dict:  "{{ servers }}"
+
+- name: Open listening TCP port {{ config_dict.port | default('') }}
+  firewalld:
+    port: "{{ config_dict.port }}/tcp"
+    permanent: yes
+    state: enabled
+    immediate: true
+  delegate_to: "{{ item.value.public_ip }}"
+  when:
+    - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
+    - config_dict.port is defined
+
+- name: Open PCP TCP port {{ config_dict.pcp_port | default('') }}
+  firewalld:
+    port: "{{ config_dict.pcp_port }}/tcp"
+    permanent: yes
+    state: enabled
+    immediate: true
+  delegate_to: "{{ item.value.public_ip }}"
+  when:
+    - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
+    - config_dict.pcp_port is defined
+
+- name: Open PCP UDP port {{ config_dict.pcp_port | default('') }}
+  firewalld:
+    port: "{{ config_dict.pcp_port }}/udp"
+    permanent: yes
+    state: enabled
+    immediate: true
+  delegate_to: "{{ item.value.public_ip }}"
+  when:
+    - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
+    - config_dict.pcp_port is defined
+
+- name: Open Watchdog TCP port {{ config_dict.wd_port | default('') }}
+  firewalld:
+    port: "{{ config_dict.wd_port }}/tcp"
+    permanent: yes
+    state: enabled
+    immediate: true
+  delegate_to: "{{ item.value.public_ip }}"
+  when:
+    - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
+    - config_dict.wd_port is defined
+    - config_dict.use_watchdog == 'on'
+
+- name: Open Watchdog UDP port {{ config_dict.wd_port | default('') }}
+  firewalld:
+    port: "{{ config_dict.wd_port }}/udp"
+    permanent: yes
+    state: enabled
+    immediate: true
+  delegate_to: "{{ item.value.public_ip }}"
+  when:
+    - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
+    - config_dict.wd_port is defined
+    - config_dict.use_watchdog == 'on'
+
+- name: Open Watchdog heartbeat TCP port {{ config_dict.wd_heartbeat_port | default('') }}
+  firewalld:
+    port: "{{ config_dict.wd_heartbeat_port }}/tcp"
+    permanent: yes
+    state: enabled
+    immediate: true
+  delegate_to: "{{ item.value.public_ip }}"
+  when:
+    - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
+    - config_dict.wd_heartbeat_port is defined
+    - config_dict.use_watchdog == 'on'
+
+- name: Open Watchdog heartbeat UDP port {{ config_dict.wd_heartbeat_port | default('') }}
+  firewalld:
+    port: "{{ config_dict.wd_heartbeat_port }}/udp"
+    permanent: yes
+    state: enabled
+    immediate: true
+  delegate_to: "{{ item.value.public_ip }}"
+  when:
+    - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
+    - config_dict.wd_heartbeat_port is defined
+    - config_dict.use_watchdog == 'on'

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -94,7 +94,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_port is defined
-    - config_dict.use_watchdog == 'on'
+    - pgpool2_watchdog == true
 
 - name: Open Watchdog UDP port {{ config_dict.wd_port | default('') }}
   firewalld:
@@ -105,7 +105,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_port is defined
-    - config_dict.use_watchdog == 'on'
+    - pgpool2_watchdog == true
 
 - name: Open Watchdog heartbeat TCP port {{ config_dict.wd_heartbeat_port | default('') }}
   firewalld:
@@ -116,7 +116,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined
-    - config_dict.use_watchdog == 'on'
+    - pgpool2_watchdog == true
 
 - name: Open Watchdog heartbeat UDP port {{ config_dict.wd_heartbeat_port | default('') }}
   firewalld:
@@ -127,7 +127,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined
-    - config_dict.use_watchdog == 'on'
+    - pgpool2_watchdog == true
 
 - name: Create pgpoolII systemd directory
   file:

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -25,6 +25,45 @@
     create_home: false
   delegate_to: "{{ item.value.public_ip }}"
 
+- name: Create configuration directory {{ pgpool2_configuration_file | dirname }}
+  file:
+    path: "{{ pgpool2_configuration_file | dirname }}"
+    state: directory
+    owner: "{{ pgpool2_user }}"
+    group: "{{ pgpool2_group }}"
+    mode: 0755
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Create logging directory {{ config_dict.logdir | default('') }}
+  file:
+    path: "{{ config_dict.logdir }}"
+    state: directory
+    owner: "{{ pgpool2_user }}"
+    group: "{{ pgpool2_group }}"
+    mode: 0755
+  delegate_to: "{{ item.value.public_ip }}"
+  when: config_dict.logdir is defined
+
+- name: Create running directory {{ config_dict.pid_file_name | default('') | dirname }}
+  file:
+    path: "{{ config_dict.pid_file_name | dirname }}"
+    state: directory
+    owner: "{{ pgpool2_user }}"
+    group: "{{ pgpool2_group }}"
+    mode: 0700
+  delegate_to: "{{ item.value.public_ip }}"
+  when: config_dict.pid_file_name is defined
+
+- name: Create oiddir directory {{ config_dict.memqcache_oiddir | default('') }}
+  file:
+    path: "{{ config_dict.memqcache_oiddir }}"
+    state: directory
+    owner: "{{ pgpool2_user }}"
+    group: "{{ pgpool2_group }}"
+    mode: 0700
+  delegate_to: "{{ item.value.public_ip }}"
+  when: config_dict.memqcache_oiddir is defined
+
 # Build the configuration file
 - include_role:
     name: manage_pgpool2

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -164,3 +164,24 @@
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined
     - config_dict.use_watchdog == 'on'
+
+- name: Create pgpoolII systemd directory
+  file:
+    path: "{{ pgpool2_systemd_unit_file | dirname }}"
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: 0700
+  delegate_to: "{{ server.value.public_ip }}"
+  when:
+    - pg_type == 'PG'
+
+- name: Generate pgpoolII systemd unit file
+  template:
+    backup: yes
+    dest: "{{ pgpool2_systemd_unit_file }}"
+    src: ./templates/pgpool-II.unit.conf.template
+    mode: 0644
+  delegate_to: "{{ server.value.public_ip }}"
+  when:
+    - pg_type == 'PG'

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -1,0 +1,7 @@
+---
+
+# Build the configuration file
+- include_role:
+    name: manage_pgpool2
+    tasks_from: pgpool2_manage_configuration
+  with_dict:  "{{ servers }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -1,4 +1,19 @@
 ---
+# Merge pgpool2_default_configuration and pgpool2_configuration
+- set_fact:
+    pgpool2_configuration: >-
+      {{ pgpool2_configuration | default([]) + [
+          merge_item |
+          combine(
+            pgpool2_configuration |
+            selectattr('key', 'match', merge_item.key) |
+            list
+          )
+        ] }}
+  loop: "{{ pgpool2_default_configuration }}"
+  loop_control:
+    loop_var: merge_item
+
 # Generate configuration parameters dictionary
 - name: Generate configuration parameters dictionary
   set_fact:
@@ -68,7 +83,6 @@
 - include_role:
     name: manage_pgpool2
     tasks_from: pgpool2_manage_configuration
-  with_dict:  "{{ servers }}"
 
 - name: Open listening TCP port {{ config_dict.port | default('') }}
   firewalld:

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -10,6 +10,21 @@
   when:
     - ci.state == 'present'
 
+- name: Create pgpoolII system group {{ pgpool2_group }}
+  group:
+    name: "{{ pgpool2_group }}"
+    state: present
+  delegate_to: "{{ item.value.public_ip }}"
+
+- name: Create pgpoolII system user {{ pgpool2_user }}
+  user:
+    name: "{{ pgpool2_user }}"
+    system: true
+    group: "{{ pgpool2_group }}"
+    state: present
+    create_home: false
+  delegate_to: "{{ item.value.public_ip }}"
+
 # Build the configuration file
 - include_role:
     name: manage_pgpool2

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -1,30 +1,5 @@
 ---
-# Merge pgpool2_default_configuration and pgpool2_configuration
-- set_fact:
-    pgpool2_configuration: >-
-      {{ pgpool2_configuration | default([]) + [
-          merge_item |
-          combine(
-            pgpool2_configuration |
-            selectattr('key', 'match', merge_item.key) |
-            list
-          )
-        ] }}
-  loop: "{{ pgpool2_default_configuration }}"
-  loop_control:
-    loop_var: merge_item
-
-# Generate configuration parameters dictionary
-- name: Generate configuration parameters dictionary
-  set_fact:
-    config_dict: >-
-      {{ config_dict|default({}) | combine( {ci.key: ci.value} ) }}
-  with_items: "{{ pgpool2_configuration }}"
-  loop_control:
-    loop_var: ci
-  when:
-    - ci.state == 'present'
-
+# Tasks for setting up pgpoolII
 - name: Create pgpoolII system group {{ pgpool2_group }}
   group:
     name: "{{ pgpool2_group }}"
@@ -78,7 +53,7 @@
     name: manage_pgpool2
     tasks_from: pgpool2_manage_configuration
   vars:
-    pgpool2_configuration_lines: "{{ pgpool2_configuration }}"
+    pgpool2_configuration_lines: "{{ pgpool2_full_configuration }}"
 
 - name: Open listening TCP port {{ config_dict.port | default('') }}
   firewalld:

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -14,6 +14,11 @@
   loop_control:
     loop_var: merge_item
 
+# Set service name accordingly to pg_type
+- set_fact:
+    pgpool2_service_name: >-
+      {% if pg_type == 'EPAS' %}edb-pgpool-{{ pgpool2_version }}{% elif pg_type == 'PG' %}pgpool-II-{{ pg_version }}{% endif %}
+
 # Generate configuration parameters dictionary
 - name: Generate configuration parameters dictionary
   set_fact:
@@ -185,3 +190,17 @@
   delegate_to: "{{ server.value.public_ip }}"
   when:
     - pg_type == 'PG'
+
+- name: Stop pgpoolII service
+  systemd:
+    name: "{{ pgpool2_service_name }}"
+    state: stopped
+  delegate_to: "{{ server.value.public_ip }}"
+
+- name: Enable and start pgpoolII service
+  systemd:
+    name: "{{ pgpool2_service_name }}"
+    enabled: true
+    daemon_reload: yes
+    state: started
+  delegate_to: "{{ server.value.public_ip }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -4,6 +4,7 @@
   group:
     name: "{{ pgpool2_group }}"
     state: present
+  become: yes
 
 - name: Create pgpoolII system user {{ pgpool2_user }}
   user:
@@ -12,6 +13,7 @@
     group: "{{ pgpool2_group }}"
     state: present
     create_home: false
+  become: yes
 
 - name: Create configuration directory {{ pgpool2_configuration_file | dirname }}
   file:
@@ -20,6 +22,7 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
     mode: 0755
+  become: yes
 
 - name: Create logging directory {{ config_dict.logdir | default('') }}
   file:
@@ -29,6 +32,7 @@
     group: "{{ pgpool2_group }}"
     mode: 0755
   when: config_dict.logdir is defined
+  become: yes
 
 - name: Create running directory {{ config_dict.pid_file_name | default('') | dirname }}
   file:
@@ -38,6 +42,7 @@
     group: "{{ pgpool2_group }}"
     mode: 0700
   when: config_dict.pid_file_name is defined
+  become: yes
 
 - name: Create oiddir directory {{ config_dict.memqcache_oiddir | default('') }}
   file:
@@ -47,6 +52,7 @@
     group: "{{ pgpool2_group }}"
     mode: 0700
   when: config_dict.memqcache_oiddir is defined
+  become: yes
 
 # Build the configuration file
 - include_role:
@@ -64,6 +70,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.port is defined
+  become: yes
 
 - name: Open PCP TCP port {{ config_dict.pcp_port | default('') }}
   firewalld:
@@ -74,6 +81,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.pcp_port is defined
+  become: yes
 
 - name: Open PCP UDP port {{ config_dict.pcp_port | default('') }}
   firewalld:
@@ -84,6 +92,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.pcp_port is defined
+  become: yes
 
 - name: Open Watchdog TCP port {{ config_dict.wd_port | default('') }}
   firewalld:
@@ -95,6 +104,7 @@
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_port is defined
     - pgpool2_watchdog == true
+  become: yes
 
 - name: Open Watchdog UDP port {{ config_dict.wd_port | default('') }}
   firewalld:
@@ -106,6 +116,7 @@
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_port is defined
     - pgpool2_watchdog == true
+  become: yes
 
 - name: Open Watchdog heartbeat TCP port {{ config_dict.wd_heartbeat_port | default('') }}
   firewalld:
@@ -117,6 +128,7 @@
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined
     - pgpool2_watchdog == true
+  become: yes
 
 - name: Open Watchdog heartbeat UDP port {{ config_dict.wd_heartbeat_port | default('') }}
   firewalld:
@@ -128,6 +140,7 @@
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined
     - pgpool2_watchdog == true
+  become: yes
 
 - name: Create pgpoolII systemd directory
   file:
@@ -138,6 +151,7 @@
     mode: 0700
   when:
     - pg_type == 'PG'
+  become: yes
 
 - name: Generate pgpoolII systemd unit file
   template:
@@ -147,11 +161,13 @@
     mode: 0644
   when:
     - pg_type == 'PG'
+  become: yes
 
 - name: Stop pgpoolII service
   systemd:
     name: "{{ pgpool2_service_name }}"
     state: stopped
+  become: yes
 
 - name: Enable and start pgpoolII service
   systemd:
@@ -159,3 +175,4 @@
     enabled: true
     daemon_reload: yes
     state: started
+  become: yes

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -1,4 +1,14 @@
 ---
+# Generate configuration parameters dictionary
+- name: Generate configuration parameters dictionary
+  set_fact:
+    config_dict: >-
+      {{ config_dict|default({}) | combine( {ci.key: ci.value} ) }}
+  with_items: "{{ pgpool2_configuration }}"
+  loop_control:
+    loop_var: ci
+  when:
+    - ci.state == 'present'
 
 # Build the configuration file
 - include_role:

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -103,7 +103,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_port is defined
-    - pgpool2_watchdog == true
+    - pgpool2_watchdog is true
   become: yes
 
 - name: Open Watchdog UDP port {{ config_dict.wd_port | default('') }}
@@ -115,7 +115,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_port is defined
-    - pgpool2_watchdog == true
+    - pgpool2_watchdog is true
   become: yes
 
 - name: Open Watchdog heartbeat TCP port {{ config_dict.wd_heartbeat_port | default('') }}
@@ -127,7 +127,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined
-    - pgpool2_watchdog == true
+    - pgpool2_watchdog is true
   become: yes
 
 - name: Open Watchdog heartbeat UDP port {{ config_dict.wd_heartbeat_port | default('') }}
@@ -139,7 +139,7 @@
   when:
     - os in ['CentOS8', 'CentOS7', 'RHEL7', 'RHEL8']
     - config_dict.wd_heartbeat_port is defined
-    - pgpool2_watchdog == true
+    - pgpool2_watchdog is true
   become: yes
 
 - name: Create pgpoolII systemd directory

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_sr_mode.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_sr_mode.yml
@@ -1,0 +1,73 @@
+---
+# Configure pgpoolII SR checking and master_slave_mode
+
+# Build random password for pgpool2_sr_user if needed
+- set_fact:
+    pgpool2_sr_check_password: >-
+      {{ lookup('password', '/dev/null chars=ascii_letters,digits length=12') }}
+  when:
+    - pgpool2_sr_check_password|length == 0
+
+# Create pgpool2_sr_user Postgres user on the primary node
+- name: Create pgpoolII SR check role on Postgres primary node
+  include_role:
+    name: manage_dbserver
+    tasks_from: manage_users
+    apply:
+      delegate_to: "{{ pgpool2_primary_backend }}"
+  vars:
+    pg_users:
+      - name: "{{ pgpool2_sr_check_user }}"
+        pass: "{{ pgpool2_sr_check_password }}"
+        role_attr_flags: login
+  when:
+    - pgpool2_primary_backend is defined
+    - pgpool2_primary_backend|length > 0
+
+- name: Build pgpoolII SR configuration
+  set_fact:
+    pgpool2_sr_configuration: >-
+      [
+        {
+          'key': 'master_slave_mode',
+          'value': 'on',
+          'state': 'present',
+          'quoted': false
+        }, 
+        {
+          'key': 'master_slave_sub_mode',
+          'value': 'stream',
+          'state': 'present',
+          'quoted': false
+        }, 
+        {
+          'key': 'sr_check_period',
+          'value': 1,
+          'state': 'present',
+          'quoted': false
+        }, 
+        {
+          'key': 'sr_check_user',
+          'value': '{{ pgpool2_sr_check_user }}',
+          'state': 'present',
+          'quoted': true
+        }, 
+        {
+          'key': 'sr_check_password',
+          'value': '{{ pgpool2_sr_check_password }}',
+          'state': 'present',
+          'quoted': true
+        } 
+      ]
+
+# Apply configuration changes
+- include_role:
+    name: manage_pgpool2
+    tasks_from: pgpool2_manage_configuration
+  vars:
+    pgpool2_configuration_lines: "{{ pgpool2_sr_configuration }}"
+
+- name: Restart pgpoolII service
+  systemd:
+    name: "{{ pgpool2_service_name }}"
+    state: restarted

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_sr_mode.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_sr_mode.yml
@@ -33,31 +33,31 @@
           'value': 'on',
           'state': 'present',
           'quoted': false
-        }, 
+        },
         {
           'key': 'master_slave_sub_mode',
           'value': 'stream',
           'state': 'present',
           'quoted': false
-        }, 
+        },
         {
           'key': 'sr_check_period',
           'value': 1,
           'state': 'present',
           'quoted': false
-        }, 
+        },
         {
           'key': 'sr_check_user',
           'value': '{{ pgpool2_sr_check_user }}',
           'state': 'present',
           'quoted': true
-        }, 
+        },
         {
           'key': 'sr_check_password',
           'value': '{{ pgpool2_sr_check_password }}',
           'state': 'present',
           'quoted': true
-        } 
+        }
       ]
 
 # Apply configuration changes
@@ -71,3 +71,4 @@
   systemd:
     name: "{{ pgpool2_service_name }}"
     state: restarted
+  become: yes

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_sr_mode.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_sr_mode.yml
@@ -2,7 +2,8 @@
 # Configure pgpoolII SR checking and master_slave_mode
 
 # Build random password for pgpool2_sr_user if needed
-- set_fact:
+- name: Build random password for pgpool2_sr_user
+  set_fact:
     pgpool2_sr_check_password: >-
       {{ lookup('password', '/dev/null chars=ascii_letters,digits length=12') }}
   when:

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_ssl.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_ssl.yml
@@ -1,0 +1,103 @@
+---
+# Tasks for setting up SSL mode for pgpoolII
+
+# Make sure the directory configured to contain SSL files exists
+- name: Create SSL directory {{ pgpool2_ssl_dir }}
+  file:
+    path: "{{ pgpool2_ssl_dir }}"
+    state: directory
+    owner: "{{ pgpool2_user }}"
+    group: "{{ pgpool2_group }}"
+    mode: 0700
+  become: yes
+
+- name: Check if the root CA certificate exists
+  stat:
+    path: "{{ pgpool2_ssl_dir }}/ca.crt"
+  become: yes
+  register: pgpool2_ssl_root_ca
+
+- name: Check if the server key exists
+  stat:
+    path: "{{ pgpool2_ssl_dir }}/server.key"
+  become: yes
+  register: pgpool2_ssl_server_key
+
+- name: Check if the server CRT exists
+  stat:
+    path: "{{ pgpool2_ssl_dir }}/server.crt"
+  become: yes
+  register: pgpool2_ssl_server_crt
+
+- name: Create root CA
+  shell:
+    cmd: >-
+      openssl req -new -x509 -days 365 -nodes \
+        -out {{ pgpool2_ssl_dir }}/ca.crt \
+        -keyout {{ pgpool2_ssl_dir }}/ca.key \
+        -subj "/CN=root-ca"
+  become: yes
+  become_user: "{{ pgpool2_user }}"
+  when: not pgpool2_ssl_root_ca.stat.exists
+
+- name: Create server key
+  shell:
+    cmd: >-
+      openssl genrsa -out {{ pgpool2_ssl_dir }}/server.key
+  become: yes
+  become_user: "{{ pgpool2_user }}"
+  when: not pgpool2_ssl_server_key.stat.exists
+
+- name: Create certificate request
+  shell:
+    cmd: >-
+      openssl req -new \
+        -key {{ pgpool2_ssl_dir }}/server.key \
+        -out {{ pgpool2_ssl_dir }}/server.csr \
+        -subj "/C={{ pgpool2_ssl_csr_dn.C }}/L={{ pgpool2_ssl_csr_dn.L }}/O={{ pgpool2_ssl_csr_dn.O }}/CN={{ pgpool2_ssl_csr_dn.CN }}/emailAddress={{ pgpool2_ssl_csr_dn.EMAIL }}"
+  become: yes
+  become_user: "{{ pgpool2_user }}"
+  when: not pgpool2_ssl_server_key.stat.exists
+
+- name: Create the CA-signed server certificate
+  shell:
+    cmd: >-
+      openssl x509 -req \
+        -in {{ pgpool2_ssl_dir }}/server.csr \
+        -days 365 \
+        -CA {{ pgpool2_ssl_dir }}/ca.crt \
+        -CAkey {{ pgpool2_ssl_dir }}/ca.key \
+        -CAcreateserial \
+        -out {{ pgpool2_ssl_dir }}/server.crt
+  become: yes
+  become_user: "{{ pgpool2_user }}"
+  when: not pgpool2_ssl_server_crt.stat.exists
+
+# Apply configuration changes
+- include_role:
+    name: manage_pgpool2
+    tasks_from: pgpool2_manage_configuration
+  vars:
+    pgpool2_configuration_lines: >-
+      [
+        {
+          'key': 'ssl',
+          'value': 'on'
+        },
+        {
+          'key': 'ssl_key',
+          'value': '{{ pgpool2_ssl_dir }}/server.key',
+          'quoted': true
+        },
+        {
+          'key': 'ssl_cert',
+          'value': '{{ pgpool2_ssl_dir }}/server.crt',
+          'quoted': true
+        }
+      ]
+
+- name: Restart pgpoolII service
+  systemd:
+    name: "{{ pgpool2_service_name }}"
+    state: restarted
+  become: yes

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_ssl.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_ssl.yml
@@ -41,12 +41,16 @@
   when: not pgpool2_ssl_root_ca.stat.exists
 
 - name: Create server key
-  shell:
+  command:
     cmd: >-
       openssl genrsa -out {{ pgpool2_ssl_dir }}/server.key
   become: yes
   become_user: "{{ pgpool2_user }}"
   when: not pgpool2_ssl_server_key.stat.exists
+
+- name: Set tmp_dn
+  set_fact:
+    tmp_dn: "{{ pgpool2_ssl_csr_dn }}"
 
 - name: Create certificate request
   shell:
@@ -54,7 +58,7 @@
       openssl req -new \
         -key {{ pgpool2_ssl_dir }}/server.key \
         -out {{ pgpool2_ssl_dir }}/server.csr \
-        -subj "/C={{ pgpool2_ssl_csr_dn.C }}/L={{ pgpool2_ssl_csr_dn.L }}/O={{ pgpool2_ssl_csr_dn.O }}/CN={{ pgpool2_ssl_csr_dn.CN }}/emailAddress={{ pgpool2_ssl_csr_dn.EMAIL }}"
+        -subj "/C={{ tmp_dn.C }}/L={{ tmp_dn.L }}/O={{ tmp_dn.O }}/CN={{ tmp_dn.CN }}/emailAddress={{ tmp_dn.EMAIL }}"
   become: yes
   become_user: "{{ pgpool2_user }}"
   when: not pgpool2_ssl_server_key.stat.exists

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_user_auth.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_user_auth.yml
@@ -7,8 +7,10 @@
   register: res_echo_home
   become: true
   become_user: "{{ pgpool2_user }}"
+  changed_when: false
 
-- set_fact:
+- name: Set the pgpool2_user_home_dir
+  set_fact:
     pgpool2_user_home_dir: "{{ res_echo_home.stdout }}"
 
 # Ensure home dir exists
@@ -22,7 +24,7 @@
   become: true
 
 # Test if the .pgpoolkey file exist in the home directory
-- name: Test if {{ pgpool2_user_home_dir}}/.pgpoolkey exists
+- name: Test if {{ pgpool2_user_home_dir }}/.pgpoolkey exists
   stat:
     path: "{{ pgpool2_user_home_dir }}/.pgpoolkey"
   register: stat_result

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_user_auth.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_user_auth.yml
@@ -1,0 +1,39 @@
+---
+# Setup pgpoolII user authentication
+
+# Fetch pgpool2_user home path
+- name: Fetch user {{ pgpool2_user }} home path
+  shell: "echo $HOME"
+  register: res_echo_home
+  become: true
+  become_user: "{{ pgpool2_user }}"
+
+- set_fact:
+    pgpool2_user_home_dir: "{{ res_echo_home.stdout }}"
+
+# Ensure home dir exists
+- name: Ensure {{ pgpool2_user_home_dir }} exists
+  file:
+    path: "{{ pgpool2_user_home_dir }}"
+    state: directory
+    owner: "{{ pgpool2_user }}"
+    group: "{{ pgpool2_group }}"
+    mode: 0700
+
+# Test if the .pgpoolkey file exist in the home directory
+- name: Test if {{ pgpool2_user_home_dir}}/.pgpoolkey exists
+  stat:
+    path: "{{ pgpool2_user_home_dir }}/.pgpoolkey"
+  register: stat_result
+
+# Build random AES key if .pgpoolkey does not exist or is empty
+- name: Build new random AES key
+  copy:
+    dest: "{{ pgpool2_user_home_dir }}/.pgpoolkey"
+    content: >
+      {{ lookup('password', '/dev/null chars=ascii_letters,digit length=128') }}
+    owner: "{{ pgpool2_user }}"
+    group: "{{ pgpool2_group }}"
+    mode: 0600
+  when:
+    - not stat_result.stat.exists or stat_result.stat.size == 0

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_user_auth.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_user_auth.yml
@@ -19,12 +19,14 @@
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
     mode: 0700
+  become: true
 
 # Test if the .pgpoolkey file exist in the home directory
 - name: Test if {{ pgpool2_user_home_dir}}/.pgpoolkey exists
   stat:
     path: "{{ pgpool2_user_home_dir }}/.pgpoolkey"
   register: stat_result
+  become: true
 
 # Build random AES key if .pgpoolkey does not exist or is empty
 - name: Build new random AES key
@@ -37,3 +39,4 @@
     mode: 0600
   when:
     - not stat_result.stat.exists or stat_result.stat.size == 0
+  become: true

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_watchdog.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_watchdog.yml
@@ -1,0 +1,109 @@
+---
+# Task for setting up pgpoolII watchdog feature
+
+- name: Create sudo rules for {{ pgpool2_user }}
+  template:
+    src: ./templates/pgpool.sudoers.d.conf.template
+    dest: /etc/sudoers.d/pgpool
+    mode: 0640
+
+- name: Watchdog configuration
+  set_fact:
+    pgpool2_watchdog_configuration: >-
+      [
+        {
+          'key': 'use_watchdog',
+          'value': 'on',
+        },
+        {
+          'key': 'delegate_IP',
+          'value': '{{ pgpool2_vip }}',
+          'quoted': true
+        },
+        {
+          'key': 'if_up_cmd',
+          'value': '/bin/sudo /sbin/ip addr add $_IP_$/24 dev {{ pgpool2_vip_dev }} label {{ pgpool2_vip_dev }}:0',
+          'quoted': true
+        },
+        {
+          'key': 'if_down_cmd',
+          'value': '/bin/sudo /sbin/ip addr del $_IP_$/24 dev {{ pgpool2_vip_dev }}',
+          'quoted': true
+        },
+        {
+          'key': 'arping_cmd',
+          'value': '/bin/sudo /sbin/arping -U $_IP_$ -w 1 -I {{ pgpool2_vip_dev }}',
+          'quoted': true
+        },
+        {
+          'key': 'wd_hostname',
+          'value': '{{ pgpool2_current_node }}',
+          'quoted': true
+        },
+        {
+          'key': 'wd_port',
+          'value': '{{ config_dict.wd_port }}',
+          'quoted': true
+        }
+      ]
+
+- set_fact:
+    pgpool2_other_node_list: []
+
+- set_fact:
+    pgpool2_other_node_list: >-
+      {{ pgpool2_other_node_list + [ node_item ] }}
+  loop: "{{ pgpool2_node_list }}"
+  loop_control:
+    loop_var:
+      node_item
+  when:
+    - node_item != pgpool2_current_node
+
+- name: Add other pgpool2 nodes in watchdog configuration
+  set_fact:
+    pgpool2_watchdog_configuration: >-
+      {{ pgpool2_watchdog_configuration }} + [
+        {
+          'key': 'other_pgpool_hostname{{ ansible_loop.index0 }}',
+          'value': '{{ node_item }}',
+          'quoted': true
+        },
+        {
+          'key': 'other_pgpool_port{{ ansible_loop.index0 }}',
+          'value': '{{ config_dict.port }}',
+          'quoted': false
+        },
+        {
+          'key': 'other_wd_port{{ ansible_loop.index0 }}',
+          'value': '{{ config_dict.wd_port }}',
+          'quoted': false
+        },
+        {
+          'key': 'heartbeat_destination{{ ansible_loop.index0 }}',
+          'value': '{{ node_item }}',
+          'quoted': true
+        },
+        {
+          'key': 'heartbeat_destination_port{{ ansible_loop.index0 }}',
+          'value': '{{ config_dict.wd_heartbeat_port }}',
+          'quoted': false
+        }
+      ]
+  loop: "{{ pgpool2_other_node_list }}"
+  loop_control:
+    extended: yes
+    loop_var:
+      node_item
+
+# Update the configuration file
+- include_role:
+    name: manage_pgpool2
+    tasks_from: pgpool2_manage_configuration
+  vars:
+    pgpool2_configuration_lines: "{{ pgpool2_watchdog_configuration }}"
+
+- name: Restart pgpoolII service
+  systemd:
+    name: "{{ pgpool2_service_name }}"
+    state: restarted

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_watchdog.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_watchdog.yml
@@ -6,6 +6,7 @@
     src: ./templates/pgpool.sudoers.d.conf.template
     dest: /etc/sudoers.d/pgpool
     mode: 0640
+  become: true
 
 - name: Watchdog configuration
   set_fact:
@@ -107,3 +108,4 @@
   systemd:
     name: "{{ pgpool2_service_name }}"
     state: restarted
+  become: true

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_watchdog.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_watchdog.yml
@@ -48,10 +48,12 @@
         }
       ]
 
-- set_fact:
+- name: Initialize pgpool2_other_node_list
+  set_fact:
     pgpool2_other_node_list: []
 
-- set_fact:
+- name: Populate pgpool2_other_node_list
+  set_fact:
     pgpool2_other_node_list: >-
       {{ pgpool2_other_node_list + [ node_item ] }}
   loop: "{{ pgpool2_node_list }}"

--- a/roles/setup_pgpool2/templates/pgpool-II.unit.conf.template
+++ b/roles/setup_pgpool2/templates/pgpool-II.unit.conf.template
@@ -1,6 +1,9 @@
 [Service]
 User={{ pgpool2_user }}
 
+EnvironmentFile=-/etc/sysconfig/pgpool-II_{{ pg_version }}
+
 ExecStart=
 ExecStart=/usr/pgpool-{{ pg_version }}/bin/pgpool -f {{ pgpool2_configuration_file }} $OPTS
-ExecStop=/usr/pgpool-13/bin/pgpool -f {{ pgpool2_configuration_file }} -m fast stop
+ExecStop=
+ExecStop=/usr/pgpool-{{ pg_version }}/bin/pgpool -f {{ pgpool2_configuration_file }} -m fast stop

--- a/roles/setup_pgpool2/templates/pgpool-II.unit.conf.template
+++ b/roles/setup_pgpool2/templates/pgpool-II.unit.conf.template
@@ -1,7 +1,7 @@
 [Service]
 User={{ pgpool2_user }}
 
-EnvironmentFile=-/etc/sysconfig/pgpool-II_{{ pg_version }}
+EnvironmentFile=-/etc/sysconfig/pgpool-II-{{ pg_version }}
 
 ExecStart=
 ExecStart=/usr/pgpool-{{ pg_version }}/bin/pgpool -f {{ pgpool2_configuration_file }} $OPTS

--- a/roles/setup_pgpool2/templates/pgpool-II.unit.conf.template
+++ b/roles/setup_pgpool2/templates/pgpool-II.unit.conf.template
@@ -1,0 +1,6 @@
+[Service]
+User={{ pgpool2_user }}
+
+ExecStart=
+ExecStart=/usr/pgpool-{{ pg_version }}/bin/pgpool -f {{ pgpool2_configuration_file }} $OPTS
+ExecStop=/usr/pgpool-13/bin/pgpool -f {{ pgpool2_configuration_file }} -m fast stop

--- a/roles/setup_pgpool2/templates/pgpool.sudoers.d.conf.template
+++ b/roles/setup_pgpool2/templates/pgpool.sudoers.d.conf.template
@@ -1,0 +1,1 @@
+{{ pgpool2_user }} ALL=(ALL) NOPASSWD: /sbin/ip,/sbin/arping

--- a/roles/setup_pgpool2/vars/EPAS.yml
+++ b/roles/setup_pgpool2/vars/EPAS.yml
@@ -6,7 +6,7 @@ pgpool2_user: "enterprisedb"
 pgpool2_group: "enterprisedb"
 
 # Directory containing SSL keys and certs
-pgpool2_ssl_dir: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/ssl"
+pgpool2_ssl_dir: "/etc/sysconfig/edb/pgpool-ssl"
 
 pgpool2_default_configuration:
   - {key: "pool_conn_dbname", value: "edb", state: absent, quoted: true}

--- a/roles/setup_pgpool2/vars/EPAS.yml
+++ b/roles/setup_pgpool2/vars/EPAS.yml
@@ -2,3 +2,182 @@
 
 pgpool2_version: 4.1
 pgpool2_package_name: "edb-pgpool{{ pgpool2_version | string | replace('.', '') }}"
+pgpool2_configuration_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pgpool.conf"
+pgpool2_user: "enterprisedb"
+pgpool2_group: "enterprisedb"
+
+pgpool2_configuration:
+  - {key: "pool_conn_dbname", value: "edb", state: absent, quoted: true}
+  - {key: "listen_addresses", value: "*", state: present, quoted: true}
+  - {key: "port", value: 5433, state: present, quoted: false}
+  - {key: "socket_dir", value: "/tmp", state: present, quoted: true}
+  - {key: "listen_backlog_multiplier", value: 2, state: present, quoted: false}
+  - {key: "serialize_accept", value: "off", state: present, quoted: false}
+  - {key: "reserved_connections", value: 0, state: present, quoted: false}
+  - {key: "pcp_listen_addresses", value: "*", state: present, quoted: true}
+  - {key: "pcp_port", value: 9898, state: present, quoted: false}
+  - {key: "pcp_socket_dir", value: "/tmp", state: present, quoted: true}
+  - {key: "backend_hostname0", value: "localhost", state: present, quoted: true}
+  - {key: "backend_port0", value: 5444, state: present, quoted: false}
+  - {key: "backend_weight0", value: 1, state: present, quoted: false}
+  - {key: "backend_data_directory0", value: "/var/lib/edb/as{{ pg_version }}/data", state: present, quoted: true}
+  - {key: "backend_flag0", value: "ALLOW_TO_FAILOVER", state: present, quoted: true}
+  - {key: "backend_application_name0", value: "server0", state: present, quoted: true}
+  - {key: "backend_hostname1", value: "host2", state: absent, quoted: true}
+  - {key: "backend_port1", value: 5433, state: absent, quoted: false}
+  - {key: "backend_weight1", value: 1, state: absent, quoted: false}
+  - {key: "backend_data_directory1", value: "/data1", state: absent, quoted: true}
+  - {key: "backend_flag1", value: "ALLOW_TO_FAILOVER", state: absent, quoted: true}
+  - {key: "backend_application_name1", value: "server1", state: absent, quoted: true}
+  - {key: "enable_pool_hba", value: "off", state: present, quoted: false}
+  - {key: "pool_passwd", value: "pool_passwd", state: present, quoted: true}
+  - {key: "authentication_timeout", value: 60, state: present, quoted: false}
+  - {key: "allow_clear_text_frontend_auth", value: "off", state: present, quoted: false}
+  - {key: "ssl", value: "off", state: present, quoted: false}
+  - {key: "ssl_key", value: "./server.key", state: absent, quoted: true}
+  - {key: "ssl_cert", value: "./server.cert", state: absent, quoted: true}
+  - {key: "ssl_ca_cert", value: "", state: absent, quoted: true}
+  - {key: "ssl_ca_cert_dir", value: "", state: absent, quoted: true}
+  - {key: "ssl_ciphers", value: "HIGH:MEDIUM:+3DES:!aNULL", state: present, quoted: true}
+  - {key: "ssl_prefer_server_ciphers", value: "off", state: present, quoted: false}
+  - {key: "ssl_ecdh_curve", value: "prime256v1", state: present, quoted: true}
+  - {key: "ssl_dh_params_file", value: "", state: present, quoted: true}
+  - {key: "num_init_children", value: 32, state: present, quoted: false}
+  - {key: "max_pool", value: 4, state: present, quoted: false}
+  - {key: "child_life_time", value: 300, state: present, quoted: false}
+  - {key: "child_max_connections", value: 0, state: present, quoted: false}
+  - {key: "connection_life_time", value: 0, state: present, quoted: false}
+  - {key: "client_idle_limit", value: 0, state: present, quoted: false}
+  - {key: "log_destination", value: "stderr", state: present, quoted: true}
+  - {key: "log_line_prefix", value: "%t: pid %p: ", state: present, quoted: true}
+  - {key: "log_connections", value: "off", state: present, quoted: false}
+  - {key: "log_hostname", value: "off", state: present, quoted: false}
+  - {key: "log_statement", value: "off", state: present, quoted: false}
+  - {key: "log_per_node_statement", value: "off", state: present, quoted: false}
+  - {key: "log_client_messages", value: "off", state: present, quoted: false}
+  - {key: "log_standby_delay", value: "none", state: present, quoted: true}
+  - {key: "syslog_facility", value: "LOCAL0", state: present, quoted: true}
+  - {key: "syslog_ident", value: "pgpool", state: present, quoted: true}
+  - {key: "log_error_verbosity", value: "default", state: absent, quoted: false}
+  - {key: "client_min_messages", value: "notice", state: absent, quoted: false}
+  - {key: "log_min_messages", value: "warning", state: absent, quoted: false}
+  - {key: "pid_file_name", value: "/var/run/edb/pgpool{{ pgpool2_version | string }}/edb-pgpool-{{ pgpool2_version | string }}.pid", state: present, quoted: true}
+  - {key: "logdir", value: "/var/log/edb/pgpool{{ pgpool2_version | string }}", state: present, quoted: true}
+  - {key: "connection_cache", value: "on", state: present, quoted: false}
+  - {key: "reset_query_list", value: "ABORT; DISCARD ALL", state: present, quoted: true}
+  - {key: "replication_mode", value: "off", state: present, quoted: false}
+  - {key: "replicate_select", value: "off", state: present, quoted: false}
+  - {key: "insert_lock", value: "on", state: present, quoted: false}
+  - {key: "lobj_lock_table", value: "", state: present, quoted: true}
+  - {key: "replication_stop_on_mismatch", value: "off", state: present, quoted: false}
+  - {key: "failover_if_affected_tuples_mismatch", value: "off", state: present, quoted: false}
+  - {key: "load_balance_mode", value: "off", state: present, quoted: false}
+  - {key: "ignore_leading_white_space", value: "on", state: present, quoted: false}
+  - {key: "white_function_list", value: "", state: present, quoted: true}
+  - {key: "black_function_list", value: "currval,lastval,nextval,setval", state: present, quoted: true}
+  - {key: "black_query_pattern_list", value: "", state: present, quoted: true}
+  - {key: "database_redirect_preference_list", value: "", state: present, quoted: true}
+  - {key: "app_name_redirect_preference_list", value: "", state: present, quoted: true}
+  - {key: "allow_sql_comments", value: "off", state: present, quoted: false}
+  - {key: "disable_load_balance_on_write", value: "transaction", state: present, quoted: true}
+  - {key: "statement_level_load_balance", value: "off", state: present, quoted: false}
+  - {key: "master_slave_mode", value: "off", state: present, quoted: false}
+  - {key: "master_slave_sub_mode", value: "stream", state: present, quoted: true}
+  - {key: "sr_check_period", value: 0, state: present, quoted: false}
+  - {key: "sr_check_user", value: "nobody", state: present, quoted: true}
+  - {key: "sr_check_password", value: "", state: present, quoted: true}
+  - {key: "sr_check_database", value: "postgres", state: present, quoted: true}
+  - {key: "delay_threshold", value: 0, state: present, quoted: false}
+  - {key: "follow_master_command", value: "", state: present, quoted: true}
+  - {key: "health_check_period", value: 0, state: present, quoted: false}
+  - {key: "health_check_timeout", value: 20, state: present, quoted: false}
+  - {key: "health_check_user", value: "nobody", state: present, quoted: true}
+  - {key: "health_check_password", value: "", state: present, quoted: true}
+  - {key: "health_check_database", value: "", state: present, quoted: true}
+  - {key: "health_check_max_retries", value: 0, state: present, quoted: false}
+  - {key: "health_check_retry_delay", value: 1, state: present, quoted: false}
+  - {key: "connect_timeout", value: 10000, state: present, quoted: false}
+  - {key: "health_check_period0", value: 0, state: absent, quoted: false}
+  - {key: "health_check_timeout0", value: 20, state: absent, quoted: false}
+  - {key: "health_check_user0", value: "nobody", state: absent, quoted: true}
+  - {key: "health_check_password0", value: "", state: absent, quoted: true}
+  - {key: "health_check_database0", value: "", state: absent, quoted: true}
+  - {key: "health_check_max_retries0", value: 0, state: absent, quoted: false}
+  - {key: "health_check_retry_delay0", value: 1, state: absent, quoted: false}
+  - {key: "connect_timeout0", value: 10000, state: absent, quoted: false}
+  - {key: "failover_command", value: "", state: present, quoted: true}
+  - {key: "failback_command", value: "", state: present, quoted: true}
+  - {key: "failover_on_backend_error", value: "on", state: present, quoted: false}
+  - {key: "detach_false_primary", value: "off", state: present, quoted: false}
+  - {key: "search_primary_node_timeout", value: 300, state: present, quoted: false}
+  - {key: "auto_failback", value: "off", state: present, quoted: false}
+  - {key: "auto_failback_interval", value: 60, state: present, quoted: false}
+  - {key: "recovery_user", value: "nobody", state: present, quoted: true}
+  - {key: "recovery_password", value: "", state: present, quoted: true}
+  - {key: "recovery_1st_stage_command", value: "", state: present, quoted: true}
+  - {key: "recovery_2nd_stage_command", value: "", state: present, quoted: true}
+  - {key: "recovery_timeout", value: 90, state: present, quoted: false}
+  - {key: "client_idle_limit_in_recovery", value: 0, state: present, quoted: false}
+  - {key: "use_watchdog", value: "off", state: present, quoted: false}
+  - {key: "trusted_servers", value: "", state: present, quoted: true}
+  - {key: "ping_path", value: "/bin", state: present, quoted: true}
+  - {key: "wd_hostname", value: "", state: present, quoted: true}
+  - {key: "wd_port", value: 9000, state: present, quoted: false}
+  - {key: "wd_priority", value: 1, state: present, quoted: false}
+  - {key: "wd_authkey", value: "", state: present, quoted: true}
+  - {key: "wd_ipc_socket_dir", value: "/tmp", state: present, quoted: true}
+  - {key: "delegate_IP", value: "", state: present, quoted: true}
+  - {key: "if_cmd_path", value: "/sbin", state: present, quoted: true}
+  - {key: "if_up_cmd", value: "/usr/bin/sudo /sbin/ip addr add $_IP_$/24 dev eth0 label eth0:0", state: present, quoted: true}
+  - {key: "if_down_cmd", value: "/usr/bin/sudo /sbin/ip addr del $_IP_$/24 dev eth0", state: present, quoted: true}
+  - {key: "arping_path", value: "/usr/sbin", state: present, quoted: true}
+  - {key: "arping_cmd", value: "/usr/bin/sudo /usr/sbin/arping -U $_IP_$ -w 1 -I eth0", state: present, quoted: true}
+  - {key: "clear_memqcache_on_escalation", value: "on", state: present, quoted: false}
+  - {key: "wd_escalation_command", value: "", state: present, quoted: true}
+  - {key: "wd_de_escalation_command", value: "", state: present, quoted: true}
+  - {key: "failover_when_quorum_exists", value: "on", state: present, quoted: false}
+  - {key: "failover_require_consensus", value: "on", state: present, quoted: false}
+  - {key: "allow_multiple_failover_requests_from_node", value: "off", state: present, quoted: false}
+  - {key: "enable_consensus_with_half_votes", value: "off", state: present, quoted: false}
+  - {key: "wd_monitoring_interfaces_list", value: "", state: present, quoted: true}
+  - {key: "wd_lifecheck_method", value: "heartbeat", state: present, quoted: true}
+  - {key: "wd_interval", value: 10, state: present, quoted: false}
+  - {key: "wd_heartbeat_port", value: 9694, state: present, quoted: false}
+  - {key: "wd_heartbeat_keepalive", value: 2, state: present, quoted: false}
+  - {key: "wd_heartbeat_deadtime", value: 30, state: present, quoted: false}
+  - {key: "heartbeat_destination0", value: "host0_ip1", state: present, quoted: true}
+  - {key: "heartbeat_destination_port0", value: 9694, state: present, quoted: false}
+  - {key: "heartbeat_device0", value: "", state: present, quoted: true}
+  - {key: "heartbeat_destination1", value: "host0_ip2", state: absent, quoted: true}
+  - {key: "heartbeat_destination_port1", value: 9694, state: absent, quoted: false}
+  - {key: "heartbeat_device1", value: "", state: absent, quoted: true}
+  - {key: "wd_life_point", value: 3, state: present, quoted: false}
+  - {key: "wd_lifecheck_query", value: "SELECT 1", state: present, quoted: true}
+  - {key: "wd_lifecheck_dbname", value: "template1", state: present, quoted: true}
+  - {key: "wd_lifecheck_user", value: "nobody", state: present, quoted: true}
+  - {key: "wd_lifecheck_password", value: "", state: present, quoted: true}
+  - {key: "other_pgpool_hostname0", value: "host0", state: absent, quoted: true}
+  - {key: "other_pgpool_port0", value: 5432, state: absent, quoted: false}
+  - {key: "other_wd_port0", value: 9000, state: absent, quoted: false}
+  - {key: "other_pgpool_hostname1", value: "host1", state: absent, quoted: true}
+  - {key: "other_pgpool_port1", value: 5432, state: absent, quoted: false}
+  - {key: "other_wd_port1", value: 9000, state: absent, quoted: false}
+  - {key: "relcache_expire", value: 0, state: present, quoted: false}
+  - {key: "relcache_size", value: 256, state: present, quoted: false}
+  - {key: "check_temp_table", value: "catalog", state: present, quoted: false}
+  - {key: "check_unlogged_table", value: "on", state: present, quoted: false}
+  - {key: "enable_shared_relcache", value: "on", state: present, quoted: false}
+  - {key: "relcache_query_target", value: "master", state: present, quoted: false}
+  - {key: "memory_cache_enabled", value: "off", state: present, quoted: false}
+  - {key: "memqcache_method", value: "shmem", state: present, quoted: true}
+  - {key: "memqcache_memcached_host", value: "localhost", state: present, quoted: true}
+  - {key: "memqcache_memcached_port", value: 11211, state: present, quoted: false}
+  - {key: "memqcache_total_size", value: 67108864, state: present, quoted: false}
+  - {key: "memqcache_max_num_cache", value: 1000000, state: present, quoted: false}
+  - {key: "memqcache_expire", value: 0, state: present, quoted: false}
+  - {key: "memqcache_auto_cache_invalidation", value: "on", state: present, quoted: false}
+  - {key: "memqcache_maxcache", value: 409600, state: present, quoted: false}
+  - {key: "memqcache_cache_block_size", value: 1048576, state: present, quoted: false}
+  - {key: "memqcache_oiddir", value: "/var/log/edb/pgpool{{ pgpool2_version | string }}/oiddir", state: present, quoted: true}
+  - {key: "white_memqcache_table_list", value: "", state: present, quoted: true}
+  - {key: "black_memqcache_table_list", value: "", state: present, quoted: true}

--- a/roles/setup_pgpool2/vars/EPAS.yml
+++ b/roles/setup_pgpool2/vars/EPAS.yml
@@ -5,6 +5,9 @@ pgpool2_configuration_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | strin
 pgpool2_user: "enterprisedb"
 pgpool2_group: "enterprisedb"
 
+# Directory containing SSL keys and certs
+pgpool2_ssl_dir: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/ssl"
+
 pgpool2_default_configuration:
   - {key: "pool_conn_dbname", value: "edb", state: absent, quoted: true}
   - {key: "listen_addresses", value: "*", state: present, quoted: true}

--- a/roles/setup_pgpool2/vars/EPAS.yml
+++ b/roles/setup_pgpool2/vars/EPAS.yml
@@ -6,10 +6,12 @@ pgpool2_configuration_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | strin
 pgpool2_user: "enterprisedb"
 pgpool2_group: "enterprisedb"
 
-pgpool2_configuration:
+pgpool2_configuration: []
+
+pgpool2_default_configuration:
   - {key: "pool_conn_dbname", value: "edb", state: absent, quoted: true}
-  - {key: "listen_addresses", value: "*", state: present, quoted: true}
-  - {key: "port", value: 5433, state: present, quoted: false}
+  - {key: "listen_addresses", value: "localhost", state: present, quoted: true}
+  - {key: "port", value: 9999, state: present, quoted: false}
   - {key: "socket_dir", value: "/tmp", state: present, quoted: true}
   - {key: "listen_backlog_multiplier", value: 2, state: present, quoted: false}
   - {key: "serialize_accept", value: "off", state: present, quoted: false}

--- a/roles/setup_pgpool2/vars/EPAS.yml
+++ b/roles/setup_pgpool2/vars/EPAS.yml
@@ -1,0 +1,4 @@
+---
+
+pgpool2_version: 4.1
+pgpool2_package_name: "edb-pgpool{{ pgpool2_version | string | replace('.', '') }}"

--- a/roles/setup_pgpool2/vars/EPAS.yml
+++ b/roles/setup_pgpool2/vars/EPAS.yml
@@ -1,16 +1,24 @@
 ---
-
 pgpool2_version: 4.1
 pgpool2_package_name: "edb-pgpool{{ pgpool2_version | string | replace('.', '') }}"
 pgpool2_configuration_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pgpool.conf"
 pgpool2_user: "enterprisedb"
 pgpool2_group: "enterprisedb"
 
+# Enable load balancing
+pgpool2_load_balancing: true
+
+# Postgres user that pgpool2 will use to check Postgres nodes roles in load
+# balance mode
+pgpool2_sr_check_user: "pgpool2"
+# If empty or not defined, a random password will be generated
+pgpool2_sr_check_password: ""
+
 pgpool2_configuration: []
 
 pgpool2_default_configuration:
   - {key: "pool_conn_dbname", value: "edb", state: absent, quoted: true}
-  - {key: "listen_addresses", value: "localhost", state: present, quoted: true}
+  - {key: "listen_addresses", value: "*", state: present, quoted: true}
   - {key: "port", value: 9999, state: present, quoted: false}
   - {key: "socket_dir", value: "/tmp", state: present, quoted: true}
   - {key: "listen_backlog_multiplier", value: 2, state: present, quoted: false}

--- a/roles/setup_pgpool2/vars/EPAS.yml
+++ b/roles/setup_pgpool2/vars/EPAS.yml
@@ -5,17 +5,6 @@ pgpool2_configuration_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | strin
 pgpool2_user: "enterprisedb"
 pgpool2_group: "enterprisedb"
 
-# Enable load balancing
-pgpool2_load_balancing: true
-
-# Postgres user that pgpool2 will use to check Postgres nodes roles in load
-# balance mode
-pgpool2_sr_check_user: "pgpool2"
-# If empty or not defined, a random password will be generated
-pgpool2_sr_check_password: ""
-
-pgpool2_configuration: []
-
 pgpool2_default_configuration:
   - {key: "pool_conn_dbname", value: "edb", state: absent, quoted: true}
   - {key: "listen_addresses", value: "*", state: present, quoted: true}

--- a/roles/setup_pgpool2/vars/PG.yml
+++ b/roles/setup_pgpool2/vars/PG.yml
@@ -1,15 +1,15 @@
 ---
 # We don't have the choice of the version with community PostgreSQL
 pgpool2_version: ""
-pgpool2_package_name: "pgpool-II_{{ pg_version }}"
-pgpool2_configuration_file: "/etc/pgpool-II_{{ pg_version }}/pgpool.conf"
+pgpool2_package_name: "pgpool-II-{{ pg_version }}"
+pgpool2_configuration_file: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
 pgpool2_user: "postgres"
 pgpool2_group: "postgres"
 # Systemd unit file
 pgpool2_systemd_unit_file: "/etc/systemd/system/pgpool-II-{{ pg_version }}.service.d/pgpool-II-{{ pg_version }}.conf"
 
 # Directory containing SSL keys and certs
-pgpool2_ssl_dir: "/etc/pgpool-II_{{ pg_version }}/ssl"
+pgpool2_ssl_dir: "/etc/pgpool-II-{{ pg_version }}/ssl"
 
 pgpool2_default_configuration:
   - {key: "listen_addresses", value: "*", state: present, quoted: true}
@@ -65,8 +65,8 @@ pgpool2_default_configuration:
   - {key: "log_error_verbosity", value: "default", state: absent, quoted: false}
   - {key: "client_min_messages", value: "notice", state: absent, quoted: false}
   - {key: "log_min_messages", value: "warning", state: absent, quoted: false}
-  - {key: "pid_file_name", value: "/var/run/pgpool-II_{{ pg_version }}/pgpool.pid", state: present, quoted: true}
-  - {key: "logdir", value: "/var/log/pgpool-II_{{ pg_version }}", state: present, quoted: true}
+  - {key: "pid_file_name", value: "/var/run/pgpool-II-{{ pg_version }}/pgpool.pid", state: present, quoted: true}
+  - {key: "logdir", value: "/var/log/pgpool-II-{{ pg_version }}", state: present, quoted: true}
   - {key: "connection_cache", value: "on", state: present, quoted: false}
   - {key: "reset_query_list", value: "ABORT; DISCARD ALL", state: present, quoted: true}
   - {key: "replication_mode", value: "off", state: present, quoted: false}

--- a/roles/setup_pgpool2/vars/PG.yml
+++ b/roles/setup_pgpool2/vars/PG.yml
@@ -3,3 +3,181 @@
 # We don't have the choice of the version with community PostgreSQL
 pgpool2_version: ""
 pgpool2_package_name: "pgpool-II-{{ pg_version }}"
+pgpool2_configuration_file: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
+pgpool2_user: "postgres"
+pgpool2_group: "postgres"
+
+pgpool2_configuration:
+  - {key: "listen_addresses", value: "*", state: present, quoted: true}
+  - {key: "port", value: 9999, state: present, quoted: false}
+  - {key: "socket_dir", value: "/tmp", state: present, quoted: true}
+  - {key: "listen_backlog_multiplier", value: 2, state: present, quoted: false}
+  - {key: "serialize_accept", value: "off", state: present, quoted: false}
+  - {key: "reserved_connections", value: 0, state: present, quoted: false}
+  - {key: "pcp_listen_addresses", value: "*", state: present, quoted: true}
+  - {key: "pcp_port", value: 9898, state: present, quoted: false}
+  - {key: "pcp_socket_dir", value: "/tmp", state: present, quoted: true}
+  - {key: "backend_hostname0", value: "localhost", state: present, quoted: true}
+  - {key: "backend_port0", value: 5432, state: present, quoted: false}
+  - {key: "backend_weight0", value: 1, state: present, quoted: false}
+  - {key: "backend_data_directory0", value: "/var/lib/pgsql/{{ pg_version }}/data", state: present, quoted: true}
+  - {key: "backend_flag0", value: "ALLOW_TO_FAILOVER", state: present, quoted: true}
+  - {key: "backend_application_name0", value: "server0", state: present, quoted: true}
+  - {key: "backend_hostname1", value: "host2", state: absent, quoted: true}
+  - {key: "backend_port1", value: 5433, state: absent, quoted: false}
+  - {key: "backend_weight1", value: 1, state: absent, quoted: false}
+  - {key: "backend_data_directory1", value: "/data1", state: absent, quoted: true}
+  - {key: "backend_flag1", value: "ALLOW_TO_FAILOVER", state: absent, quoted: true}
+  - {key: "backend_application_name1", value: "server1", state: absent, quoted: true}
+  - {key: "enable_pool_hba", value: "off", state: present, quoted: false}
+  - {key: "pool_passwd", value: "pool_passwd", state: present, quoted: true}
+  - {key: "authentication_timeout", value: 60, state: present, quoted: false}
+  - {key: "allow_clear_text_frontend_auth", value: "off", state: present, quoted: false}
+  - {key: "ssl", value: "off", state: present, quoted: false}
+  - {key: "ssl_key", value: "./server.key", state: absent, quoted: true}
+  - {key: "ssl_cert", value: "./server.cert", state: absent, quoted: true}
+  - {key: "ssl_ca_cert", value: "", state: absent, quoted: true}
+  - {key: "ssl_ca_cert_dir", value: "", state: absent, quoted: true}
+  - {key: "ssl_ciphers", value: "HIGH:MEDIUM:+3DES:!aNULL", state: present, quoted: true}
+  - {key: "ssl_prefer_server_ciphers", value: "off", state: present, quoted: false}
+  - {key: "ssl_ecdh_curve", value: "prime256v1", state: present, quoted: true}
+  - {key: "ssl_dh_params_file", value: "", state: present, quoted: true}
+  - {key: "num_init_children", value: 32, state: present, quoted: false}
+  - {key: "max_pool", value: 4, state: present, quoted: false}
+  - {key: "child_life_time", value: 300, state: present, quoted: false}
+  - {key: "child_max_connections", value: 0, state: present, quoted: false}
+  - {key: "connection_life_time", value: 0, state: present, quoted: false}
+  - {key: "client_idle_limit", value: 0, state: present, quoted: false}
+  - {key: "log_destination", value: "stderr", state: present, quoted: true}
+  - {key: "log_line_prefix", value: "%t: pid %p: ", state: present, quoted: true}
+  - {key: "log_connections", value: "off", state: present, quoted: false}
+  - {key: "log_hostname", value: "off", state: present, quoted: false}
+  - {key: "log_statement", value: "off", state: present, quoted: false}
+  - {key: "log_per_node_statement", value: "off", state: present, quoted: false}
+  - {key: "log_client_messages", value: "off", state: present, quoted: false}
+  - {key: "log_standby_delay", value: "none", state: present, quoted: true}
+  - {key: "syslog_facility", value: "LOCAL0", state: present, quoted: true}
+  - {key: "syslog_ident", value: "pgpool", state: present, quoted: true}
+  - {key: "log_error_verbosity", value: "default", state: absent, quoted: false}
+  - {key: "client_min_messages", value: "notice", state: absent, quoted: false}
+  - {key: "log_min_messages", value: "warning", state: absent, quoted: false}
+  - {key: "pid_file_name", value: "/var/run/pgpool-II-{{ pg_version }}/pgpool.pid", state: present, quoted: true}
+  - {key: "logdir", value: "/var/log/pgpool-II-{{ pg_version }}", state: present, quoted: true}
+  - {key: "connection_cache", value: "on", state: present, quoted: false}
+  - {key: "reset_query_list", value: "ABORT; DISCARD ALL", state: present, quoted: true}
+  - {key: "replication_mode", value: "off", state: present, quoted: false}
+  - {key: "replicate_select", value: "off", state: present, quoted: false}
+  - {key: "insert_lock", value: "on", state: present, quoted: false}
+  - {key: "lobj_lock_table", value: "", state: present, quoted: true}
+  - {key: "replication_stop_on_mismatch", value: "off", state: present, quoted: false}
+  - {key: "failover_if_affected_tuples_mismatch", value: "off", state: present, quoted: false}
+  - {key: "load_balance_mode", value: "off", state: present, quoted: false}
+  - {key: "ignore_leading_white_space", value: "on", state: present, quoted: false}
+  - {key: "white_function_list", value: "", state: present, quoted: true}
+  - {key: "black_function_list", value: "currval,lastval,nextval,setval", state: present, quoted: true}
+  - {key: "black_query_pattern_list", value: "", state: present, quoted: true}
+  - {key: "database_redirect_preference_list", value: "", state: present, quoted: true}
+  - {key: "app_name_redirect_preference_list", value: "", state: present, quoted: true}
+  - {key: "allow_sql_comments", value: "off", state: present, quoted: false}
+  - {key: "disable_load_balance_on_write", value: "transaction", state: present, quoted: true}
+  - {key: "statement_level_load_balance", value: "off", state: present, quoted: false}
+  - {key: "master_slave_mode", value: "off", state: present, quoted: false}
+  - {key: "master_slave_sub_mode", value: "stream", state: present, quoted: true}
+  - {key: "sr_check_period", value: 0, state: present, quoted: false}
+  - {key: "sr_check_user", value: "nobody", state: present, quoted: true}
+  - {key: "sr_check_password", value: "", state: present, quoted: true}
+  - {key: "sr_check_database", value: "postgres", state: present, quoted: true}
+  - {key: "delay_threshold", value: 0, state: present, quoted: false}
+  - {key: "follow_master_command", value: "", state: present, quoted: true}
+  - {key: "health_check_period", value: 0, state: present, quoted: false}
+  - {key: "health_check_timeout", value: 20, state: present, quoted: false}
+  - {key: "health_check_user", value: "nobody", state: present, quoted: true}
+  - {key: "health_check_password", value: "", state: present, quoted: true}
+  - {key: "health_check_database", value: "", state: present, quoted: true}
+  - {key: "health_check_max_retries", value: 0, state: present, quoted: false}
+  - {key: "health_check_retry_delay", value: 1, state: present, quoted: false}
+  - {key: "connect_timeout", value: 10000, state: present, quoted: false}
+  - {key: "health_check_period0", value: 0, state: absent, quoted: false}
+  - {key: "health_check_timeout0", value: 20, state: absent, quoted: false}
+  - {key: "health_check_user0", value: "nobody", state: absent, quoted: true}
+  - {key: "health_check_password0", value: "", state: absent, quoted: true}
+  - {key: "health_check_database0", value: "", state: absent, quoted: true}
+  - {key: "health_check_max_retries0", value: 0, state: absent, quoted: false}
+  - {key: "health_check_retry_delay0", value: 1, state: absent, quoted: false}
+  - {key: "connect_timeout0", value: 10000, state: absent, quoted: false}
+  - {key: "failover_command", value: "", state: present, quoted: true}
+  - {key: "failback_command", value: "", state: present, quoted: true}
+  - {key: "failover_on_backend_error", value: "on", state: present, quoted: false}
+  - {key: "detach_false_primary", value: "off", state: present, quoted: false}
+  - {key: "search_primary_node_timeout", value: 300, state: present, quoted: false}
+  - {key: "auto_failback", value: "off", state: present, quoted: false}
+  - {key: "auto_failback_interval", value: 60, state: present, quoted: false}
+  - {key: "recovery_user", value: "nobody", state: present, quoted: true}
+  - {key: "recovery_password", value: "", state: present, quoted: true}
+  - {key: "recovery_1st_stage_command", value: "", state: present, quoted: true}
+  - {key: "recovery_2nd_stage_command", value: "", state: present, quoted: true}
+  - {key: "recovery_timeout", value: 90, state: present, quoted: false}
+  - {key: "client_idle_limit_in_recovery", value: 0, state: present, quoted: false}
+  - {key: "use_watchdog", value: "off", state: present, quoted: false}
+  - {key: "trusted_servers", value: "", state: present, quoted: true}
+  - {key: "ping_path", value: "/bin", state: present, quoted: true}
+  - {key: "wd_hostname", value: "", state: present, quoted: true}
+  - {key: "wd_port", value: 9000, state: present, quoted: false}
+  - {key: "wd_priority", value: 1, state: present, quoted: false}
+  - {key: "wd_authkey", value: "", state: present, quoted: true}
+  - {key: "wd_ipc_socket_dir", value: "/tmp", state: present, quoted: true}
+  - {key: "delegate_IP", value: "", state: present, quoted: true}
+  - {key: "if_cmd_path", value: "/sbin", state: present, quoted: true}
+  - {key: "if_up_cmd", value: "/usr/bin/sudo /sbin/ip addr add $_IP_$/24 dev eth0 label eth0:0", state: present, quoted: true}
+  - {key: "if_down_cmd", value: "/usr/bin/sudo /sbin/ip addr del $_IP_$/24 dev eth0", state: present, quoted: true}
+  - {key: "arping_path", value: "/usr/sbin", state: present, quoted: true}
+  - {key: "arping_cmd", value: "/usr/bin/sudo /usr/sbin/arping -U $_IP_$ -w 1 -I eth0", state: present, quoted: true}
+  - {key: "clear_memqcache_on_escalation", value: "on", state: present, quoted: false}
+  - {key: "wd_escalation_command", value: "", state: present, quoted: true}
+  - {key: "wd_de_escalation_command", value: "", state: present, quoted: true}
+  - {key: "failover_when_quorum_exists", value: "on", state: present, quoted: false}
+  - {key: "failover_require_consensus", value: "on", state: present, quoted: false}
+  - {key: "allow_multiple_failover_requests_from_node", value: "off", state: present, quoted: false}
+  - {key: "enable_consensus_with_half_votes", value: "off", state: present, quoted: false}
+  - {key: "wd_monitoring_interfaces_list", value: "", state: present, quoted: true}
+  - {key: "wd_lifecheck_method", value: "heartbeat", state: present, quoted: true}
+  - {key: "wd_interval", value: 10, state: present, quoted: false}
+  - {key: "wd_heartbeat_port", value: 9694, state: present, quoted: false}
+  - {key: "wd_heartbeat_keepalive", value: 2, state: present, quoted: false}
+  - {key: "wd_heartbeat_deadtime", value: 30, state: present, quoted: false}
+  - {key: "heartbeat_destination0", value: "host0_ip1", state: present, quoted: true}
+  - {key: "heartbeat_destination_port0", value: 9694, state: present, quoted: false}
+  - {key: "heartbeat_device0", value: "", state: present, quoted: true}
+  - {key: "heartbeat_destination1", value: "host0_ip2", state: absent, quoted: true}
+  - {key: "heartbeat_destination_port1", value: 9694, state: absent, quoted: false}
+  - {key: "heartbeat_device1", value: "", state: absent, quoted: true}
+  - {key: "wd_life_point", value: 3, state: present, quoted: false}
+  - {key: "wd_lifecheck_query", value: "SELECT 1", state: present, quoted: true}
+  - {key: "wd_lifecheck_dbname", value: "template1", state: present, quoted: true}
+  - {key: "wd_lifecheck_user", value: "nobody", state: present, quoted: true}
+  - {key: "wd_lifecheck_password", value: "", state: present, quoted: true}
+  - {key: "other_pgpool_hostname0", value: "host0", state: absent, quoted: true}
+  - {key: "other_pgpool_port0", value: 5432, state: absent, quoted: false}
+  - {key: "other_wd_port0", value: 9000, state: absent, quoted: false}
+  - {key: "other_pgpool_hostname1", value: "host1", state: absent, quoted: true}
+  - {key: "other_pgpool_port1", value: 5432, state: absent, quoted: false}
+  - {key: "other_wd_port1", value: 9000, state: absent, quoted: false}
+  - {key: "relcache_expire", value: 0, state: present, quoted: false}
+  - {key: "relcache_size", value: 256, state: present, quoted: false}
+  - {key: "check_temp_table", value: "catalog", state: present, quoted: false}
+  - {key: "check_unlogged_table", value: "on", state: present, quoted: false}
+  - {key: "enable_shared_relcache", value: "on", state: present, quoted: false}
+  - {key: "relcache_query_target", value: "master", state: present, quoted: false}
+  - {key: "memory_cache_enabled", value: "off", state: present, quoted: false}
+  - {key: "memqcache_method", value: "shmem", state: present, quoted: true}
+  - {key: "memqcache_memcached_host", value: "localhost", state: present, quoted: true}
+  - {key: "memqcache_memcached_port", value: 11211, state: present, quoted: false}
+  - {key: "memqcache_total_size", value: 67108864, state: present, quoted: false}
+  - {key: "memqcache_max_num_cache", value: 1000000, state: present, quoted: false}
+  - {key: "memqcache_expire", value: 0, state: present, quoted: false}
+  - {key: "memqcache_auto_cache_invalidation", value: "on", state: present, quoted: false}
+  - {key: "memqcache_maxcache", value: 409600, state: present, quoted: false}
+  - {key: "memqcache_cache_block_size", value: 1048576, state: present, quoted: false}
+  - {key: "memqcache_oiddir", value: "/var/log/pgpool/oiddir", state: present, quoted: true}
+  - {key: "white_memqcache_table_list", value: "", state: present, quoted: true}
+  - {key: "black_memqcache_table_list", value: "", state: present, quoted: true}

--- a/roles/setup_pgpool2/vars/PG.yml
+++ b/roles/setup_pgpool2/vars/PG.yml
@@ -1,0 +1,5 @@
+---
+
+# We don't have the choice of the version with community PostgreSQL
+pgpool2_version: ""
+pgpool2_package_name: "pgpool-II-{{ pg_version }}"

--- a/roles/setup_pgpool2/vars/PG.yml
+++ b/roles/setup_pgpool2/vars/PG.yml
@@ -8,6 +8,9 @@ pgpool2_group: "postgres"
 # Systemd unit file
 pgpool2_systemd_unit_file: "/etc/systemd/system/pgpool-II-{{ pg_version }}.service.d/pgpool-II-{{ pg_version }}.conf"
 
+# Directory containing SSL keys and certs
+pgpool2_ssl_dir: "/etc/pgpool-II_{{ pg_version }}/ssl"
+
 pgpool2_default_configuration:
   - {key: "listen_addresses", value: "*", state: present, quoted: true}
   - {key: "port", value: 9999, state: present, quoted: false}

--- a/roles/setup_pgpool2/vars/PG.yml
+++ b/roles/setup_pgpool2/vars/PG.yml
@@ -1,8 +1,8 @@
 ---
 # We don't have the choice of the version with community PostgreSQL
 pgpool2_version: ""
-pgpool2_package_name: "pgpool-II-{{ pg_version }}"
-pgpool2_configuration_file: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
+pgpool2_package_name: "pgpool-II_{{ pg_version }}"
+pgpool2_configuration_file: "/etc/pgpool-II_{{ pg_version }}/pgpool.conf"
 pgpool2_user: "postgres"
 pgpool2_group: "postgres"
 # Systemd unit file
@@ -73,8 +73,8 @@ pgpool2_default_configuration:
   - {key: "log_error_verbosity", value: "default", state: absent, quoted: false}
   - {key: "client_min_messages", value: "notice", state: absent, quoted: false}
   - {key: "log_min_messages", value: "warning", state: absent, quoted: false}
-  - {key: "pid_file_name", value: "/var/run/pgpool-II-{{ pg_version }}/pgpool.pid", state: present, quoted: true}
-  - {key: "logdir", value: "/var/log/pgpool-II-{{ pg_version }}", state: present, quoted: true}
+  - {key: "pid_file_name", value: "/var/run/pgpool-II_{{ pg_version }}/pgpool.pid", state: present, quoted: true}
+  - {key: "logdir", value: "/var/log/pgpool-II_{{ pg_version }}", state: present, quoted: true}
   - {key: "connection_cache", value: "on", state: present, quoted: false}
   - {key: "reset_query_list", value: "ABORT; DISCARD ALL", state: present, quoted: true}
   - {key: "replication_mode", value: "off", state: present, quoted: false}

--- a/roles/setup_pgpool2/vars/PG.yml
+++ b/roles/setup_pgpool2/vars/PG.yml
@@ -8,17 +8,6 @@ pgpool2_group: "postgres"
 # Systemd unit file
 pgpool2_systemd_unit_file: "/etc/systemd/system/pgpool-II-{{ pg_version }}.service.d/pgpool-II-{{ pg_version }}.conf"
 
-# Enable load balancing
-pgpool2_load_balancing: true
-
-# Postgres user that pgpool2 will use to check Postgres nodes roles in load
-# balance mode
-pgpool2_sr_check_user: "pgpool2"
-# If empty or not defined, a random password will be generated
-pgpool2_sr_check_password: ""
-
-pgpool2_configuration: []
-
 pgpool2_default_configuration:
   - {key: "listen_addresses", value: "*", state: present, quoted: true}
   - {key: "port", value: 9999, state: present, quoted: false}

--- a/roles/setup_pgpool2/vars/PG.yml
+++ b/roles/setup_pgpool2/vars/PG.yml
@@ -1,5 +1,4 @@
 ---
-
 # We don't have the choice of the version with community PostgreSQL
 pgpool2_version: ""
 pgpool2_package_name: "pgpool-II-{{ pg_version }}"
@@ -8,6 +7,15 @@ pgpool2_user: "postgres"
 pgpool2_group: "postgres"
 # Systemd unit file
 pgpool2_systemd_unit_file: "/etc/systemd/system/pgpool-II-{{ pg_version }}.service.d/pgpool-II-{{ pg_version }}.conf"
+
+# Enable load balancing
+pgpool2_load_balancing: true
+
+# Postgres user that pgpool2 will use to check Postgres nodes roles in load
+# balance mode
+pgpool2_sr_check_user: "pgpool2"
+# If empty or not defined, a random password will be generated
+pgpool2_sr_check_password: ""
 
 pgpool2_configuration: []
 

--- a/roles/setup_pgpool2/vars/PG.yml
+++ b/roles/setup_pgpool2/vars/PG.yml
@@ -7,7 +7,9 @@ pgpool2_configuration_file: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
 pgpool2_user: "postgres"
 pgpool2_group: "postgres"
 
-pgpool2_configuration:
+pgpool2_configuration: []
+
+pgpool2_default_configuration:
   - {key: "listen_addresses", value: "*", state: present, quoted: true}
   - {key: "port", value: 9999, state: present, quoted: false}
   - {key: "socket_dir", value: "/tmp", state: present, quoted: true}

--- a/roles/setup_pgpool2/vars/PG.yml
+++ b/roles/setup_pgpool2/vars/PG.yml
@@ -6,6 +6,8 @@ pgpool2_package_name: "pgpool-II-{{ pg_version }}"
 pgpool2_configuration_file: "/etc/pgpool-II-{{ pg_version }}/pgpool.conf"
 pgpool2_user: "postgres"
 pgpool2_group: "postgres"
+# Systemd unit file
+pgpool2_systemd_unit_file: "/etc/systemd/system/pgpool-II-{{ pg_version }}.service.d/pgpool-II-{{ pg_version }}.conf"
 
 pgpool2_configuration: []
 


### PR DESCRIPTION
This PR introduces PgpoolII deployment and management.

PgpoolII features availables:

- Read only queries load balancing.
- PgpoolII instances High-Availability with VIP management.
- Automated write queries routing to right Postgres node, even after Postgres failover.
- SSL support.

Battle tested on:
- CentOS 8 / PostgreSQL 13 / PgpoolII 4.1 (community)
- CentOS 7 / EPAS 12 / EDB PgpoolII 4.1