### PR TITLE
Allow to install and setup replication without using replication slots

### DIFF
--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -11,6 +11,7 @@ efm_cluster_name: "efm"
 efm_service: "edb-{{ efm_cluster_name }}-{{ efm_version }}"
 
 disable_logging: yes
+use_replication_slots: true
 use_hostname: true
 
 pass_dir: "~/.edb"

--- a/roles/init_dbserver/tasks/pg_set_superuser_password.yml
+++ b/roles/init_dbserver/tasks/pg_set_superuser_password.yml
@@ -35,4 +35,5 @@
           value: "{{ inventory_hostname | regex_replace('[^a-zA-Z0-9_]', '_') }}"
   when:
     - pg_version|int > 11
+    - use_replication_slots
   no_log: "{{ disable_logging }}"

--- a/roles/setup_replication/defaults/main.yml
+++ b/roles/setup_replication/defaults/main.yml
@@ -7,6 +7,7 @@ pg_version: "13"
 dsable_logging: yes
 
 force_replication: false
+use_replication_slots: true
 use_hostname: true
 
 # EFM service information

--- a/roles/setup_replication/tasks/pg_basebackup.yml
+++ b/roles/setup_replication/tasks/pg_basebackup.yml
@@ -11,6 +11,7 @@
 - name: Add slot_name in pg_basebackup
   set_fact:
     pg_basebackup: "{{ pg_basebackup + ' --slot=' }}{{ inventory_hostname | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+  when: use_replication_slots
 
 - name: Set replication user information
   set_fact:

--- a/roles/setup_replication/tasks/upstream_node_slots.yml
+++ b/roles/setup_replication/tasks/upstream_node_slots.yml
@@ -29,3 +29,4 @@
        - name: "{{ inventory_hostname | regex_replace('[^a-zA-Z0-9_]', '_') }}"
          slot_type: physical
   no_log: "{{ disable_logging }}"
+  when: use_replication_slots


### PR DESCRIPTION
Hi,

It's not always convenient to use replication slots when you already have archive/restore_command configured and using a dedicated backup tool (barman, pgbackrest,...).

Adding a `use_replication_slots` (default true, so no behavior change to be expected) option seems a fair and quick way to achieve this, for at least `init_dbserver` and `setup_replication` roles.

Thanks in advance for your review.
Kind Regards,
Stefan