### PR TITLE
Execute yum updateinfo -y

### DIFF
--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -80,3 +80,14 @@
   become: true
   loop: "{{ yum_additional_repos }}"
   when: yum_additional_repos | length > 0
+
+# This is needed for some fresh versions of CentOS8 where this issue is met:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1768206
+# Executing yum/dnf updateinfo -y makes the import of GPG keys effective even
+# if command's return is different from 0.
+- name: Execute yum updateinfo
+  ansible.builtin.shell: yum updateinfo -y
+  register: updateinfo_output
+  become: true
+  failed_when: false
+  changed_when: updateinfo_output.rc != 0


### PR DESCRIPTION
Executing this command makes the import of GPG keys effective for
all the following dnf/yum executions.

If we don't do that, import of the keys will be done later by
another dnf/yum command. This shouldn't be an issue, but for unknown
reason, when dnf/yum imports keys then it does only that, whatever
the command being executed.

More details here:
https://bugzilla.redhat.com/show_bug.cgi?id=1768206