### PR TITLE
Update requires_ansible to ">=2.10"

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: ">=2.10,<=2.11"
+requires_ansible: ">=2.10"


### PR DESCRIPTION
To avoid the following warning on 2.11+:
```
[WARNING]: Collection edb_devops.edb_postgres does not support Ansible version
```