### PR TITLE
Preserve ownership of known_hosts file by becoming postgres/barman user.

### DIFF
--- a/roles/setup_barman/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_barman/tasks/exchange_ssh_keys.yml
@@ -72,6 +72,7 @@
     loop_var: _item
   delegate_to: "{{ _barman_server_public_ip }}"
   become: yes
+  become_user: "{{ barman_user }}"
   no_log: "{{ disable_logging }}"
 
 - name: Run ssh-keyscan from the Postgres server
@@ -89,6 +90,7 @@
   loop_control:
     loop_var: _item
   become: yes
+  become_user: "{{ pg_owner }}"
   no_log: "{{ disable_logging }}"
 
 - name: Reset _barman_server_info


### PR DESCRIPTION
Dear EDB team!

Please review my pull request to preserve the ownership of the known_hosts files for the users postgres and barman when using the role setup_barman. Up to now, the ownership seems to get lost and will be root. This behaviour might be connected to Ticket [Ansible ticket #69231](https://github.com/ansible/ansible/pull/69231). I added to the Ansible tasks the parameter 'becoming_user' with the variables for either postgres or barman user.

Best regards,
Dirk