### PR TITLE
Adapted db template reference to allow for value substituion

### DIFF
--- a/roles/manage_dbserver/tasks/manage_db.yml
+++ b/roles/manage_dbserver/tasks/manage_db.yml
@@ -18,7 +18,7 @@
     encoding: "{{ line_item.encoding | default(omit) }}"
     lc_collate: "{{ line_item.lc_collate | default(omit) }}"
     lc_ctype: "{{ line_item.lc_ctype | default(omit) }}"
-    template: "line_item.template | default('template0')"
+    template: "{{ line_item.template | default('template0') }}"
     port: "{{ pg_port }}"
     maintenance_db: "{{ pg_database }}"
     state: "{{ line_item.state | default('present') }}"


### PR DESCRIPTION
I tried to utilize the manage_dbserver role as follows in order to deploy a database:

    pg_databases:
    - name: dbnew
      owner: postgres
      encoding: UTF-8

Ansible failed with the following traceback:

    The full traceback is:
    Traceback (most recent call last):
    File "/tmp/ansible_postgresql_db_payload_8uxzwrrs/ansible_postgresql_db_payload.zip/ansible/modules/database/postgresql/postgresql_db.py", line 581, in main
    File "/tmp/ansible_postgresql_db_payload_8uxzwrrs/ansible_postgresql_db_payload.zip/ansible/modules/database/postgresql/postgresql_db.py", line 268, in db_create
    File "/tmp/ansible_postgresql_db_payload_8uxzwrrs/ansible_postgresql_db_payload.zip/ansible/module_utils/database.py", line 126, in pg_quote_identifier
    raise SQLParseError('PostgreSQL does not support %s with more than %i dots' % (id_type, _PG_IDENTIFIER_TO_DOT_LEVEL[id_type]))
    ansible.module_utils.database.SQLParseError: PostgreSQL does not support database with more than 1 dots
    failed: [primary1] (item={'name': 'dbnew', 'owner': 'postgres', 'encoding': 'UTF-8'}) => {
    "ansible_loop_var": "line_item",
    "changed": false,
    "invocation": {
        "module_args": {
            "ca_cert": null,
            "conn_limit": "",
            "db": "dbnew",
            "encoding": "UTF-8",
            "lc_collate": "",
            "lc_ctype": "",
            "login_host": "",
            "login_password": "",
            "login_unix_socket": "/var/run/postgresql",
            "login_user": "postgres",
            "maintenance_db": "postgres",
            "name": "dbnew",
            "owner": "postgres",
            "port": 5432,
            "session_role": null,
            "ssl_mode": "prefer",
            "state": "present",
            "tablespace": "",
            "target": "",
            "target_opts": "",
            "template": "line_item.template | default('template0')"
        }
    },
    "line_item": {
        "encoding": "UTF-8",
        "name": "dbnew",
        "owner": "postgres"
    },
    "msg": "PostgreSQL does not support database with more than 1 dots"
    }

It looked like the template value was not resolved 
`
"template": "line_item.template | default('template0')" 
`


After this replacement the db creation worked as expected.