### PR TITLE
Fixes for efm pgpool integration and pgpool2 permissions

### DIFF
--- a/roles/setup_efm/templates/pcp_attach_all.sh.template
+++ b/roles/setup_efm/templates/pcp_attach_all.sh.template
@@ -4,6 +4,7 @@ export PGPOOL_PATH="{{ pgpool2_bin_path }}"
 export PCP_USER="{{ pcp_admin_user }}"
 export PCP_PORT="{{ pgpool2_pcp_port }}"
 export PGPORT="{{ pg_port }}"
+export PGDATABASE="{{ pg_database }}"
 
 declare -a POOLERS=(
 {% for item in pgpool2_nodes %}

--- a/roles/setup_efm/templates/pg_pcp_health.sh.template
+++ b/roles/setup_efm/templates/pg_pcp_health.sh.template
@@ -4,6 +4,7 @@ export PGPOOL_PATH="{{ pgpool2_bin_path }}"
 export PCP_USER="{{ pcp_admin_user }}"
 export PCP_PORT="{{ pgpool2_pcp_port }}"
 export PGPORT="{{ pg_port }}"
+export PGDATABASE="{{ pg_database }}"
 
 declare -a POOLERS=(
 {% for item in pgpool2_nodes %}

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_sr_mode.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_sr_mode.yml
@@ -27,6 +27,22 @@
     - pgpool2_primary_public_ip is defined
     - pgpool2_primary_public_ip|length > 0
 
+# grant monitoring privilege to pgpool2 user for replication status
+- name: Grant execute privileges on system functions to pgpoolII sr user
+  include_role:
+    name: manage_dbserver
+    tasks_from: manage_privileges
+    apply:
+      delegate_to: "{{ pgpool2_primary_public_ip }}"
+  vars:
+    pg_grant_roles:
+       - user: "{{ pgpool2_sr_check_user }}"
+         role: "pg_monitor"
+  run_once: true
+  when:
+    - pgpool2_primary_public_ip is defined
+    - pgpool2_primary_public_ip|length > 0
+
 - name: Build pgpoolII SR configuration
   set_fact:
     pgpool2_sr_configuration: >-


### PR DESCRIPTION
Due to missing PGDATABASE environment variablein the pcp_attach_all.sh and pg_pcp_health.sh scipts, pcp commands are logging the following message in postgres log:
efm@efm app=[unknown] FATAL:  no pg_hba.conf entry for host 'xxx.xxx.xxxx.xxx', user 'efm', database 'efm', SSL on 

This commit fixes that. 

Pgpool2 sr_user has missing permission. Added pg_monitor role to pgpool2 user