### PR TITLE
Use throttle=1 when updating the pg_hba.conf file

### DIFF
--- a/roles/manage_dbserver/tasks/manage_hba_conf.yml
+++ b/roles/manage_dbserver/tasks/manage_hba_conf.yml
@@ -30,6 +30,7 @@
       loop_var: line_item
   no_log: "{{ disable_logging }}"
   register: hba_update
+  throttle: 1
 
 - name: Reload the pg service
   systemd:


### PR DESCRIPTION
To avoid concurrency issue.