### PR TITLE
Update EFM service name

### DIFF
--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -5,10 +5,12 @@ pg_type: PG
 pg_version: 12
 pg_ssl: true
 
+pg_instance_name: main
+
 # EFM service information
 efm_version: 4.2
-efm_cluster_name: "efm"
-efm_service: "edb-{{ efm_cluster_name }}-{{ efm_version }}"
+efm_cluster_name: "{{ pg_instance_name }}"
+efm_service: "edb-efm-{{ efm_cluster_name }}-{{ efm_version }}"
 
 disable_logging: yes
 use_replication_slots: true

--- a/roles/init_dbserver/vars/EPAS_Debian.yml
+++ b/roles/init_dbserver/vars/EPAS_Debian.yml
@@ -1,5 +1,4 @@
 ---
-pg_instance_name: "main"
 pg_wal: ""
 pg_data: "/var/lib/edb-as/{{ pg_version }}/{{ pg_instance_name }}"
 pg_default_data: "/var/lib/edb-as/{{ pg_version }}/{{ pg_instance_name }}"

--- a/roles/init_dbserver/vars/EPAS_RedHat.yml
+++ b/roles/init_dbserver/vars/EPAS_RedHat.yml
@@ -1,5 +1,4 @@
 ---
-pg_instance_name: "main"
 pg_wal: ""
 pg_data: "/var/lib/edb/as{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_default_data: "/var/lib/edb/as{{ pg_version }}/{{ pg_instance_name }}/data"

--- a/roles/init_dbserver/vars/PG_Debian.yml
+++ b/roles/init_dbserver/vars/PG_Debian.yml
@@ -1,5 +1,4 @@
 ---
-pg_instance_name: "main"
 pg_wal: ""
 pg_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"
 pg_default_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"

--- a/roles/init_dbserver/vars/PG_RedHat.yml
+++ b/roles/init_dbserver/vars/PG_RedHat.yml
@@ -1,5 +1,4 @@
 ---
-pg_instance_name: "main"
 pg_wal: ""
 pg_data: "/var/lib/pgsql/{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_default_data: "/var/lib/pgsql/{{ pg_version }}/{{ pg_instance_name }}/data"

--- a/roles/manage_dbserver/defaults/main.yml
+++ b/roles/manage_dbserver/defaults/main.yml
@@ -6,7 +6,7 @@ pg_type: "PG"
 
 efm_cluster_name: "{{ pg_instance_name }}"
 efm_version: 4.2
-efm_service: "edb-{{ efm_cluster_name }}-{{ efm_version }}"
+efm_service: "edb-efm-{{ efm_cluster_name }}-{{ efm_version }}"
 
 pass_dir: "~/.edb"
 passfile: ""

--- a/roles/setup_efm/defaults/main.yml
+++ b/roles/setup_efm/defaults/main.yml
@@ -16,7 +16,7 @@ pg_ssl: true
 
 efm_nodes_list: ""
 efm_cluster_name: "{{ pg_instance_name }}"
-efm_service: "edb-{{ efm_cluster_name }}-{{ efm_version }}"
+efm_service: "edb-efm-{{ efm_cluster_name }}-{{ efm_version }}"
 edb_efm_lock_file: "/var/lock/{{ efm_cluster_name }}-{{ efm_version }}/{{ efm_cluster_name }}.lock"
 # common variables require for the role
 etc_hosts_lists: []

--- a/roles/setup_replication/defaults/main.yml
+++ b/roles/setup_replication/defaults/main.yml
@@ -10,10 +10,12 @@ force_replication: false
 use_replication_slots: true
 use_hostname: true
 
+pg_instance_name: main
+
 # EFM service information
 efm_version: 4.2
-efm_cluster_name: "efm"
-efm_service: "edb-{{ efm_cluster_name }}-{{ efm_version }}"
+efm_cluster_name: "{{ pg_instance_name }}"
+efm_service: "edb-efm-{{ efm_cluster_name }}-{{ efm_version }}"
 
 synchronous_standby_names: ""
 synchronous_standbys: []

--- a/roles/setup_replication/vars/EPAS_Debian.yml
+++ b/roles/setup_replication/vars/EPAS_Debian.yml
@@ -1,5 +1,4 @@
 ---
-pg_instance_name: "main"
 pg_data: "/var/lib/edb-as/{{ pg_version }}/{{ pg_instance_name }}"
 pg_default_data: "/var/lib/edb-as/{{ pg_version }}/{{ pg_instance_name }}"
 pg_log: "/var/log/edb"
@@ -18,7 +17,7 @@ pg_replication_user_password: ""
 synchronous_standby_names: ""
 
 random_string: ""
-    
+
 pg_database: "postgres"
 pg_service: "edb-as@{{ pg_version }}-{{ pg_instance_name }}"
 

--- a/roles/setup_replication/vars/EPAS_RedHat.yml
+++ b/roles/setup_replication/vars/EPAS_RedHat.yml
@@ -1,5 +1,4 @@
 ---
-pg_instance_name: "main"
 pg_data: "/var/lib/edb/as{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_default_data: "/var/lib/edb/as{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_log: "/var/log/edb"
@@ -19,7 +18,7 @@ pg_replication_user_password: ""
 synchronous_standby_names: ""
 
 random_string: ""
-    
+
 pg_database: "edb"
 pg_service: "{{ lookup('edb_devops.edb_postgres.pg_service') }}"
 

--- a/roles/setup_replication/vars/PG_Debian.yml
+++ b/roles/setup_replication/vars/PG_Debian.yml
@@ -1,5 +1,4 @@
 ---
-pg_instance_name: "main"
 pg_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"
 pg_default_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"
 pg_log: "/var/log/postgres"
@@ -18,7 +17,7 @@ pg_replication_user_password: ""
 synchronous_standby_names: ""
 
 random_string: ""
-    
+
 pg_database: "postgres"
 pg_service: "postgresql@{{ pg_version }}-{{ pg_instance_name }}"
 

--- a/roles/setup_replication/vars/PG_RedHat.yml
+++ b/roles/setup_replication/vars/PG_RedHat.yml
@@ -1,5 +1,4 @@
 ---
-pg_instance_name: "main"
 pg_data: "/var/lib/pgsql/{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_default_data: "/var/lib/pgsql/{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_log: "/var/log/postgres"


### PR DESCRIPTION
From `edb-<cluster-name>-<efm-version>` to `edb-efm-<cluster-name>-<efm-version>`.

By default, the service name was: `edb-main-4.2`, which is not meaningful