### PR TITLE
Allow host connections to PEM instance

### DIFF
--- a/roles/setup_pemagent/tasks/pem_agent_hba.yml
+++ b/roles/setup_pemagent/tasks/pem_agent_hba.yml
@@ -20,6 +20,13 @@
            "databases": "pem",
            "method": "scram-sha-256"
            },
+          {
+           "users": "{{ pg_pem_admin_user }}",
+           "source": "{{ node_hostvars.private_ip }}/32",
+           "databases": "pem",
+           "method": "scram-sha-256",
+           "contype": "host"
+           },
       ]
 
 - name: Update PEM server to allow connections from the agent
@@ -56,4 +63,3 @@
     tasks_from: manage_hba_conf
   vars:
     pg_hba_ip_addresses: "{{ pem_agent_hba_local_entry }}"
-


### PR DESCRIPTION
As a fallback method to avoid failure due to random SSL error when
registering PEM agents.