### PR TITLE
Do not replace special chars in sync standby names

### DIFF
--- a/roles/setup_replication/tasks/setup_replication.yml
+++ b/roles/setup_replication/tasks/setup_replication.yml
@@ -41,7 +41,7 @@
 
 - name: Prepare synchronous_standby_names
   set_fact:
-    synchronous_standbys: "{{ synchronous_standbys + [node.inventory_hostname | regex_replace('[^a-zA-Z0-9_]', '_')] }}"
+    synchronous_standbys: "{{ synchronous_standbys + [ node.inventory_hostname ] }}"
   loop: "{{ lookup('pg_sr_cluster_nodes', wantlist=True) }}"
   loop_control:
     loop_var: node


### PR DESCRIPTION
This is only needed for replication slot names, we don't have to do
it for the application_name.