### PR TITLE
Fix pgpool2_nodes lookup filter

### DIFF
--- a/plugins/lookup/pgpool2_nodes.py
+++ b/plugins/lookup/pgpool2_nodes.py
@@ -37,7 +37,7 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
 
         nodes = []
-        if len(variables['groups']['pgpool2']) == 0:
+        if len(variables['groups'].get('pgpool2', [])) == 0:
             return []
 
         myvars = getattr(self._templar, '_available_variables', {})


### PR DESCRIPTION
Return an empty list even if there isn't any pgpool2 node defined
in the inventory.