### PR TITLE
Check `pg_type` on setup EPAS repo for RedHat

### DIFF
--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -61,6 +61,8 @@
     name: "{{ edb_rpm_repo }}"
     state: present
   become: yes
+  when:
+    - pg_type == 'EPAS'
 
 - name: Set Credentials for EDB Yum Repo
   replace:
@@ -68,3 +70,5 @@
     regexp: '<username>:<password>'
     replace: "{{ repo_username }}:{{ repo_password }}"
   become: yes
+  when:
+    - pg_type == 'EPAS'


### PR DESCRIPTION
Hi, Team,

When I run a playbook with `pg_type: "PG"` on RedHat-based OS, ansible execution failed at accessing EPAS repo.

So I add `pg_type == 'EPAS'` check for `Install EPAS repo for RedHat` and `Set Credentials for EDB Yum Repo` in `PG_RedHat_setuprepos.yml` file.

Best Regards.