### PR TITLE
Debian fix setup_replication and manage_dbserver

### DIFF
--- a/roles/manage_dbserver/vars/EPAS_Debian.yml
+++ b/roles/manage_dbserver/vars/EPAS_Debian.yml
@@ -2,6 +2,7 @@
 # Variables for EPAS
 pg_port: "5444"
 pg_owner: "enterprisedb"
+pg_user_home: "/var/lib/edb-as"
 pg_service: "edb-as@{{ pg_version }}-{{ pg_instance_name }}"
 pg_database: "postgres"
 pg_unix_socket_directories:
@@ -13,7 +14,7 @@ pg_extensions:
     - { "name": "pg_stat_statements", "database": "edb" }
     - { "name": "pg_stat_statements", "database": "postgres" }
 
-shell_profile_path: "/var/lib/edb/.enterprisedb_profile"
+shell_profile_path: "{{ pg_user_home }}/.enterprisedb_profile"
 shell_profile_owner: "enterprisedb"
 shell_profile_group: "enterprisedb"
 shell_profile_mode: "0600"
@@ -26,12 +27,11 @@ shell_profile_content: |
   export PGLOCALEDIR=/usr/lib/edb-as/{{ pg_version }}/share/locale
   export PGHOST={{ pg_unix_socket_directories[0] }}
 
-psqlrc_path: "/var/lib/edb/.psqlrc"
+psqlrc_path: "{{ pg_user_home }}/.psqlrc"
 psqlrc_owner: "enterprisedb"
 psqlrc_group: "enterprisedb"
 psqlrc_mode: "0600"
 psqlrc_content: |
   -- psql configuration
 
-pg_user_home: "/var/lib/edb-as"
-pg_data: "/var/lib/edb-as/{{ pg_version }}/{{ pg_instance_name }}"
+pg_data: "{{ pg_user_home }}/{{ pg_version }}/{{ pg_instance_name }}"

--- a/roles/manage_dbserver/vars/EPAS_Debian.yml
+++ b/roles/manage_dbserver/vars/EPAS_Debian.yml
@@ -34,4 +34,4 @@ psqlrc_content: |
   -- psql configuration
 
 pg_user_home: "/var/lib/edb-as"
-pg_data: "/var/lib/edb-as/{{ pg_version }}/{{ deb_cluster_name }}"
+pg_data: "/var/lib/edb-as/{{ pg_version }}/{{ pg_instance_name }}"

--- a/roles/manage_dbserver/vars/EPAS_RedHat.yml
+++ b/roles/manage_dbserver/vars/EPAS_RedHat.yml
@@ -2,6 +2,7 @@
 # Variables for EPAS
 pg_port: "5444"
 pg_owner: "enterprisedb"
+pg_user_home: "/var/lib/edb"
 pg_service: "{{ lookup('edb_devops.edb_postgres.pg_service') }}"
 pg_database: "postgres"
 pg_unix_socket_directories:
@@ -13,7 +14,7 @@ pg_extensions:
     - { "name": "pg_stat_statements", "database": "edb" }
     - { "name": "pg_stat_statements", "database": "postgres" }
 
-shell_profile_path: "/var/lib/edb/.enterprisedb_profile"
+shell_profile_path: "{{ pg_user_home }}/.enterprisedb_profile"
 shell_profile_owner: "enterprisedb"
 shell_profile_group: "enterprisedb"
 shell_profile_mode: "0600"
@@ -26,12 +27,11 @@ shell_profile_content: |
   export PGLOCALEDIR=/usr/edb/as{{ pg_version }}/share/locale
   export PGHOST={{ pg_unix_socket_directories[0] }}
 
-psqlrc_path: "/var/lib/edb/.psqlrc"
+psqlrc_path: "{{ pg_user_home }}/.psqlrc"
 psqlrc_owner: "enterprisedb"
 psqlrc_group: "enterprisedb"
 psqlrc_mode: "0600"
 psqlrc_content: |
   -- psql configuration
 
-pg_user_home: "/var/lib/edb"
-pg_data: "/var/lib/edb/as{{ pg_version }}/data"
+pg_data: "{{ pg_user_home }}/as{{ pg_version }}/data"

--- a/roles/manage_dbserver/vars/PG_Debian.yml
+++ b/roles/manage_dbserver/vars/PG_Debian.yml
@@ -2,12 +2,13 @@
 # Variables for EPAS
 pg_port: "5432"
 pg_owner: "postgres"
+pg_user_home: "/var/lib/postgresql"
 pg_service: "postgresql@{{ pg_version }}-{{ pg_instance_name }}"
 pg_database: "postgres"
 pg_unix_socket_directories:
   - "/var/run/postgresql"
 
-shell_profile_path: "/var/lib/pgsql/.pgsql_profile"
+shell_profile_path: "{{ pg_user_home }}/.pgsql_profile"
 shell_profile_owner: "postgres"
 shell_profile_group: "postgres"
 shell_profile_mode: "0600"
@@ -20,12 +21,11 @@ shell_profile_content: |
   export PGLOCALEDIR=/usr/lib/postgresql/{{ pg_version }}/share/locale
   export PGHOST={{ pg_unix_socket_directories[0] }}
 
-psqlrc_path: "/var/lib/pgsql/.psqlrc"
+psqlrc_path: "{{ pg_user_home }}/.psqlrc"
 psqlrc_owner: "postgres"
 psqlrc_group: "postgres"
 psqlrc_mode: "0600"
 psqlrc_content: |
   -- psql configuration
 
-pg_user_home: "/var/lib/postgresql"
-pg_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"
+pg_data: "{{ pg_user_home }}/{{ pg_version }}/{{ pg_instance_name }}"

--- a/roles/manage_dbserver/vars/PG_Debian.yml
+++ b/roles/manage_dbserver/vars/PG_Debian.yml
@@ -28,4 +28,4 @@ psqlrc_content: |
   -- psql configuration
 
 pg_user_home: "/var/lib/postgresql"
-pg_data: "/var/lib/postgresql/{{ pg_version }}/{{ deb_cluster_name }}"
+pg_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"

--- a/roles/manage_dbserver/vars/PG_RedHat.yml
+++ b/roles/manage_dbserver/vars/PG_RedHat.yml
@@ -2,12 +2,13 @@
 # Variables for EPAS
 pg_port: "5432"
 pg_owner: "postgres"
+pg_user_home: "/var/lib/pgsql"
 pg_service: "{{ lookup('edb_devops.edb_postgres.pg_service') }}"
 pg_database: "postgres"
 pg_unix_socket_directories:
   - "/var/run/postgresql"
 
-shell_profile_path: "/var/lib/pgsql/.pgsql_profile"
+shell_profile_path: "{{ pg_user_home }}/.pgsql_profile"
 shell_profile_owner: "postgres"
 shell_profile_group: "postgres"
 shell_profile_mode: "0600"
@@ -20,12 +21,11 @@ shell_profile_content: |
   export PGLOCALEDIR=/usr/pgsql-{{ pg_version }}/share/locale
   export PGHOST={{ pg_unix_socket_directories[0] }}
 
-psqlrc_path: "/var/lib/pgsql/.psqlrc"
+psqlrc_path: "{{ pg_user_home }}/.psqlrc"
 psqlrc_owner: "postgres"
 psqlrc_group: "postgres"
 psqlrc_mode: "0600"
 psqlrc_content: |
   -- psql configuration
 
-pg_user_home: "/var/lib/pgsql"
-pg_data: "/var/lib/pgsql/{{ pg_version }}/data"
+pg_data: "{{ pg_user_home }}/{{ pg_version }}/data"

--- a/roles/setup_replication/tasks/rm_replication.yml
+++ b/roles/setup_replication/tasks/rm_replication.yml
@@ -22,7 +22,7 @@
 
 - name: Drop the default debian database
   shell: >
-    {{ pg_deb_drop_cluster }} {{ pg_version }} {{ deb_cluster_name }}
+    {{ pg_deb_drop_cluster }} {{ pg_version }} {{ pg_instance_name }}
   args:
     executable: /bin/bash
   changed_when: drop_cluster.rc == 0


### PR DESCRIPTION
This fix some path issues for debian in `setup_replication` and `manage_dbserver`.
It also cleans up some multi-instance support left-overs.
