### PR TITLE
Barman fixes

### DIFF
--- a/roles/setup_barman/tasks/post_configure_barman.yml
+++ b/roles/setup_barman/tasks/post_configure_barman.yml
@@ -52,6 +52,8 @@
   delegate_to: "{{ _barman_server_public_ip }}"
   become: true
   become_user: barman
+  when:
+    - "'primary' in group_names"
 
 - name: Execute barman check
   ansible.builtin.command:
@@ -59,6 +61,8 @@
   delegate_to: "{{ _barman_server_public_ip }}"
   become: true
   become_user: barman
+  when:
+    - "'primary' in group_names"
 
 - name: Take a barman backup
   ansible.builtin.command:
@@ -66,3 +70,5 @@
   delegate_to: "{{ _barman_server_public_ip }}"
   become: true
   become_user: barman
+  when:
+    - "'primary' in group_names"

--- a/roles/setup_barman/tasks/update_barman_pgpass.yml
+++ b/roles/setup_barman/tasks/update_barman_pgpass.yml
@@ -36,6 +36,7 @@
     regexp: "^{{ _pg_host | regex_escape() }}:{{ pg_port }}:\\*:{{ barman_pg_user | regex_escape() }}:.*"
     create: yes
   delegate_to: "{{ _barman_server_public_ip }}"
+  throttle: 1
   become: yes
 
 - name: Reset _barman_server_info


### PR DESCRIPTION
Do not execute the backup and check commands on standbys. Standby
nodes must be configured and ready to be backuped in case of
switchover/failover but are not supposed to be backuped when they
still are in recovery mode.

Use throttle=1 when updating the .pgpass file on the barman server
to avoid race condition that can lead to missing entries when working
with multiple PG nodes.