### PR TITLE
Pass input_password to generate_password

### DIFF
--- a/roles/manage_dbserver/tasks/generate_password.yml
+++ b/roles/manage_dbserver/tasks/generate_password.yml
@@ -27,7 +27,7 @@
   no_log: "{{ disable_logging }}"
   delegate_to: localhost
 
-- name: Make sure file is has permission for owner only
+- name: Make sure file has permission for owner only
   file:
     path: "{{ passfile }}"
     mode: 0600

--- a/roles/setup_barman/tasks/generate_pg_password.yml
+++ b/roles/setup_barman/tasks/generate_pg_password.yml
@@ -6,6 +6,7 @@
     tasks_from: generate_password
   vars:
     input_user: "{{ barman_pg_user }}"
+    input_password: ""
 
 - name: Set barman_pg_password
   set_fact:


### PR DESCRIPTION
Because input_password cannot be reset, we must pass it with an empty
value if we want the password file being created.