### PR TITLE
Force the update of ca-certificates

### DIFF
--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -1,4 +1,10 @@
 ---
+- name: Update the ca-certificates package
+  ansible.builtin.yum:
+    name: ca-certificates
+    state: latest
+  become: true
+
 - name: Download EDB GPG key for RedhHat 8
   rpm_key:
     key: "{{ edb_gpg_key_8 }}"


### PR DESCRIPTION
Due to old version of this package, the installation of some of
the repositories could fail with the following error:

Failure downloading https://[...].rpm, Request failed: <urlopen
error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed
(_ssl.c:618)>

Issue reported by Stefan Fercot (@pgstef)