### PR TITLE
Barman support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ This role helps in managing Pgpool II user list and configuration.
 For more information on the role, please refer roles README
 [README.md](./roles/manage_pgpool2/README.md)
 
+### setup_barmanserver
+
+Setting up Barman server role.
+[README.md](./roles/setup_barmanserver/README.md)
+
+### setup_barman
+
+Configure Postgres backups with Barman.
+[README.md](./roles/setup_barman/README.md)
+
+
 ## Pre-Requisites
 
 For correctly installed and configuration of the cluster following are requirements:

--- a/inventory.yml
+++ b/inventory.yml
@@ -6,6 +6,11 @@ all:
         pemserver1:
           ansible_host: xxx.xxx.xxx.xxx
           private_ip: xxx.xxx.xxx.xxx
+    barmanserver:
+      hosts:
+        barman1:
+          ansible_host: xxx.xxx.xxx.xxx
+          private_ip: xxx.xxx.xxx.xxx
     primary:
       hosts:
         primary1:
@@ -13,6 +18,9 @@ all:
           private_ip: xxx.xxx.xxx.xxx
           pem_agent: true
           pem_server_private_ip: xxx.xxx.xxx.xxx
+          barman: true
+          barman_server_private_ip: xxx.xxx.xxx.xxx
+          barman_backup_method: rsync
     standby:
       hosts:
         standby1:
@@ -22,6 +30,9 @@ all:
           replication_type: synchronous
           pem_agent: true
           pem_server_private_ip: xxx.xxx.xxx.xxx
+          barman: true
+          barman_server_private_ip: xxx.xxx.xxx.xxx
+          barman_backup_method: postgres
         standby2:
           ansible_host: xxx.xxx.xxx.xxx
           private_ip: xxx.xxx.xxx.xxx
@@ -29,3 +40,6 @@ all:
           replication_type: asynchronous
           pem_agent: true
           pem_server_private_ip: xxx.xxx.xxx.xxx
+          barman: true
+          barman_server_private_ip: xxx.xxx.xxx.xxx
+          barman_backup_method: postgres

--- a/lookup_plugins/barman_server.py
+++ b/lookup_plugins/barman_server.py
@@ -1,0 +1,73 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: barman_server
+    author: Julien Tachoires
+    short_description: Lookup Barman server, based on its private_ip
+    description:
+      - "Lookup Barman server, based on its private_ip"
+    options:
+      _terms:
+        description: Private IP of the Barman server.
+        required: False
+      default:
+        description: barman_server_private_ip of the current node.
+"""
+
+EXAMPLES = """
+- name: Show Barman server informations
+  debug: msg="{{ lookup('barman_server') }}"
+"""
+
+RETURN = """
+_value:
+  description:
+    - List of Barman server nodes
+  type: list
+  elements:
+    - dict: node_type, hostname, ansible_host (public IP address), private_ip
+"""
+
+from ansible.errors import AnsibleError
+from ansible.inventory.manager import InventoryManager
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+
+        myvars = getattr(self._templar, '_available_variables', {})
+        inventory_hostname = variables['inventory_hostname']
+
+        # If no terms, we'll used the current Barman server private IP
+        if len(terms) == 0:
+            if 'barman_server_private_ip' not in myvars['hostvars'][inventory_hostname]:
+                # barman_server_private_ip not set, return None
+                return []
+            barman_server_private_ip = myvars['hostvars'][inventory_hostname]['barman_server_private_ip']
+        else:
+            barman_server_private_ip = terms[0]
+
+        # If no barmanserver found in the inventory file, just return None
+        if 'barmanserver' not in variables['groups']:
+            return []
+        if len(variables['groups']['barmanserver']) == 0:
+            return []
+
+        # Lookup for barman servers with a matching private_ip
+        for host in variables['groups']['barmanserver']:
+            hostvars = myvars['hostvars'][host]
+
+            if hostvars['private_ip'] != barman_server_private_ip:
+                continue
+
+            return [
+                dict(
+                    node_type='barmanserver',
+                    ansible_host=hostvars['ansible_host'],
+                    hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
+                    private_ip=hostvars['private_ip'],
+                    inventory_hostname=hostvars['inventory_hostname']
+                )
+            ]

--- a/playbook.yml
+++ b/playbook.yml
@@ -42,3 +42,7 @@
       when: "'setup_pgbouncer' in host_supported_roles"
     - role: manage_pgbouncer
       when: "'manage_pgbouncer' in host_supported_roles"
+    - role: setup_barmanserver
+      when: "'setup_barmanserver' in host_supported_roles"
+    - role: setup_barman
+      when: "'setup_barman' in host_supported_roles"

--- a/roles/setup_barman/README.md
+++ b/roles/setup_barman/README.md
@@ -1,0 +1,167 @@
+# setup_barman
+
+This role is for configuring Barman backups on Postgres nodes.
+
+## Requirements
+
+Following are the requirements of this role.
+  1. Ansible
+  2. `edb_devops.postgres` -> `setup_repo` role for setting the repository on
+     the systems.
+
+## Role Variables
+
+When executing the role via ansible these are the required variables:
+
+  * ***pg_version***
+
+  Postgres Versions supported are: 10, 11, 12 and 13
+
+  * ***pg_type***
+
+  Database Engine supported are: PG and EPAS
+
+These and other variables can be assigned in the `pre_tasks` definition of the
+section: *How to include the `setup_barman` role in your Playbook*
+
+The rest of the variables can be configured and are available in the:
+
+  * [roles/setup_barman/defaults/main.yml](./defaults/main.yml)
+
+Below is the documentation of the rest of the main variables:
+
+### `barman_pg_user`
+
+Dedicated Postgres user excuting barman queries. Default: `barman`
+
+Example:
+```yaml
+barman_pg_user: 'barman'
+```
+
+## Host Variables
+
+Below are the host variables defined in the inventory file, for each Postgres
+node we want to backup with Barman.
+
+### `barman`
+
+Enable Barman backups for the host. Default: `false`
+
+Example:
+```yaml
+barman: yes
+```
+
+### `barman_server_private_ip`
+
+Barman server private IP address. Default: None
+
+Example:
+```yaml
+barman_server_private_ip: 10.0.0.123
+```
+
+### `barman_backup_method`
+
+Backup method. Can be:
+
+  * `postgres` for backups based on `pg_basebackup` using Streaming
+    Replication protocol.
+  * `rsync` for backups based on the `rsync` command using SSH protocol.
+
+Default: `rsync`
+
+Note: `rsync` backups can only be proceeded on primary nodes. Backuping
+standby nodes must be done with the `postgres` backup method.
+
+## Dependencies
+
+This role does not have any dependencies, but packages repositories should have
+been configured beforehand with the `setup_repo` role.
+
+## Example Playbook
+
+### Inventory file content
+
+Content of the `inventory.yml` file:
+
+```yaml
+---
+all:
+  children:
+    barmanserver:
+      hosts:
+        barman1:
+          ansible_host: xxx.xxx.xxx.xxx
+          private_ip: xxx.xxx.xxx.xxx
+    primary:
+      hosts:
+        primary1:
+          ansible_host: xxx.xxx.xxx.xxx
+          private_ip: xxx.xxx.xxx.xxx
+          barman: true
+          barman_server_private_ip: xxx.xxx.xxx.xxx
+          barman_backup_method: rsync
+    standby:
+      hosts:
+        standby1:
+          ansible_host: xxx.xxx.xxx.xxx
+          private_ip: xxx.xxx.xxx.xxx
+          upstream_node_private_ip: xxx.xxx.xxx.xxx
+          replication_type: synchronous
+          barman: true
+          barman_server_private_ip: xxx.xxx.xxx.xxx
+          barman_backup_method: postgres
+        standby2:
+          ansible_host: xxx.xxx.xxx.xxx
+          private_ip: xxx.xxx.xxx.xxx
+          upstream_node_private_ip: xxx.xxx.xxx.xxx
+          replication_type: asynchronous
+          barman: true
+          barman_server_private_ip: xxx.xxx.xxx.xxx
+          barman_backup_method: postgres
+```
+
+### How to include the `setup_barman` role in your Playbook
+
+Below is an example of how to include the `setup_barman` role:
+```yaml
+---
+- hosts: primary, standby
+  name: Configure Barman backup on Postgres nodes
+  become: yes
+  gather_facts: yes
+
+  # When using collections
+  #collections:
+  #  - edb_devops.edb_postgres
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        pg_version: 13
+        pg_type: "PG"
+
+  roles:
+    - setup_barman
+```
+
+Defining and adding variables is done in the `set_fact` of the `pre_tasks`.
+
+All the variables are available at:
+
+  * [roles/setup_barman/defaults/main.yml](./defaults/main.yml)
+
+## License
+
+BSD
+
+## Author information
+
+Author:
+
+  * Julien Tachoires
+  * Vibhor Kumar (Reviewer)
+  * EDB Postgres
+  * julien.tachoires@enterprisedb.com www.enterprisedb.com

--- a/roles/setup_barman/defaults/main.yml
+++ b/roles/setup_barman/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+
+barman_cli_package: "barman-cli-2.12-1"
+
+barman_pg_user: "barman"
+
+pass_dir: "~/.edb"
+
+supported_os:
+  - CentOS7
+  - CentOS8
+  - RHEL7
+  - RHEL8

--- a/roles/setup_barman/tasks/configure_barman.yml
+++ b/roles/setup_barman/tasks/configure_barman.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Get Barman server informations
+  set_fact:
+    _barman_server_info: "{{ lookup('barman_server', wantlist=True) }}"
+
+- name: Fail if barman server informations are not found
+  fail:
+    msg: "Unable to find barman server informations"
+  when:
+    - _barman_server_info|length == 0
+
+- name: Set _barman_server_public_ip
+  set_fact:
+    _barman_server_public_ip: "{{ _barman_server_info[0].ansible_host }}"
+
+- name: Ensure the barman configuration for the current host is present
+  template:
+    src: "./templates/barman.{{ barman_backup_method }}.template"
+    dest: "{{ barman_configuration_files_directory }}/{{ ansible_hostname }}.conf"
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    mode: 0700
+  delegate_to: "{{ _barman_server_public_ip }}"
+  become: yes
+
+- name: Reset _barman_server_info
+  set_fact:
+    _barman_server_info: ""

--- a/roles/setup_barman/tasks/configure_pg_backup.yml
+++ b/roles/setup_barman/tasks/configure_pg_backup.yml
@@ -1,0 +1,35 @@
+---
+
+- name: Ensure wal_level is configured to replica
+  include_role:
+    name: manage_dbserver
+    tasks_from: manage_postgres_params
+  vars:
+    pg_postgres_conf_params:
+      - name: wal_level
+        value: "replica"
+  no_log: "{{ disable_logging }}"
+
+- name: Ensure the replication slot barman exists
+  include_role:
+    name: manage_dbserver
+    tasks_from: manage_slots
+  vars:
+    pg_slots:
+      - name: barman
+        slot_type: physical
+  no_log: "{{ disable_logging }}"
+  when: barman_backup_method == 'postgres'
+
+- name: Ensure WAL archiving is configured
+  include_role:
+    name: manage_dbserver
+    tasks_from: manage_postgres_params
+  vars:
+    pg_postgres_conf_params:
+      - name: archive_mode
+        value: "on"
+      - name: archive_command
+        value: "barman-wal-archive {{ hostvars[ansible_hostname].barman_server_private_ip }} {{ ansible_hostname }} %p"
+  no_log: "{{ disable_logging }}"
+  when: barman_backup_method == 'rsync'

--- a/roles/setup_barman/tasks/create_pg_user.yml
+++ b/roles/setup_barman/tasks/create_pg_user.yml
@@ -1,0 +1,36 @@
+---
+
+- name: Initialize _role_attr_flags
+  set_fact:
+    _role_attr_flags: "login,replication"
+
+- name: Create barman user on the Postgres instance
+  include_role:
+    name: manage_dbserver
+    tasks_from: manage_users
+  vars:
+    pg_users:
+      - name: "{{ barman_pg_user }}"
+        pass: "{{ barman_pg_password }}"
+        role_attr_flags: "{{ _role_attr_flags }}"
+
+- name: Ensure privileges for the barman user
+  include_role:
+    name: manage_dbserver
+    tasks_from: manage_privileges
+  vars:
+    pg_grant_privileges:
+      - roles: "{{ barman_pg_user }}"
+        database: postgres
+        privileges: execute
+        schema: pg_catalog
+        objects: >-
+          pg_start_backup(text:boolean:boolean),pg_stop_backup(),pg_stop_backup(boolean:boolean),pg_switch_wal(),pg_create_restore_point(text)
+        type: function
+    pg_grant_roles:
+      - role: pg_read_all_settings
+        user: "{{ barman_pg_user }}"
+        db: postgres
+      - role: pg_read_all_stats
+        user: "{{ barman_pg_user }}"
+        db: postgres

--- a/roles/setup_barman/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_barman/tasks/exchange_ssh_keys.yml
@@ -1,0 +1,96 @@
+---
+
+- name: Get Barman server informations
+  set_fact:
+    _barman_server_info: "{{ lookup('barman_server', wantlist=True) }}"
+
+- name: Fail if barman server informations are not found
+  fail:
+    msg: "Unable to find barman server informations"
+  when:
+    - _barman_server_info|length == 0
+
+- name: Set _barman_server_public_ip
+  set_fact:
+    _barman_server_public_ip: "{{ _barman_server_info[0].ansible_host }}"
+
+- name: Fetch barman server SSH public key
+  slurp:
+    src: "{{ barman_home + '/.ssh/id_rsa.pub' }}"
+  delegate_to: "{{ _barman_server_public_ip }}"
+  register: _barman_server_ssh_public_key_b64
+  become: yes
+
+- name: Set _barman_server_ssh_public_key
+  set_fact:
+      _barman_server_ssh_public_key: "{{ _barman_server_ssh_public_key_b64.content | b64decode | trim }}"
+
+- name: Fetch {{ pg_owner }} SSH public key
+  slurp:
+    src: "{{ pg_user_home + '/.ssh/id_rsa.pub' }}"
+  register: _pg_ssh_public_key_b64
+  become: yes
+
+- name: Set _pg_ssh_public_key
+  set_fact:
+      _pg_ssh_public_key: "{{ _pg_ssh_public_key_b64.content | b64decode | trim }}"
+
+- name: Ensure {{ pg_owner }} SSH public key is on the barman server
+  lineinfile:
+    path: "{{ barman_home + '/.ssh/authorized_keys' }}"
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    mode: 0600
+    line: "{{ _pg_ssh_public_key }}"
+    create: yes
+  delegate_to: "{{ _barman_server_public_ip }}"
+  become: yes
+
+- name: Ensure {{ barman_user }} SSH public key is on the Postgres server
+  lineinfile:
+    path: "{{ pg_user_home + '/.ssh/authorized_keys' }}"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: 0600
+    line: "{{ _barman_server_ssh_public_key }}"
+    create: yes
+
+- name: Run ssh-keyscan from the Barman server
+  command: ssh-keyscan {{ hostvars[ansible_hostname].private_ip }}
+  register: _barman_ssh_keyscan_output
+  delegate_to: "{{ _barman_server_public_ip }}"
+  become: yes
+  changed_when: false
+
+- name: Add {{ pg_owner }} SSH public key into barman server known hosts
+  known_hosts:
+    path: "{{ barman_home + '/.ssh/known_hosts' }}"
+    name: "{{ hostvars[ansible_hostname].private_ip }}"
+    key: "{{ _item }}"
+  with_items: "{{ _barman_ssh_keyscan_output.stdout_lines }}"
+  loop_control:
+    loop_var: _item
+  delegate_to: "{{ _barman_server_public_ip }}"
+  become: yes
+  no_log: "{{ disable_logging }}"
+
+- name: Run ssh-keyscan from the Postgres server
+  command: ssh-keyscan {{ hostvars[ansible_hostname].barman_server_private_ip }}
+  register: _pg_ssh_keyscan_output
+  become: yes
+  changed_when: false
+
+- name: Add {{ barman_user }} SSH public key into Postgres server known hosts
+  known_hosts:
+    path: "{{ pg_user_home + '/.ssh/known_hosts' }}"
+    name: "{{ hostvars[ansible_hostname].barman_server_private_ip }}"
+    key: "{{ _item }}"
+  with_items: "{{ _pg_ssh_keyscan_output.stdout_lines }}"
+  loop_control:
+    loop_var: _item
+  become: yes
+  no_log: "{{ disable_logging }}"
+
+- name: Reset _barman_server_info
+  set_fact:
+    _barman_server_info: ""

--- a/roles/setup_barman/tasks/generate_pg_password.yml
+++ b/roles/setup_barman/tasks/generate_pg_password.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Build random password for {{ barman_pg_user }}
+  include_role:
+    name: manage_dbserver
+    tasks_from: generate_password
+  vars:
+    input_user: "{{ barman_pg_user }}"
+
+- name: Set barman_pg_password
+  set_fact:
+    barman_pg_password: "{{ input_password }}"

--- a/roles/setup_barman/tasks/generate_ssh_keys.yml
+++ b/roles/setup_barman/tasks/generate_ssh_keys.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Ensure the directory {{ pg_user_home }}/.ssh exists
+  file:
+    state: directory
+    path: "{{ pg_user_home }}/.ssh"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: 0700
+  become: true
+
+- name: Check if the SSH private key exists
+  stat:
+    path: "{{ pg_user_home }}/.ssh/id_rsa"
+  register: postgres_ssh_private_key
+  become: true
+
+- name: Ensure Postgres owner's SSH keys exist
+  openssh_keypair:
+    path: "{{ pg_user_home }}/.ssh/id_rsa"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+  when: not postgres_ssh_private_key.stat.exists
+  become: true

--- a/roles/setup_barman/tasks/main.yml
+++ b/roles/setup_barman/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+# Entry point of the setup_barman role
+- name: Include the setup_barman.yml
+  include_tasks: setup_barman.yml

--- a/roles/setup_barman/tasks/setup_barman.yml
+++ b/roles/setup_barman/tasks/setup_barman.yml
@@ -1,0 +1,58 @@
+---
+
+- name: Set the os variable
+  set_fact:
+    os: "{{ ansible_distribution | replace('RedHat', 'RHEL') }}{{ ansible_distribution_major_version }}"
+
+- name: Set barman_backup_method
+  set_fact:
+    barman_backup_method: "{{ hostvars[ansible_hostname].barman_backup_method | default('rsync') }}"
+
+- name: Check barman_backup_method value
+  fail:
+    msg: "Barman backup method {{ barman_backup_method }} not supported."
+  when: >
+    barman_backup_method not in ['postgres', 'rsync']
+
+- name: Check support for Operating System
+  fail:
+    msg: "Operating System = {{ os }} not supported."
+  when: os not in supported_os
+
+- name: Reference pg_type variables
+  include_vars: "{{ role_path }}/../init_dbserver/vars/{{ pg_type }}.yml"
+
+- name: Reference barman server variables
+  include_vars: "{{ role_path }}/../setup_barmanserver/defaults/main.yml"
+
+- name: Include the package installation tasks
+  include_role:
+    name: setup_barmanserver
+    tasks_from: install_packages
+
+- name: Include the password generation tasks
+  include_tasks: generate_pg_password.yml
+  when: barman_pg_password is not defined
+
+- name: Include the barman .pgpass file tasks
+  include_tasks: update_barman_pgpass.yml
+
+- name: Include the Postgres user creation tasks
+  include_tasks: create_pg_user.yml
+  when: >
+    'primary' in group_names
+
+- name: Include the HBA file update tasks
+  include_tasks: update_pg_hba.yml
+
+- name: Include the SSH keys generation tasks
+  include_tasks: generate_ssh_keys.yml
+
+- name: Include the SSH keys exchange tasks
+  include_tasks: exchange_ssh_keys.yml
+
+- name: Include the barman configuration tasks
+  include_tasks: configure_barman.yml
+
+- name: Include the Postgres configuration tasks for backup
+  include_tasks: configure_pg_backup.yml

--- a/roles/setup_barman/tasks/update_barman_pgpass.yml
+++ b/roles/setup_barman/tasks/update_barman_pgpass.yml
@@ -1,0 +1,31 @@
+---
+
+- name: Get Barman server informations
+  set_fact:
+    _barman_server_info: "{{ lookup('barman_server', wantlist=True) }}"
+
+- name: Fail if barman server informations are not found
+  fail:
+    msg: "Unable to find barman server informations"
+  when:
+    - _barman_server_info|length == 0
+
+- name: Set _barman_server_public_ip
+  set_fact:
+    _barman_server_public_ip: "{{ _barman_server_info[0].ansible_host }}"
+
+- name: Ensure barman .pgpass file contains one entry for {{ ansible_host }}
+  lineinfile:
+    path: "{{ barman_home + '/.pgpass' }}"
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    mode: 0600
+    line: "{{ hostvars[ansible_hostname].private_ip }}:{{ pg_port }}:*:{{ barman_pg_user }}:{{ barman_pg_password }}"
+    regexp: "^{{ hostvars[ansible_hostname].private_ip | regex_escape() }}:{{ pg_port }}:\\*:{{ barman_pg_user | regex_escape() }}:.*"
+    create: yes
+  delegate_to: "{{ _barman_server_public_ip }}"
+  become: yes
+
+- name: Reset _barman_server_info
+  set_fact:
+    _barman_server_info: ""

--- a/roles/setup_barman/tasks/update_pg_hba.yml
+++ b/roles/setup_barman/tasks/update_pg_hba.yml
@@ -1,0 +1,39 @@
+---
+
+- name: Initialize the hba_entries variable
+  set_fact:
+    hba_entries: >-
+      [
+        {
+          'users': 'barman',
+          'databases': 'postgres',
+          'contype': 'hostssl',
+          'source': '{{ hostvars[ansible_hostname].barman_server_private_ip | default("127.0.0.1") }}/32'
+        }
+      ]
+
+- name: Add HBA rule for barman replication
+  set_fact:
+    hba_entries: >-
+      {{ hba_entries }} + [
+        {
+          'users': 'barman',
+          'databases': 'replication',
+          'contype': 'hostssl',
+          'source': '{{ hostvars[ansible_hostname].barman_server_private_ip }}/32'
+        }
+      ]
+  when:
+    - hostvars[ansible_hostname].barman_server_private_ip is defined
+    - barman_backup_method == 'postgres'
+
+- name: Allow access from the barman server
+  include_role:
+    name: manage_dbserver
+    tasks_from: manage_hba_conf
+  vars:
+    pg_hba_ip_addresses: "{{ hba_entries }}"
+
+- name: Reset hba_entries
+  set_fact:
+    hba_entries: []

--- a/roles/setup_barman/templates/barman.postgres.template
+++ b/roles/setup_barman/templates/barman.postgres.template
@@ -1,0 +1,10 @@
+[{{ ansible_hostname }}]
+path_prefix = "{{ pg_bin_path }}"
+description =  "{{ ansible_hostname }}"
+conninfo = host={{ hostvars[ansible_hostname].private_ip }} user={{ barman_pg_user }} dbname=postgres port={{ pg_port }}
+streaming_conninfo = host={{ hostvars[ansible_hostname].private_ip  }}  user={{ barman_pg_user }} port={{ pg_port }}
+backup_method = postgres
+streaming_archiver = on
+slot_name = barman
+backup_options = concurrent_backup
+immediate_checkpoint = true

--- a/roles/setup_barman/templates/barman.rsync.template
+++ b/roles/setup_barman/templates/barman.rsync.template
@@ -1,0 +1,11 @@
+[{{ ansible_hostname }}]
+path_prefix = "{{ pg_bin_path }}"
+description =  "{{ ansible_hostname }}"
+conninfo = host={{ hostvars[ansible_hostname].private_ip }} user={{ barman_pg_user }} dbname=postgres port={{ pg_port }}
+ssh_command = ssh {{ pg_owner }}@{{ hostvars[ansible_hostname].private_ip }}
+backup_method = rsync
+parallel_jobs = 1
+reuse_backup = link
+archiver = on
+backup_options = concurrent_backup
+immediate_checkpoint = true

--- a/roles/setup_barmanserver/README.md
+++ b/roles/setup_barmanserver/README.md
@@ -1,0 +1,182 @@
+# setup_barmanserver
+
+This role is for setting up Barman server. Barman is a backup and recovery tool
+for Postgres.
+
+## Requirements
+
+Following are the requirements of this role.
+  1. Ansible
+  2. `edb_devops.postgres` -> `setup_repo` role for setting the repository on
+     the systems.
+
+## Role Variables
+
+When executing the role via ansible these are the required variables:
+
+  * ***pg_version***
+
+  Postgres Versions supported are: 10, 11, 12 and 13
+
+  * ***pg_type***
+
+  Database Engine supported are: PG and EPAS
+
+These and other variables can be assigned in the `pre_tasks` definition of the
+section: *How to include the `setup_barmanserver` role in your Playbook*
+
+The rest of the variables can be configured and are available in the:
+
+  * [roles/setup_barmanserver/defaults/main.yml](./defaults/main.yml)
+
+Below is the documentation of the rest of the main variables:
+
+### `barman_user`
+
+System user running barman commands. Default: `barman`
+
+Example:
+```yaml
+barman_user: 'barman'
+```
+
+### `barman_group`
+
+System group the barman user is part of. Default: `barman`
+
+Example:
+```yaml
+barman_group: 'barman'
+```
+
+### `barman_configuration_file`
+
+Barman main configuration file path. Default: `/etc/barman.conf`
+
+Example:
+```yaml
+barman_configuration_file: '/etc/barman.conf'
+```
+
+### `barman_configuration_files_directory`
+
+Directory containing the included barman configuration files.
+Default: `/etc/barman.d`
+
+Example:
+```yaml
+barman_configuration_files_directory: '/etc/barman.d'
+```
+
+### `barman_home`
+
+Path of the barman home directory. Backup files and archived WAL files are
+stored in this root directory. Default: `/var/lib/barman`
+
+Example:
+```yaml
+barman_home: '/var/lib/barman'
+```
+
+### `barman_lock_directory`
+
+Path of the barman execution directory. Default: `/var/run/barman`
+
+Example:
+```yaml
+barman_lock_directory: '/var/run/barman'
+```
+
+### `barman_log_file`
+
+Barman logging file path. Default: `/var/log/barman/barman.log`
+
+Example:
+```yaml
+barman_log_file: '/var/log/barman/barman.log'
+```
+
+### `barman_log_level`
+
+Logging level. Default: `INFO`
+
+Example:
+```yaml
+barman_log_level: 'INFO'
+```
+
+### `barman_compression`
+
+Compression tool to use for backups and archived WAL files. Default: `gzip`
+
+Example:
+```yaml
+barman_compression: 'gzip'
+```
+
+## Dependencies
+
+This role does not have any dependencies, but packages repositories should have
+been configured beforehand with the `setup_repo` role.
+
+## Example Playbook
+
+### Inventory file content
+
+Content of the `inventory.yml` file:
+
+```yaml
+---
+all:
+  children:
+    barmanserver:
+      hosts:
+        barman1:
+          ansible_host: xxx.xxx.xxx.xxx
+          private_ip: xxx.xxx.xxx.xxx
+```
+
+### How to include the `setup_barmanserver` role in your Playbook
+
+Below is an example of how to include the `setup_barmanserver` role:
+```yaml
+---
+- hosts: barmanserver
+  name: Deploy Barman Servers
+  become: yes
+  gather_facts: yes
+
+  # When using collections
+  #collections:
+  #  - edb_devops.edb_postgres
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        pg_version: 13
+        pg_type: "PG"
+
+  roles:
+    # Install Postgres binaries required for Barman
+    - install_dbserver
+    - setup_barmanserver
+```
+
+Defining and adding variables is done in the `set_fact` of the `pre_tasks`.
+
+All the variables are available at:
+
+  * [roles/setup_barmanserver/defaults/main.yml](./defaults/main.yml)
+
+## License
+
+BSD
+
+## Author information
+
+Author:
+
+  * Julien Tachoires
+  * Vibhor Kumar (Reviewer)
+  * EDB Postgres
+  * julien.tachoires@enterprisedb.com www.enterprisedb.com

--- a/roles/setup_barmanserver/defaults/main.yml
+++ b/roles/setup_barmanserver/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+
+barman_package: "barman-2.12-1"
+barman_cli_package: "barman-cli-2.12-1"
+
+barman_user: "barman"
+barman_group: "barman"
+barman_configuration_file: "/etc/barman.conf"
+barman_configuration_files_directory: "/etc/barman.d"
+barman_home: "/var/lib/barman"
+barman_lock_directory: "/var/run/barman"
+barman_log_file: "/var/log/barman/barman.log"
+barman_log_level: "INFO"
+barman_compression: "gzip"
+
+supported_os:
+  - CentOS7
+  - CentOS8
+  - RHEL7
+  - RHEL8

--- a/roles/setup_barmanserver/tasks/create_directories.yml
+++ b/roles/setup_barmanserver/tasks/create_directories.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Ensure logging directory {{ barman_home }} exists
+  file:
+    path: "{{ barman_log_file | dirname }}"
+    state: directory
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    mode: 0755
+  become: yes
+
+- name: Ensure running directory {{ barman_lock_directory }} exists
+  file:
+    path: "{{ barman_lock_directory }}"
+    state: directory
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    mode: 0750
+  become: yes
+
+- name: Ensure configuration files directory {{ barman_configuration_files_directory }} exists
+  file:
+    path: "{{ barman_configuration_files_directory }}"
+    state: directory
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    mode: 0750
+  become: yes

--- a/roles/setup_barmanserver/tasks/create_user.yml
+++ b/roles/setup_barmanserver/tasks/create_user.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Ensure barman system group {{ barman_group }} exists
+  group:
+    name: "{{ barman_group }}"
+    state: present
+  become: yes
+
+- name: Ensure barman system user {{ barman_user }} exists
+  user:
+    name: "{{ barman_user }}"
+    system: true
+    group: "{{ barman_group }}"
+    state: present
+    create_home: true
+    home: "{{ barman_home }}"
+  become: yes

--- a/roles/setup_barmanserver/tasks/generate_configuration.yml
+++ b/roles/setup_barmanserver/tasks/generate_configuration.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Build configuration file {{ barman_configuration_file }}
+  template:
+    src: "./templates/barman.conf.template"
+    dest: "{{ barman_configuration_file }}"
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    mode: 0600
+  become: true

--- a/roles/setup_barmanserver/tasks/generate_ssh_keys.yml
+++ b/roles/setup_barmanserver/tasks/generate_ssh_keys.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Ensure the directory {{ barman_home }}/.ssh exists
+  file:
+    state: directory
+    path: "{{ barman_home }}/.ssh"
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    mode: 0700
+  become: true
+
+- name: Check if the SSH private key exists
+  stat:
+    path: "{{ barman_home }}/.ssh/id_rsa"
+  register: barman_ssh_private_key
+  become: true
+
+- name: Ensure barman user's SSH keys exist
+  openssh_keypair:
+    path: "{{ barman_home }}/.ssh/id_rsa"
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+  when: not barman_ssh_private_key.stat.exists
+  become: true

--- a/roles/setup_barmanserver/tasks/install_packages.yml
+++ b/roles/setup_barmanserver/tasks/install_packages.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Set package names for CentOS/RHEL
+  set_fact:
+    _barman_package: >-
+      {{ barman_package }}.*el{{ os[-1:] }}
+    _barman_cli_package: >-
+      {{ barman_cli_package }}.*el{{ os[-1:] }}
+  when: os is search("(CentOS|RHEL)")
+
+- name: Install Barman packages for CentOS/RHEL 8
+  dnf:
+    name:
+      - "{{ _barman_package }}"
+      - "{{ _barman_cli_package }}"
+    state: present
+  when: os in ['CentOS8', 'RHEL8']
+  become: yes
+
+- name: Install Barman packages for CentOS/RHEL 7
+  yum:
+    name:
+      - "{{ _barman_package }}"
+      - "{{ _barman_cli_package }}"
+    state: present
+  when: os in ['CentOS7', 'RHEL7']
+  become: yes

--- a/roles/setup_barmanserver/tasks/main.yml
+++ b/roles/setup_barmanserver/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+# Entry point of the setup_barmanserver role
+- name: Include the setup_barmanserver.yml
+  include_tasks: setup_barmanserver.yml

--- a/roles/setup_barmanserver/tasks/setup_barmanserver.yml
+++ b/roles/setup_barmanserver/tasks/setup_barmanserver.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Set the os variable
+  set_fact:
+    os: "{{ ansible_distribution | replace('RedHat', 'RHEL') }}{{ ansible_distribution_major_version }}"
+
+- name: Check support for Operating System
+  fail:
+    msg: "Operating System = {{ os }} not supported."
+  when: os not in supported_os
+
+- name: Include the package installation tasks
+  include_tasks: install_packages.yml
+
+- name: Include the user ans group creation tasks
+  include_tasks: create_user.yml
+
+- name: Include the directories creation tasks
+  include_tasks: create_directories.yml
+
+- name: Include the configuration file generation tasks
+  include_tasks: generate_configuration.yml
+
+- name: Include the SSH keys generation tasks
+  include_tasks: generate_ssh_keys.yml

--- a/roles/setup_barmanserver/templates/barman.conf.template
+++ b/roles/setup_barmanserver/templates/barman.conf.template
@@ -1,0 +1,94 @@
+; Barman, Backup and Recovery Manager for PostgreSQL
+; http://www.pgbarman.org/ - http://www.2ndQuadrant.com/
+;
+; Main configuration file
+
+[barman]
+; System user
+barman_user = {{ barman_user }}
+
+; Directory of configuration files. Place your sections in separate files with .conf extension
+; For example place the 'main' server section in /etc/barman.d/main.conf
+configuration_files_directory = {{ barman_configuration_files_directory }}
+
+; Main directory
+barman_home = {{ barman_home }}
+
+; Locks directory - default: %(barman_home)s
+barman_lock_directory = {{ barman_lock_directory }}
+
+; Log location
+log_file = {{ barman_log_file }}
+
+; Log level (see https://docs.python.org/3/library/logging.html#levels)
+log_level = {{ barman_log_level }}
+
+; Default compression level: possible values are None (default), bzip2, gzip, pigz, pygzip or pybzip2
+compression = {{ barman_compression }}
+
+; Pre/post backup hook scripts
+;pre_backup_script = env | grep ^BARMAN
+;pre_backup_retry_script = env | grep ^BARMAN
+;post_backup_retry_script = env | grep ^BARMAN
+;post_backup_script = env | grep ^BARMAN
+
+; Pre/post archive hook scripts
+;pre_archive_script = env | grep ^BARMAN
+;pre_archive_retry_script = env | grep ^BARMAN
+;post_archive_retry_script = env | grep ^BARMAN
+;post_archive_script = env | grep ^BARMAN
+
+; Pre/post delete scripts
+;pre_delete_script = env | grep ^BARMAN
+;pre_delete_retry_script = env | grep ^BARMAN
+;post_delete_retry_script = env | grep ^BARMAN
+;post_delete_script = env | grep ^BARMAN
+
+; Pre/post wal delete scripts
+;pre_wal_delete_script = env | grep ^BARMAN
+;pre_wal_delete_retry_script = env | grep ^BARMAN
+;post_wal_delete_retry_script = env | grep ^BARMAN
+;post_wal_delete_script = env | grep ^BARMAN
+
+; Global bandwidth limit in KBPS - default 0 (meaning no limit)
+;bandwidth_limit = 4000
+
+; Number of parallel jobs for backup and recovery via rsync (default 1)
+;parallel_jobs = 1
+
+; Immediate checkpoint for backup command - default false
+;immediate_checkpoint = false
+
+; Enable network compression for data transfers - default false
+;network_compression = false
+
+; Number of retries of data copy during base backup after an error - default 0
+;basebackup_retry_times = 0
+
+; Number of seconds of wait after a failed copy, before retrying - default 30
+;basebackup_retry_sleep = 30
+
+; Maximum execution time, in seconds, per server
+; for a barman check command - default 30
+;check_timeout = 30
+
+; Time frame that must contain the latest backup date.
+; If the latest backup is older than the time frame, barman check
+; command will report an error to the user.
+; If empty, the latest backup is always considered valid.
+; Syntax for this option is: "i (DAYS | WEEKS | MONTHS)" where i is an
+; integer > 0 which identifies the number of days | weeks | months of
+; validity of the latest backup for this check. Also known as 'smelly backup'.
+;last_backup_maximum_age =
+
+; Minimum number of required backups (redundancy)
+;minimum_redundancy = 1
+
+; Global retention policy (REDUNDANCY or RECOVERY WINDOW)
+; Examples of retention policies
+; Retention policy (disabled, default)
+;retention_policy =
+; Retention policy (based on redundancy)
+;retention_policy = REDUNDANCY 2
+; Retention policy (based on recovery window)
+;retention_policy = RECOVERY WINDOW OF 4 WEEKS

--- a/vars_plugins/host_supported_roles.py
+++ b/vars_plugins/host_supported_roles.py
@@ -45,6 +45,11 @@ GROUP_ROLES = {
         'setup_repo',
         'setup_pgpool2',
         'manage_pgpool2'
+    ],
+    'barmanserver': [
+        'setup_repo',
+        'setup_barmanserver',
+        'install_dbserver'
     ]
 }
 
@@ -86,6 +91,14 @@ class VarsModule(BaseVarsPlugin):
                     host_supported_roles = list(
                         set(host_supported_roles)
                         | set(['setup_pemagent'])
+                    )
+                # Special case for the pemserver, primary or standby nodes when
+                # the host variable barman is set to true.
+                if (group in ['pemserver', 'primary', 'standby']
+                        and host_vars.get('barman', False)):
+                    host_supported_roles = list(
+                        set(host_supported_roles)
+                        | set(['setup_barman'])
                     )
 
         data['host_supported_roles'] = host_supported_roles


### PR DESCRIPTION
This PR includes:
- new role for Barman server deployment: `setup_barmanserver`
- new role for configuring Barman on Postgres nodes: `setup_barman`

Local backups are not supported.
Remote backup methods supported are `postgres` and `rsync`.