### PR TITLE
Use default values in the pg_service lookup func.

### DIFF
--- a/plugins/lookup/pg_service.py
+++ b/plugins/lookup/pg_service.py
@@ -19,9 +19,9 @@ from ansible.plugins.lookup import LookupBase
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
 
-        pg_type = variables['pg_type']
-        pg_version = variables['pg_version']
-        pg_instance_name = variables['pg_instance_name']
+        pg_type = variables.get('pg_type', '13')
+        pg_version = variables.get('pg_version', 'PG')
+        pg_instance_name = variables.get('pg_instance_name', 'main')
 
         if pg_type == 'EPAS':
             p = 'edb-as-%s'


### PR DESCRIPTION
To cover the case where the variables a not defined by users and
are only defined in defaults/main.yml which makes them not
available in the lookup function.