### PR TITLE
Fixes pg_sr_cluster_nodes lookup filter

### DIFF
--- a/plugins/lookup/pg_sr_cluster_nodes.py
+++ b/plugins/lookup/pg_sr_cluster_nodes.py
@@ -117,6 +117,19 @@ class LookupModule(LookupBase):
 
             pg_standbys_len = len(pg_standbys.keys())
 
-        if node_private_ip not in pg_primary_map:
-            return []
-        return pg_clusters[pg_primary_map[node_private_ip]]
+        if node_private_ip in pg_primary_map:
+            # Current node is part of one of the SR clusters found
+            return pg_clusters[pg_primary_map[node_private_ip]]
+        else:
+            primary_private_ips = pg_clusters.keys()
+            # If the current node is not part of any SR cluster found, but,
+            # only one SR cluster has been found, then we return this SR
+            # cluster because there is no doubt.
+            if len(primary_private_ips) == 1:
+                return pg_clusters[primary_private_ips[0]]]
+            else:
+                raise AnsibleError(
+                    "Unable to find the SR cluster topology because multiple "
+                    "SR clusters were found and this current node does not "
+                    "appear to be part of any of them"
+                )


### PR DESCRIPTION
Handle the case when the current node is not part of any SR cluster
found.