### PR TITLE
CentOS8/RHEL8 disable inbuilt PG module

### DIFF
--- a/roles/install_dbserver/tasks/PG_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_install.yml
@@ -1,7 +1,6 @@
 ---
 - name: Disable builtin postgresql module
   shell: >
-    # Disable the built-in PostgreSQL module:
     dnf -qy module disable postgresql
   args:
     executable: /bin/bash


### PR DESCRIPTION
Ansible combining the comment and command in shell module due to which in built postgresql module is not getting disabled. This commit fixes that