### PR TITLE
Repmgr support - part 1

### DIFF
--- a/plugins/lookup/repmgr_nodes.py
+++ b/plugins/lookup/repmgr_nodes.py
@@ -1,0 +1,187 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: repmgr_nodes
+    author: Julien Tachoires
+    short_description: Lookup for repmgr nodes
+    description:
+      - "Retrieves the repmgr nodes list, based on node's private IP"
+    options:
+      _terms:
+        description: The private IP of one member of the repmgr cluster.
+        required: False
+      default:
+        description: The private IP of the current node is used.
+"""
+
+EXAMPLES = """
+- name: Show all members of the repmgr cluster that the current node is part of
+  debug: msg="{{ lookup('repmgr_nodes') }}"
+
+- name: Show all members of the repmgr cluster that the {{ primary_private_ip }} is part of
+  debug: msg="{{ lookup('repmgr_nodes', primary_private_ip) }}"
+"""
+
+RETURN = """
+_value:
+  description:
+    - List of Postgres nodes
+  type: list
+  elements: dict
+"""
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+
+        repmgr_clusters = {}
+        repmgr_standbys = {}
+        repmgr_witnesses = {}
+        repmgr_primary_map = {}
+        node_id = {}
+
+        myvars = getattr(self._templar, '_available_variables', {})
+
+        # If no terms, we'll used the current private IP
+        if len(terms) == 0:
+            node_private_ip = myvars['hostvars'][variables['inventory_hostname']]['private_ip']  # noqa
+        else:
+            node_private_ip = terms[0]
+
+        # If no primary found in the inventory we return an empty list
+        if 'primary' not in variables['groups']:
+            return []
+
+        # Initiate repmgr_clusters and repmgr_primary_map for each primary node we have
+        # in the inventory.
+        for host in variables['groups']['primary']:
+            hostvars = myvars['hostvars'][host]
+            private_ip = hostvars['private_ip']
+
+            node_id[private_ip] = 1
+            repmgr_clusters[private_ip] = []
+            repmgr_clusters[private_ip].append(
+                dict(
+                    node_type='primary',
+                    id=node_id[private_ip],
+                    ansible_host=hostvars['ansible_host'],
+                    hostname=hostvars.get('hostname',
+                                          hostvars.get('ansible_hostname')),
+                    private_ip=hostvars['private_ip'],
+                    upstream_node_private_ip=None,
+                    replication_type=None,
+                    inventory_hostname=hostvars['inventory_hostname']
+                )
+            )
+            repmgr_primary_map[private_ip] = private_ip
+
+        # Populate repmgr_standbys dict if we have standby nodes in the inventory
+        if 'standby' in variables['groups']:
+            for host in variables['groups']['standby']:
+                hostvars = myvars['hostvars'][host]
+                node_id[hostvars['upstream_node_private_ip']] += 1
+                repmgr_standbys[host] = dict(
+                    node_type='standby',
+                    id=node_id[hostvars['upstream_node_private_ip']],
+                    ansible_host=hostvars['ansible_host'],
+                    hostname=hostvars.get('hostname',
+                                          hostvars.get('ansible_hostname')),
+                    private_ip=hostvars['private_ip'],
+                    upstream_node_private_ip=hostvars['upstream_node_private_ip'],
+                    replication_type=hostvars.get('replication_type',
+                                                  'asynchronous'),
+                    inventory_hostname=hostvars['inventory_hostname']
+                )
+
+        repmgr_standbys_len = len(repmgr_standbys.keys())
+
+        # Populate repmgr_witnesses dict if we have witness nodes in the inventory
+        if 'witness' in variables['groups']:
+            for host in variables['groups']['witness']:
+                hostvars = myvars['hostvars'][host]
+                node_id[hostvars['upstream_node_private_ip']] += 1
+                repmgr_witnesses[host] = dict(
+                    node_type='witness',
+                    id=node_id[hostvars['upstream_node_private_ip']],
+                    ansible_host=hostvars['ansible_host'],
+                    hostname=hostvars.get('hostname',
+                                          hostvars.get('ansible_hostname')),
+                    private_ip=hostvars['private_ip'],
+                    upstream_node_private_ip=hostvars['upstream_node_private_ip'],
+                    replication_type=None,
+                    inventory_hostname=hostvars['inventory_hostname']
+                )
+
+        repmgr_witnesses_len = len(repmgr_witnesses.keys())
+
+        # Append the standby nodes into the right repmgr_clusters item, based on
+        # standby's upstream node.
+        while repmgr_standbys_len != 0:
+
+            for k in list(repmgr_standbys.keys()):
+                sby = repmgr_standbys[k]
+
+                if sby['upstream_node_private_ip'] in repmgr_primary_map:
+                    upstream_private_ip = sby['upstream_node_private_ip']
+                    primary_private_ip = repmgr_primary_map[upstream_private_ip]
+                    repmgr_primary_map[sby['private_ip']] = primary_private_ip
+                    repmgr_clusters[primary_private_ip].append(sby)
+                    del(repmgr_standbys[k])
+
+            # Case when at least one host has not been handled in this loop
+            # iteration.
+            if repmgr_standbys_len == len(repmgr_standbys.keys()):
+                raise AnsibleError(
+                    "Inventory error with the following standbys nodes %s. "
+                    "Upstream node is not configured or not found"
+                    % [s for s in repmgr_standbys.keys()]
+                )
+
+            repmgr_standbys_len = len(repmgr_standbys.keys())
+
+        # Append witness nodes into the right repmgr_clusters item, based on
+        # witness's upstream node.
+        while repmgr_witnesses_len != 0:
+
+            for k in list(repmgr_witnesses.keys()):
+                wit = repmgr_witnesses[k]
+
+                if wit['upstream_node_private_ip'] in repmgr_primary_map:
+                    upstream_private_ip = wit['upstream_node_private_ip']
+                    primary_private_ip = repmgr_primary_map[upstream_private_ip]
+                    repmgr_primary_map[wit['private_ip']] = primary_private_ip
+                    repmgr_clusters[primary_private_ip].append(wit)
+                    del(repmgr_witnesses[k])
+
+            # Case when at least one host has not been handled in this loop
+            # iteration.
+            if repmgr_witnesses_len == len(repmgr_witnesses.keys()):
+                raise AnsibleError(
+                    "Inventory error with the following witness nodes %s. "
+                    "Upstream node is not configured or not found"
+                    % [s for s in repmgr_witnesses.keys()]
+                )
+
+            repmgr_witnesses_len = len(repmgr_witnesses.keys())
+
+
+        if node_private_ip in repmgr_primary_map:
+            # Current node is part of one of the SR clusters found
+            return repmgr_clusters[repmgr_primary_map[node_private_ip]]
+        else:
+            primary_private_ips = list(repmgr_clusters.keys())
+            # If the current node is not part of any repmgr cluster found, but,
+            # only one repmgr cluster has been found, then we return this repmgr
+            # cluster because there is no doubt.
+            if len(primary_private_ips) == 1:
+                return repmgr_clusters[primary_private_ips[0]]
+            else:
+                raise AnsibleError(
+                    "Unable to find the repmgr cluster topology because multiple "
+                    "repmgr clusters were found and this current node does not "
+                    "appear to be part of any of them"
+                )

--- a/plugins/lookup/supported_roles.py
+++ b/plugins/lookup/supported_roles.py
@@ -33,7 +33,8 @@ GROUP_ROLES = {
         'init_dbserver',
         'manage_dbserver',
         'setup_efm',
-        'autotuning'
+        'autotuning',
+        'setup_repmgr',
     ],
     'standby': [
         'setup_repo',
@@ -41,7 +42,8 @@ GROUP_ROLES = {
         'setup_replication',
         'manage_dbserver',
         'setup_efm',
-        'autotuning'
+        'autotuning',
+        'setup_repmgr',
     ],
     'pemserver': [
         'setup_repo',
@@ -78,7 +80,8 @@ GROUP_ROLES = {
     'witness': [
         'setup_repo',
         'install_dbserver',
-        'setup_efm'
+        'setup_efm',
+        'setup_repmgr',
     ],
 }
 
@@ -135,5 +138,13 @@ class LookupModule(LookupBase):
                 supported_roles = list(
                     set(supported_roles)
                     | set(['setup_hammerdb'])
+                )
+            # Special case for the witness nodes when the host variable
+            # init_dbserver is set to true. This is required for repmgr: the
+            # witness node must have a dedicated database instance running.
+            if (group in ['witness'] and hostvars.get('init_dbserver', False)):
+                supported_roles = list(
+                    set(supported_roles)
+                    | set(['init_dbserver'])
                 )
         return supported_roles

--- a/roles/setup_repmgr/README.md
+++ b/roles/setup_repmgr/README.md
@@ -1,0 +1,170 @@
+# setup_repmgr
+
+This Ansible Role installs and configures High-Availability of a streaming
+replication Postgres cluster, based on `repmgr`.
+
+**Note:**
+Only PostgreSQL is supported by this role, EPAS will be supported in the future.
+For more details refer to the: *Database engines supported* section.
+
+**The ansible playbook must be executed under an account that has full
+privileges.**
+
+## Requirements
+
+The requirements for this Ansible Role are:
+
+  1. Ansible >= 2.9
+  2. `community.general`
+  3. `edb_devops.edb_postgres` -> `setup_repo` - for installing the EPAS/PG
+     repository
+  4. `edb_devops.edb_postgres` -> `install_dbserver` - for installing the EPAS/PG
+     binaries
+  5. `edb_devops.edb_postgres` -> `init_dbserver` - for initializing the EPAS/PG
+     data directory and configuring a primary node.
+  6. `edb_devops.edb_postgres` -> `setup_replication` - for creating the standby.
+
+## Role variables
+
+When executing the role via ansible there are three required variables:
+
+  * ***pg_version***
+
+  Postgres Versions supported are: 10, 11, 12, 13 and 14
+
+  * ***pg_type***
+
+  Database Engine supported is PG
+
+
+These and other variables can be assigned in the `pre_tasks` definition of the
+section: *How to include the `setup_repmgr` role in your Playbook*
+
+The rest of the variables can be configured and are available in the:
+
+  * [roles/setup_repmgr/defaults/main.yml](./defaults/main.yml) 
+  * [roles/setup_repmgr/vars/PG_RedHat.yml](./vars/PG_RedHat.yml) 
+  * [roles/setup_repmgr/vars/PG_Debian.yml](./vars/PG_Debian.yml) 
+
+## Dependencies
+
+This role depends on the `manage_dbserver` role.
+
+## Example Playbook
+
+### Inventory file content
+
+Content of the `inventory.yml` file for 3 Postgres nodes cluster composed of 1
+primary node and 2 standby nodes:
+
+```yaml
+all:
+  children:
+    primary:
+      hosts:
+        primary1:
+          ansible_host: 192.168.122.1
+          private_ip: 10.0.0.1
+    standby:
+      hosts:
+        standby1:
+          ansible_host: 192.168.122.2
+          private_ip: 10.0.0.2
+          upstream_node_private_ip: 10.0.0.1
+          replication_type: synchronous
+        standby2:
+          ansible_host: 192.168.122.3
+          private_ip: 10.0.0.3
+          upstream_node_private_ip: 10.0.0.1
+          replication_type: asynchronous
+```
+
+The following inventory example illustrates how to deploy a 2 Postgres nodes
+composed of 1 primary node, 1 standby node and 1 witness node:
+
+```yaml
+all:
+  children:
+    primary:
+      hosts:
+        primary1:
+          ansible_host: 192.168.122.1
+          private_ip: 10.0.0.1
+    standby:
+      hosts:
+        standby1:
+          ansible_host: 192.168.122.2
+          private_ip: 10.0.0.2
+          upstream_node_private_ip: 10.0.0.1
+          replication_type: asynchronous
+    witness:
+      hosts:
+        witness1:
+          init_dbserver: true
+          ansible_host: 192.168.122.3
+          private_ip: 10.0.0.3
+          upstream_node_private_ip: 10.0.0.1
+```
+
+
+### How to include the `setup_repmgr` role in your Playbook
+
+Below is an example of how to include the `setup_repmgr` role:
+
+```yaml
+---
+- hosts: primary,standby,witness
+  name: Install and configure Repmgr
+  become: true
+  gather_facts: yes
+
+  collections:
+    - edb_devops.edb_postgres
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        pg_type: "PG"
+        pg_version: "14"
+
+        repmgr_failover: automatic
+        repmgr_reconnect_attemps: 2
+        repmgr_reconnect_interval: 2
+
+  roles:
+    - setup_repmgr
+```
+
+## Database engines supported
+
+### Community PostgreSQL and Repmgr
+
+| Distribution | 10 | 11 | 12 | 13 | 14 |
+| ------------------------- |:--:|:--:|:--:|:--:|:--:|
+| CentOS 8 | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
+| Red Hat Linux 8 | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
+| Debian 10 | :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:| :white_check_mark:|
+
+- :white_check_mark: - Tested and supported
+- :x: - Not supported
+
+## Playbook execution examples
+
+```bash
+# To deploy community Postgres version 14 on CentOS8 hosts with the user centos
+$ ansible-playbook playbook.yml \
+  -u centos \
+  -i inventory.yml \
+  --private-key <key.pem> \
+  --extra-vars="pg_version=14 pg_type=PG"
+```
+
+## License
+
+BSD
+
+## Author information
+
+Author:
+
+  * Julien Tachoires (@jt-edb)

--- a/roles/setup_repmgr/defaults/main.yml
+++ b/roles/setup_repmgr/defaults/main.yml
@@ -1,0 +1,51 @@
+---
+pg_version: 14
+pg_instance_name: main
+disable_logging: true
+use_hostname: true
+
+# Database name used by repmgr
+pg_repmgr_dbname: repmgr
+# Database username used by repmgr
+pg_repmgr_user: repmgr
+# Password of the database user, will be generated if empty
+pg_repmgr_user_password: ""
+# Replication user created by setup_replication
+pg_replication_user: repuser
+
+# Repmgr log level
+repmgr_log_level: INFO
+# Repmgr log facility
+repmgr_log_facility: STDERR
+# Repmgr log file path when using STDERR
+repmgr_log_file: /var/log/repmgr/repmgr.log
+
+# Repmgr failover mode, could be 'automatic' for automatic failover, or
+# 'manual'
+repmgr_failover: automatic
+# Number of connection attemps in case of failure before triggering an
+# automatic failover.
+repmgr_reconnect_attemps: 3
+# Interval of time, in seconds, between each reconnect attemps
+repmgr_reconnect_interval: 5
+
+etc_hosts_lists: []
+
+supported_os:
+  - CentOS7
+  - CentOS8
+  - RedHat7
+  - RedHat8
+  - Ubuntu20
+  - Debian9
+  - Debian10
+
+supported_pg_type:
+  - PG
+
+supported_pg_version:
+  - 10
+  - 11
+  - 12
+  - 13
+  - 14

--- a/roles/setup_repmgr/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_repmgr/tasks/exchange_ssh_keys.yml
@@ -1,0 +1,90 @@
+- name: Set _local_host and _remote_host when using hostname
+  ansible.builtin.set_fact:
+    _local_host: "{{ local_node.inventory_hostname }}"
+    _remote_host: "{{ remote_node.inventory_hostname }}"
+  when: use_hostname
+
+- name: Set _local_host and _remote_host when not using hostname
+  ansible.builtin.set_fact:
+    _local_host: "{{ local_node.private_ip }}"
+    _remote_host: "{{ remote_node.private_ip }}"
+  when: not use_hostname
+
+- name: Fetch remote server SSH public key
+  ansible.builtin.slurp:
+    src: "{{ pg_user_home + '/.ssh/id_rsa.pub' }}"
+  delegate_to: "{{ remote_node.ansible_host }}"
+  register: _remote_server_ssh_public_key_b64
+  become: true
+
+- name: Set _remote_server_ssh_public_key
+  ansible.builtin.set_fact:
+      _remote_server_ssh_public_key: "{{ _remote_server_ssh_public_key_b64.content | b64decode | trim }}"
+
+- name: Fetch local {{ pg_owner }} SSH public key
+  ansible.builtin.slurp:
+    src: "{{ pg_user_home + '/.ssh/id_rsa.pub' }}"
+  register: _local_ssh_public_key_b64
+  become: true
+
+- name: Set _local_ssh_public_key
+  set_fact:
+      _local_ssh_public_key: "{{ _local_ssh_public_key_b64.content | b64decode | trim }}"
+
+- name: Ensure local {{ pg_owner }} SSH public key is on the remote server
+  ansible.builtin.lineinfile:
+    path: "{{ pg_user_home + '/.ssh/authorized_keys' }}"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: 0600
+    line: "{{ _local_ssh_public_key }}"
+    create: true
+  delegate_to: "{{ remote_node.ansible_host }}"
+  become: true
+
+- name: Ensure remote {{ pg_owner }} SSH public key is on the local server
+  ansible.builtin.lineinfile:
+    path: "{{ pg_user_home + '/.ssh/authorized_keys' }}"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: 0600
+    line: "{{ _remote_server_ssh_public_key }}"
+    create: true
+
+- name: Run ssh-keyscan from the remote server
+  ansible.builtin.command: ssh-keyscan {{ _local_host }}
+  register: _remote_ssh_keyscan_output
+  delegate_to: "{{ remote_node.ansible_host }}"
+  become: true
+  changed_when: false
+
+- name: Add local {{ pg_owner }} SSH public key into remote server known hosts
+  ansible.builtin.known_hosts:
+    path: "{{ pg_user_home + '/.ssh/known_hosts' }}"
+    name: "{{ _local_host }}"
+    key: "{{ _item }}"
+  with_items: "{{ _remote_ssh_keyscan_output.stdout_lines }}"
+  loop_control:
+    loop_var: _item
+  delegate_to: "{{ remote_node.ansible_host }}"
+  become: true
+  become_user: "{{ pg_owner }}"
+  no_log: "{{ disable_logging }}"
+
+- name: Run ssh-keyscan from the local server
+  ansible.builtin.command: ssh-keyscan {{ _remote_host }}
+  register: _local_ssh_keyscan_output
+  become: yes
+  changed_when: false
+
+- name: Add remote SSH public key into local server known hosts
+  ansible.builtin.known_hosts:
+    path: "{{ pg_user_home + '/.ssh/known_hosts' }}"
+    name: "{{ _remote_host }}"
+    key: "{{ _item }}"
+  with_items: "{{ _local_ssh_keyscan_output.stdout_lines }}"
+  loop_control:
+    loop_var: _item
+  become: true
+  become_user: "{{ pg_owner }}"
+  no_log: "{{ disable_logging }}"

--- a/roles/setup_repmgr/tasks/generate_ssh_keys.yml
+++ b/roles/setup_repmgr/tasks/generate_ssh_keys.yml
@@ -1,0 +1,22 @@
+- name: Ensure the directory {{ pg_user_home }}/.ssh exists
+  ansible.builtin.file:
+    state: directory
+    path: "{{ pg_user_home }}/.ssh"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: 0700
+  become: true
+
+- name: Check if the SSH private key exists
+  ansible.builtin.stat:
+    path: "{{ pg_user_home }}/.ssh/id_rsa"
+  register: postgres_ssh_private_key
+  become: true
+
+- name: Ensure Postgres owner's SSH keys exist
+  community.crypto.openssh_keypair:
+    path: "{{ pg_user_home }}/.ssh/id_rsa"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+  when: not postgres_ssh_private_key.stat.exists
+  become: true

--- a/roles/setup_repmgr/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_repmgr/tasks/linux_update_etc_hosts.yml
@@ -1,0 +1,16 @@
+- name: Update /etc/hosts file, based on variable etc_hosts_list
+  ansible.builtin.lineinfile:
+     path: "/etc/hosts"
+     line: "{{ item }}"
+  loop: "{{ etc_hosts_lists }}"
+
+- name: Update /etc/hosts file, based on the inventory
+  ansible.builtin.lineinfile:
+     path: "/etc/hosts"
+     line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
+     regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+  loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update system hostname
+  ansible.builtin.hostname:
+    name: "{{ inventory_hostname }}"

--- a/roles/setup_repmgr/tasks/main.yml
+++ b/roles/setup_repmgr/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+# Entry point of the setup_repmgr role
+- name: Include the setup_repmgr.yml
+  include_tasks: setup_repmgr.yml

--- a/roles/setup_repmgr/tasks/repmgr_configure.yml
+++ b/roles/setup_repmgr/tasks/repmgr_configure.yml
@@ -1,0 +1,8 @@
+- name: Write repmgr.conf
+  ansible.builtin.template:
+    src: repmgr.conf.j2
+    dest: "{{ repmgr_configuration_file }}"
+    mode: "0600"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+  become: true

--- a/roles/setup_repmgr/tasks/repmgr_configure_spl.yml
+++ b/roles/setup_repmgr/tasks/repmgr_configure_spl.yml
@@ -1,0 +1,48 @@
+- name: Read shared_preload_libraries
+  community.postgresql.postgresql_query:
+    query: >-
+      SELECT setting FROM pg_settings
+      WHERE name = 'shared_preload_libraries'
+    port: "{{ pg_port }}"
+    db: "{{ pg_database }}"
+    login_user: "{{ pg_owner }}"
+    login_unix_socket: "{{ pg_unix_socket_directories[0] }}"
+  no_log: "{{ disable_logging }}"
+  become: true
+  become_user: "{{ pg_owner }}"
+  register: spl
+
+- name: Initialize variables
+  ansible.builtin.set_fact:
+    spl_list: "{{ spl.query_result[0].setting.split(',') | map('regex_replace', '[\"]+', '') | map('trim') | list }}"
+    new_spl_list: []
+    update_spl: false
+
+- name: Add 'repmgr' to SPL if needed
+  ansible.builtin.set_fact:
+    new_spl_list: "{{ spl_list + ['repmgr'] }}"
+    update_spl: true
+  when: "'repmgr' not in spl_list"
+
+- name: Update SPL
+  community.postgresql.postgresql_query:
+    query: >-
+      ALTER SYSTEM SET shared_preload_libraries TO {{ new_spl_list | map('quote') | join(',') }}
+    port: "{{ pg_port }}"
+    db: "{{ pg_database }}"
+    login_user: "{{ pg_owner }}"
+    login_unix_socket: "{{ pg_unix_socket_directories[0] }}"
+    autocommit: true
+  no_log: "{{ disable_logging }}"
+  become: true
+  become_user: "{{ pg_owner }}"
+  when:
+    - update_spl
+
+- name: Restart Postgres service
+  ansible.builtin.systemd:
+    name: "{{ pg_service }}"
+    state: restarted
+  become: true
+  when:
+    - update_spl

--- a/roles/setup_repmgr/tasks/repmgr_hba.yml
+++ b/roles/setup_repmgr/tasks/repmgr_hba.yml
@@ -1,0 +1,6 @@
+- name: Update HBA configuration
+  ansible.builtin.include_role:
+    name: manage_dbserver
+    tasks_from: manage_hba_conf
+  vars:
+    pg_hba_ip_addresses: "{{ repmgr_allow_ip_addresses }}"

--- a/roles/setup_repmgr/tasks/repmgr_install.yml
+++ b/roles/setup_repmgr/tasks/repmgr_install.yml
@@ -1,0 +1,5 @@
+- name: Install repmgr package
+  ansible.builtin.package:
+    name: "{{ repmgr_package_name }}"
+    state: present
+  become: true

--- a/roles/setup_repmgr/tasks/repmgr_prepare_hba.yml
+++ b/roles/setup_repmgr/tasks/repmgr_prepare_hba.yml
@@ -1,0 +1,45 @@
+- name: Prepare HBA non ssl list
+  ansible.builtin.set_fact:
+    repmgr_allow_ip_addresses: >-
+      {{ repmgr_allow_ip_addresses | default([]) }} + [
+        {
+          "contype": "host",
+          "users": "{{ pg_repmgr_user }}",
+          "source": "{{ node.private_ip }}/32",
+          "databases": "{{ pg_repmgr_dbname }}"
+          },
+        {
+          "contype": "host",
+          "users": "{{ pg_repmgr_user }}",
+          "source": "127.0.0.1/32",
+          "databases": "{{ pg_repmgr_dbname }}"
+          }
+      ]
+  when: not pg_ssl
+  loop: "{{ repmgr_cluster_nodes }}"
+  loop_control:
+    loop_var: node
+  run_once: true
+  no_log: "{{ disable_logging }}"
+
+- name: Prepare HBA ssl list
+  ansible.builtin.set_fact:
+    repmgr_allow_ip_addresses: >-
+      {{ repmgr_allow_ip_addresses | default([]) }} + [
+        {
+          "users": "{{ pg_repmgr_user }}",
+          "source": "{{ node.private_ip }}/32",
+          "databases": "{{ pg_repmgr_dbname }}"
+          },
+        {
+          "users": "{{ pg_repmgr_user }}",
+          "source": "127.0.0.1/32",
+          "databases": "{{ pg_repmgr_dbname }}"
+          }
+      ]
+  when: pg_ssl
+  loop: "{{ repmgr_cluster_nodes }}"
+  loop_control:
+    loop_var: node
+  run_once: true
+  no_log: "{{ disable_logging }}"

--- a/roles/setup_repmgr/tasks/repmgr_register_node.yml
+++ b/roles/setup_repmgr/tasks/repmgr_register_node.yml
@@ -1,0 +1,33 @@
+- name: Make sure /var/log/repmgr exists
+  ansible.builtin.file:
+    path: /var/log/repmgr
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    state: directory
+  become: true
+
+- name: Register repmgr node
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ pg_bin_path }}/repmgr \
+      -f {{ repmgr_configuration_file }} \
+      {{ repmgr_role }} register -F &>> /var/log/repmgr/register.log
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: "{{ pg_owner }}"
+  throttle: 1
+  when: "repmgr_role in ('primary', 'standby')"
+
+- name: Register repmgr witness node
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ pg_bin_path }}/repmgr \
+      -f {{ repmgr_configuration_file }} \
+      {{ repmgr_role }} register -F -h {{ repmgr_primary_info.private_ip }} &>> /var/log/repmgr/register.log
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: "{{ pg_owner }}"
+  throttle: 1
+  when: "repmgr_role in ('witness')"

--- a/roles/setup_repmgr/tasks/repmgr_setup_db.yml
+++ b/roles/setup_repmgr/tasks/repmgr_setup_db.yml
@@ -1,0 +1,18 @@
+- name: Create repmgr database
+  ansible.builtin.include_role:
+    name: manage_dbserver
+    tasks_from: manage_db
+  vars:
+    pg_databases:
+      - name: "{{ pg_repmgr_dbname }}"
+        owner: "{{ pg_repmgr_user }}"
+
+- name: Create repmgr extension
+  ansible.builtin.include_role:
+    name: manage_dbserver
+    tasks_from: manage_extensions
+  vars:
+    pg_extensions:
+      - name: repmgr
+        database: "{{ pg_repmgr_dbname }}"
+  when: "'primary' in group_names"

--- a/roles/setup_repmgr/tasks/repmgr_setup_db_user.yml
+++ b/roles/setup_repmgr/tasks/repmgr_setup_db_user.yml
@@ -1,0 +1,36 @@
+- name: Generate the pg_repmgr_user_password
+  ansible.builtin.include_role:
+    name: manage_dbserver
+    tasks_from: generate_password
+  vars:
+    input_user: "{{ pg_repmgr_user }}"
+    input_password: "{{ pg_repmgr_user_password }}"
+  when: pg_repmgr_user_password|length < 1
+
+- name: Set pg_repmgr_user_password
+  ansible.builtin.set_fact:
+     pg_repmgr_user_password: "{{ input_password }}"
+  when: pg_repmgr_user_password|length < 1
+
+- name: Create repmgr database user
+  ansible.builtin.include_role:
+    name: manage_dbserver
+    tasks_from: manage_users
+  vars:
+    pg_users:
+      - name: "{{ pg_repmgr_user }}"
+        pass: "{{ pg_repmgr_user_password }}"
+        role_attr_flags: superuser
+
+- name: Update repmgr user's search_path
+  community.postgresql.postgresql_query:
+    query: >-
+      ALTER USER {{ pg_repmgr_user }}
+      SET search_path TO repmgr, "$user", public
+    port: "{{ pg_port }}"
+    db: "{{ pg_database }}"
+    login_user: "{{ pg_owner }}"
+    login_unix_socket: "{{ pg_unix_socket_directories[0] }}"
+  no_log: "{{ disable_logging }}"
+  become: true
+  become_user: "{{ pg_owner }}"

--- a/roles/setup_repmgr/tasks/repmgr_setup_systemd.yml
+++ b/roles/setup_repmgr/tasks/repmgr_setup_systemd.yml
@@ -1,0 +1,32 @@
+- name: "Ensure /etc/systemd/system/{{ repmgrd_service }}.service.d exists"
+  ansible.builtin.file:
+    path: "/etc/systemd/system/{{ repmgrd_service }}.service.d"
+    state: directory
+  become: true
+  when: ansible_os_family == 'RedHat'
+
+- name: "Write /etc/systemd/system/{{ repmgrd_service }}.service.d/override.conf"
+  ansible.builtin.template:
+    src: override.conf.j2
+    dest: "/etc/systemd/system/{{ repmgrd_service }}.service.d/override.conf"
+    mode: "0600"
+    owner: root
+    group: root
+  become: true
+  when: ansible_os_family == 'RedHat'
+
+- name: "Write /etc/default/repmgrd"
+  ansible.builtin.template:
+    src: default.repmgrd.j2
+    dest: /etc/default/repmgrd
+    owner: root
+    group: root
+  become: true
+  when: ansible_os_family == 'Debian'
+
+- name: Enable and start repmgrd
+  ansible.builtin.systemd:
+    name: "{{ repmgrd_service }}"
+    state: restarted
+    daemon_reload: true
+  become: true

--- a/roles/setup_repmgr/tasks/repmgr_sudoers.yml
+++ b/roles/setup_repmgr/tasks/repmgr_sudoers.yml
@@ -1,0 +1,8 @@
+- name: Write /etc/sudoers.d/repmgr.conf
+  ansible.builtin.template:
+    src: sudoers.d.repmgr.conf.j2
+    dest: /etc/sudoers.d/repmgr
+    mode: "0600"
+    owner: root
+    group: root
+  become: true

--- a/roles/setup_repmgr/tasks/repmgr_update_pgpass.yml
+++ b/roles/setup_repmgr/tasks/repmgr_update_pgpass.yml
@@ -1,0 +1,24 @@
+- name: Generate the pg_repmgr_user_password
+  ansible.builtin.include_role:
+    name: manage_dbserver
+    tasks_from: generate_password
+  vars:
+    input_user: "{{ pg_repmgr_user }}"
+    input_password: "{{ pg_repmgr_user_password }}"
+  when: pg_repmgr_user_password|length < 1
+
+- name: Set pg_repmgr_user_password
+  ansible.builtin.set_fact:
+     pg_repmgr_user_password: "{{ input_password }}"
+  when: pg_repmgr_user_password|length < 1
+
+- name: Add repmgr user's password in pgpass
+  ansible.builtin.include_role:
+    name: manage_dbserver
+    tasks_from: manage_pgpass
+  vars:
+    pg_pgpass_values:
+      - user: "{{ pg_repmgr_user }}"
+        password: "{{ pg_repmgr_user_password }}"
+        database: "{{ pg_repmgr_dbname }}"
+        create: true

--- a/roles/setup_repmgr/tasks/setup_repmgr.yml
+++ b/roles/setup_repmgr/tasks/setup_repmgr.yml
@@ -1,0 +1,101 @@
+---
+- name: Set the os variable
+  ansible.builtin.set_fact:
+    os: "{{ ansible_distribution }}{{ ansible_distribution_major_version }}"
+
+- name: Check support for Operating System
+  ansible.builtin.fail:
+    msg: "Operating System = {{ os }} not supported."
+  when: os not in supported_os
+
+- name: Check supported versions for Database engine
+  ansible.builtin.fail:
+    msg: "Database Engine Version = {{ pg_version }} not supported.
+          Supported versions are {{ supported_pg_version }}"
+  when: pg_version|int not in supported_pg_version
+
+- name: Reference variables
+  ansible.builtin.include_vars: "{{ pg_type }}_{{ ansible_os_family }}.yml"
+
+- name: Set repmgr_cluster_nodes
+  ansible.builtin.set_fact:
+    repmgr_cluster_nodes: "{{ lookup('edb_devops.edb_postgres.repmgr_nodes', wantlist=True) }}"
+
+- name: Set repmgr_node_info
+  ansible.builtin.set_fact:
+    repmgr_node_info: "{{ item }}"
+  loop: "{{ repmgr_cluster_nodes }}"
+  when: "item.inventory_hostname == inventory_hostname"
+
+- name: Set repmgr_primary_info
+  ansible.builtin.set_fact:
+    repmgr_primary_info: "{{ item }}"
+  loop: "{{ repmgr_cluster_nodes }}"
+  when: "item.node_type == 'primary'"
+  run_once: true
+
+- name: Include linux_update_etc_hosts.yml
+  ansible.builtin.include_tasks: linux_update_etc_hosts.yml
+  when: use_hostname
+
+- name: Include repmgr_install.yml
+  ansible.builtin.include_tasks: repmgr_install.yml
+
+- name: Include repmgr_configure_spl.yml
+  ansible.builtin.include_tasks: repmgr_configure_spl.yml
+
+- name: Include repmgr_setup_db_user.yml
+  ansible.builtin.include_tasks: repmgr_setup_db_user.yml
+  when: "('primary' in group_names) or ('witness' in group_names)"
+
+- name: Include repmgr_update_pgpass.yml
+  ansible.builtin.include_tasks: repmgr_update_pgpass.yml
+
+- name: Include repmgr_setup_db.yml
+  ansible.builtin.include_tasks: repmgr_setup_db.yml
+  when: "('primary' in group_names) or ('witness' in group_names)"
+
+- name: Include repmgr_prepare_hba.yml
+  ansible.builtin.include_tasks: repmgr_prepare_hba.yml
+
+- name: Include repmgr_hba.yml
+  ansible.builtin.include_tasks: repmgr_hba.yml
+
+- name: Include repmgr_configure.yml
+  ansible.builtin.include_tasks: repmgr_configure.yml
+
+- name: Register the repmgr primary node
+  ansible.builtin.include_tasks: repmgr_register_node.yml
+  when: "'primary' in group_names"
+  vars:
+    repmgr_role: primary
+
+- name: Register the repmgr standby nodes
+  ansible.builtin.include_tasks: repmgr_register_node.yml
+  when: "'standby' in group_names"
+  vars:
+    repmgr_role: standby
+
+- name: Register the repmgr witness nodes
+  ansible.builtin.include_tasks: repmgr_register_node.yml
+  when: "'witness' in group_names"
+  vars:
+    repmgr_role: witness
+
+- name: Include generate_ssh_keys.yml
+  ansible.builtin.include_tasks: generate_ssh_keys.yml
+
+- name: Include exchange_ssh_keys.yml
+  ansible.builtin.include_tasks: exchange_ssh_keys.yml
+  loop: "{{ repmgr_cluster_nodes }}"
+  loop_control:
+    loop_var: remote_node
+  when: "remote_node.inventory_hostname != inventory_hostname"
+  vars:
+    local_node: "{{ repmgr_node_info }}"
+
+- name: Include repmgr_sudoers.yml
+  ansible.builtin.include_tasks: repmgr_sudoers.yml
+
+- name: Include repmgr_setup_systemd.yml
+  ansible.builtin.include_tasks: repmgr_setup_systemd.yml

--- a/roles/setup_repmgr/templates/default.repmgrd.j2
+++ b/roles/setup_repmgr/templates/default.repmgrd.j2
@@ -1,0 +1,21 @@
+# default settings for repmgrd. This file is source by /bin/sh from
+# /etc/init.d/repmgrd
+
+# disable repmgrd by default so it won't get started upon installation
+# valid values: yes/no
+REPMGRD_ENABLED=yes
+
+# configuration file (required)
+REPMGRD_CONF="/etc/repmgr.conf"
+
+# additional options
+#REPMGRD_OPTS=""
+
+# user to run repmgrd as
+REPMGRD_USER={{ pg_owner }}
+
+# repmgrd binary
+REPMGRD_BIN=/usr/bin/repmgrd
+
+# pid file
+REPMGRD_PIDFILE=/var/run/repmgrd.pid

--- a/roles/setup_repmgr/templates/override.conf.j2
+++ b/roles/setup_repmgr/templates/override.conf.j2
@@ -1,0 +1,8 @@
+[Unit]
+After={{ pg_service }}.service
+
+[Service]
+User={{ pg_owner }}
+Group={{ pg_group }}
+
+Environment=REPMGRDCONF={{ repmgr_configuration_file }}

--- a/roles/setup_repmgr/templates/repmgr.conf.j2
+++ b/roles/setup_repmgr/templates/repmgr.conf.j2
@@ -1,0 +1,442 @@
+###################################################
+# repmgr sample configuration file
+###################################################
+
+# Some configuration items will be set with a default value; this
+# is noted for each item. Where no default value is shown, the
+# parameter will be treated as empty or false.
+#
+# repmgr parses its configuration file in the same way as PostgreSQL itself
+# does. In particular, strings must be enclosed in single quotes (although
+# simple identifiers may be provided as-is).
+#
+# For details on the configuration file format see the documentation at:
+#
+#   https://repmgr.org/docs/current/configuration-file.html#CONFIGURATION-FILE-FORMAT
+#
+# =============================================================================
+# Required configuration items
+# =============================================================================
+#
+# repmgr and repmgrd require the following items to be explicitly configured.
+
+
+node_id={{ repmgr_node_info['id'] }}			 # A unique integer greater than zero
+node_name='{{ repmgr_node_info['inventory_hostname'] }}'			 # An arbitrary (but unique) string; we recommend
+				 # using the server's hostname or another identifier
+				 # unambiguously associated with the server to avoid
+				 # confusion. Avoid choosing names which reflect the
+				 # node's current role, e.g. 'primary' or 'standby1',
+				 # as roles can change and it will be confusing if
+				 # the current primary is called 'standby1'.
+				 # The string's maximum length is 63 characters and it should
+				 # contain only printable ASCII characters.
+
+conninfo='dbname={{ pg_repmgr_dbname }} user={{ pg_repmgr_user }} port={{ pg_port }} host={% if use_hostname %}{{ repmgr_node_info['inventory_hostname'] }}{% else %}{{ repmgr_node_info['private_ip'] }}{% endif %} connect_timeout=2'			 # Database connection information as a conninfo string.
+				 # All servers in the cluster must be able to connect to
+				 # the local node using this string.
+				 #
+				 # For details on conninfo strings, see:
+				 #  https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+				 #
+				 # If repmgrd is in use, consider explicitly setting
+				 # "connect_timeout" in the conninfo string to determine
+				 # the length of time which elapses before a network
+				 # connection attempt is abandoned; for details see:
+				 #  https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-CONNECT-TIMEOUT
+
+data_directory='{{ pg_data }}'		 # The node's data directory. This is needed by repmgr
+				 # when performing operations when the PostgreSQL instance
+				 # is not running and there's no other way of determining
+				 # the data directory.
+
+
+# =============================================================================
+# Optional configuration items
+# =============================================================================
+
+
+#------------------------------------------------------------------------------
+# Server settings
+#------------------------------------------------------------------------------
+
+#config_directory=''		 # If configuration files are located outside the data
+				 # directory, specify the directory where the main
+				 # postgresql.conf file is located.
+
+#------------------------------------------------------------------------------
+# Replication settings
+#------------------------------------------------------------------------------
+
+replication_user='{{ pg_replication_user }}'	 # User to make replication connections with, if not set
+				 #  defaults to the user defined in "conninfo".
+
+#replication_type='physical'	 # Must "physical" (the default).
+
+#location='default'		 # An arbitrary string defining the location of the node; this
+				 # is used during failover to check visibility of the
+				 # current primary node. For further details see:
+				 #   https://repmgr.org/docs/current/repmgrd-network-split.html
+
+use_replication_slots=yes	 # whether to use physical replication slots
+				 # NOTE: when using replication slots,
+				 # 'max_replication_slots' should be configured for
+				 # at least the number of standbys which will connect
+				 # to the primary.
+
+#------------------------------------------------------------------------------
+# Witness server settings
+#------------------------------------------------------------------------------
+
+#witness_sync_interval=15	 # interval (in seconds) to synchronise node records
+				 # to the witness server
+
+#------------------------------------------------------------------------------
+# Logging settings
+#------------------------------------------------------------------------------
+#
+# Note that logging facility settings will only apply to `repmgrd` by default;
+# `repmgr` will always write to STDERR unless the switch `--log-to-file` is
+# supplied, in which case it will log to the same destination as `repmgrd`.
+# This is mainly intended for those cases when `repmgr` is executed directly
+# by `repmgrd`.
+
+log_level='{{ repmgr_log_level }}'		 # Log level: possible values are DEBUG, INFO, NOTICE,
+				 # WARNING, ERROR, ALERT, CRIT or EMERG
+
+log_facility='{{ repmgr_log_facility }}'		 # Logging facility: possible values are STDERR, or for
+				 # syslog integration, one of LOCAL0, LOCAL1, ..., LOCAL7, USER
+
+log_file='{{ repmgr_log_file }}'			 # STDERR can be redirected to an arbitrary file
+#log_status_interval=300	 # interval (in seconds) for repmgrd to log a status message
+
+
+#------------------------------------------------------------------------------
+# Event notification settings
+#------------------------------------------------------------------------------
+
+# event notifications can be passed to an arbitrary external program
+# together with the following parameters:
+#
+#   %n - node ID
+#   %e - event type
+#   %s - success (1 or 0)
+#   %t - timestamp
+#   %d - details
+#
+# the values provided for "%t" and "%d" will probably contain spaces,
+# so should be quoted in the provided command configuration, e.g.:
+#
+#   event_notification_command='/path/to/some/script %n %e %s "%t" "%d"'
+#
+# By default, all notifications will be passed; the notification types
+# can be filtered to explicitly named ones, e.g.:
+#
+#   event_notifications=primary_register,standby_register
+
+#event_notification_command=''		# An external program or script which
+					# can be executed by the user under which
+					# repmgr/repmgrd are run.
+
+#event_notifications=''			# A commas-separated list of notification
+					# types
+
+#------------------------------------------------------------------------------
+# Environment/command settings
+#------------------------------------------------------------------------------
+
+pg_bindir='{{ pg_bin_path }}'				# Path to PostgreSQL binary directory (location
+					# of pg_ctl, pg_basebackup etc.). Only needed
+					# if these files are not in the system $PATH.
+					#
+					# Debian/Ubuntu users: you will probably need to
+					# set this to the directory where `pg_ctl` is located,
+					# e.g. /usr/lib/postgresql/9.6/bin/
+					#
+					# *NOTE* "pg_bindir" is only used when repmgr directly
+					# executes PostgreSQL binaries; any user-defined scripts
+					# *must* be specified with the full path
+
+repmgr_bindir='{{ pg_bin_path }}'			# Path to repmgr binary directory (location of the repmgr
+					# binary. Only needed if the repmgr executable is not in
+					# the system $PATH or the path defined in "pg_bindir".
+
+#use_primary_conninfo_password=false	# explicitly set "password" in "primary_conninfo"
+					# using the value contained in the environment variable
+					# PGPASSWORD
+#passfile=''				# path to .pgpass file to include in "primary_conninfo"
+
+#------------------------------------------------------------------------------
+# external command options
+#------------------------------------------------------------------------------
+#
+# Options which can be passed to external commands invoked by repmgr/repmgrd.
+#
+# Examples:
+#
+#   pg_ctl_options='-s'
+#   pg_basebackup_options='--label=repmgr_backup'
+#   rsync_options=--archive --checksum --compress --progress --rsh="ssh -o \"StrictHostKeyChecking no\""
+#   ssh_options=-o "StrictHostKeyChecking no"
+
+#pg_ctl_options=''			# Options to append to "pg_ctl"
+#pg_basebackup_options=''		# Options to append to "pg_basebackup"
+                                        # (Note: when cloning from Barman, repmgr will honour any
+                                        # --waldir/--xlogdir setting present in "pg_basebackup_options"
+#rsync_options=''			# Options to append to "rsync"
+ssh_options='-q -o ConnectTimeout=10'	# Options to append to "ssh"
+
+
+
+#------------------------------------------------------------------------------
+# "standby clone" settings
+#------------------------------------------------------------------------------
+#
+# These settings apply when cloning a standby ("repmgr standby clone").
+#
+# Examples:
+#
+#   tablespace_mapping='/path/to/original/tablespace=/path/to/new/tablespace'
+#   restore_command = 'cp /path/to/archived/wals/%f %p'
+
+#tablespace_mapping=''			# Tablespaces can be remapped from one
+					# file system location to another. This
+					# parameter can be provided multiple times.
+
+#restore_command=''			# This will be included in the recovery configuration
+					# generated by repmgr.
+
+#archive_cleanup_command=''		# This will be included in the recovery configuration
+					# generated by repmgr. Note we recommend using Barman for
+					# managing WAL archives (see: https://www.pgbarman.org )
+
+#recovery_min_apply_delay=		# If provided, "recovery_min_apply_delay" will be set to
+					# this value (PostgreSQL 9.4 and later). Value can be
+                                        # an integer representing milliseconds, or a string
+                                        # representing a period of time (e.g. '5 min').
+
+
+#------------------------------------------------------------------------------
+# "standby promote" settings
+#------------------------------------------------------------------------------
+
+# These settings apply when instructing a standby to promote itself to the
+# new primary ("repmgr standby promote").
+
+#promote_check_timeout=60		# The length of time (in seconds) to wait
+					# for the new primary to finish promoting
+#promote_check_interval=1		# The interval (in seconds) to check whether
+					# the new primary has finished promoting
+
+
+#------------------------------------------------------------------------------
+# "standby follow" settings
+#------------------------------------------------------------------------------
+
+# These settings apply when instructing a standby to follow the new primary
+# ("repmgr standby follow").
+
+#primary_follow_timeout=60		# The max length of time (in seconds) to wait
+					# for the new primary to become available
+#standby_follow_timeout=30		# The max length of time (in seconds) to wait
+					# for the standby to connect to the primary
+#standby_follow_restart=false		# Restart the standby instead of sending a SIGHUP
+					# (only for PostgreSQL 13 and later)
+
+#------------------------------------------------------------------------------
+# "standby switchover" settings
+#------------------------------------------------------------------------------
+
+# These settings apply when switching roles between a primary and a standby
+# ("repmgr standby switchover").
+
+#shutdown_check_timeout=60		# The max length of time (in seconds) to wait for the demotion
+					# candidate (current primary) to shut down
+#standby_reconnect_timeout=60		# The max length of time (in seconds) to wait
+					# for the demoted standby to reconnect to the promoted
+					# primary (note: this value should be equal to or greater
+					# than that set for "node_rejoin_timeout")
+#wal_receive_check_timeout=30		# The max length of time (in seconds) to wait for the walreceiver
+					# on the standby to flush WAL to disk before comparing location
+					# with the shut-down primary
+
+#------------------------------------------------------------------------------
+# "node rejoin" settings
+#------------------------------------------------------------------------------
+
+# These settings apply when reintegrating a node into a replication cluster
+# with "repmgrd_node_rejoin"
+
+#node_rejoin_timeout=60		# The maximum length of time (in seconds) to wait for
+					# the node to reconnect to the replication cluster
+
+#------------------------------------------------------------------------------
+# Barman options
+#------------------------------------------------------------------------------
+
+#barman_server=''			# The barman configuration section
+#barman_host=''				# The host name of the barman server
+#barman_config=''			# The Barman configuration file on the
+					# Barman server (needed if the file is
+					# in a non-standard location)
+
+#------------------------------------------------------------------------------
+# Failover and monitoring settings (repmgrd)
+#------------------------------------------------------------------------------
+#
+# These settings are only applied when repmgrd is running. Values shown
+# are defaults.
+
+failover='{{ repmgr_failover }}'			# one of 'automatic', 'manual'.
+					# determines what action to take in the event of upstream failure
+					#
+					# 'automatic': repmgrd will automatically attempt to promote the
+					#    node or follow the new upstream node
+					# 'manual': repmgrd will take no action and the node will require
+					#    manual attention to reattach it to replication
+
+#priority=100				# indicates a preferred priority for promoting nodes;
+					# a value of zero prevents the node being promoted to primary
+					# (default: 100)
+
+#connection_check_type=ping		# How to check availability of the upstream node; valid options:
+					#  'ping': use PQping() to check if the node is accepting connections
+					#  'connection': attempt to make a new connection to the node
+					#  'query': execute an SQL statement on the node via the existing connection
+reconnect_attempts={{ repmgr_reconnect_attempts }}			# Number of attempts which will be made to reconnect to an unreachable
+					# primary (or other upstream node)
+reconnect_interval={{ repmgr_reconnect_interval }}			# Interval between attempts to reconnect to an unreachable
+					# primary (or other upstream node)
+promote_command='{{ pg_bin_path }}/repmgr standby promote -f {{ repmgr_configuration_file }}'			# command repmgrd executes when promoting a new primary; use something like:
+					#
+					#     repmgr standby promote -f /etc/repmgr.conf
+					#
+follow_command='{{ pg_bin_path }}/repmgr standby follow -f {{ repmgr_configuration_file }} -W --upstream-node-id=%n'			# command repmgrd executes when instructing a standby to follow a new primary;
+					# use something like:
+					#
+					#     repmgr standby follow -f /etc/repmgr.conf -W --upstream-node-id=%n
+					#
+#primary_notification_timeout=60	# Interval (in seconds) which repmgrd on a standby
+					# will wait for a notification from the new primary,
+					# before falling back to degraded monitoring
+#repmgrd_standby_startup_timeout=60	# Interval (in seconds) which repmgrd on a standby will wait
+					# for the the local node to restart and become ready to accept connections after
+					# executing "follow_command" (defaults to the value set in "standby_reconnect_timeout")
+
+monitoring_history=yes			# Whether to write monitoring data to the "monitoring_history" table
+#monitor_interval_secs=2		# Interval (in seconds) at which to write monitoring data
+#degraded_monitoring_timeout=-1		# Interval (in seconds) after which repmgrd will terminate if the
+					# server(s) being monitored are no longer available. -1 (default)
+					# disables the timeout completely.
+#async_query_timeout=60			# Interval (in seconds) which repmgrd will wait before
+					# cancelling an asynchronous query.
+#repmgrd_pid_file=			# Path of PID file to use for repmgrd; if not set, a PID file will
+					# be generated in a temporary directory specified by the environment
+					# variable $TMPDIR, or if not set, in "/tmp". This value can be overridden
+					# by the command line option "-p/--pid-file"; the command line option
+					# "--no-pid-file" will force PID file creation to be skipped.
+					# Note: there is normally no need to set this, particularly if
+					# repmgr was installed from packages.
+#repmgrd_exit_on_inactive_node=false	# If "true", and the node record is marked as "inactive", abort repmgrd startup
+#standby_disconnect_on_failover=false	# If "true", in a failover situation wait for all standbys to
+					# disconnect their WAL receivers before electing a new primary
+					# (PostgreSQL 9.5 and later only; repmgr user must be a superuser for this)
+#sibling_nodes_disconnect_timeout=30	# If "standby_disconnect_on_failover" is true, the maximum length of time
+					#  (in seconds) to wait for other standbys to confirm they have disconnected their
+					# WAL receivers
+#primary_visibility_consensus=false	# If "true", only continue with failover if no standbys have seen
+					# the primary node recently. *Must* be the same on all nodes.
+#always_promote=false			# Always promote a node, even if repmgr metadata is outdated
+#failover_validation_command=''		# Script to execute for an external mechanism to validate the failover
+					# decision made by repmgrd. One or both of the following parameter placeholders
+					# should be provided, which will be replaced by repmgrd with the appropriate
+					# value: %n (node_id), %a (node_name). *Must* be the same on all nodes.
+#election_rerun_interval=15		# if "failover_validation_command" is set, and the command returns
+					# an error, pause the specified amount of seconds before rerunning the election.
+					#
+					# The following items are relevant for repmgrd running on the primary,
+					# and will be ignored on non-primary nodes
+#child_nodes_check_interval=5		# Interval (in seconds) to check for attached child nodes (standbys)
+#child_nodes_connected_min_count=-1	# Minimum number of child nodes which must remain connected, otherwise
+					# disconnection command will be triggered
+#child_nodes_disconnect_min_count=-1	# Minimum number of disconnected child nodes required to execute disconnection command
+					# (ignored if "child_nodes_connected_min_count" set)
+#child_nodes_disconnect_timeout=30	# Interval between child node disconnection and disconnection command execution
+#child_nodes_disconnect_command=''	# Command to execute if child node disconnection detected
+
+#------------------------------------------------------------------------------
+# service control commands
+#------------------------------------------------------------------------------
+#
+# repmgr provides options to override the default pg_ctl commands
+# used to stop, start, restart, reload and promote the PostgreSQL cluster
+#
+# These options are useful when PostgreSQL has been installed from a package
+# which provides OS-level service commands. In environments using an init system
+# such as systemd, which keeps track of the state of various services, it is
+# essential that the service commands are correctly configured and pg_ctl is
+# not executed directly.
+#
+# NOTE: These commands must be runnable on remote nodes as well for switchover
+# to function correctly.
+#
+# If you use sudo, the user repmgr runs as (usually 'postgres')	 must have
+# passwordless sudo access to execute the command.
+#
+# For example, to use systemd, you can set
+#
+#    service_start_command = 'sudo systemctl start postgresql-9.6'
+#    (...)
+#
+# and then use the following sudoers configuration:
+#
+#    # this is required when running sudo over ssh without -t:
+#    Defaults:postgres !requiretty
+#    postgres ALL = NOPASSWD: /usr/bin/systemctl stop postgresql-9.6, \
+#	/usr/bin/systemctl start postgresql-9.6, \
+#	/usr/bin/systemctl restart postgresql-9.6
+#
+# Debian/Ubuntu users: use "sudo pg_ctlcluster" to execute service control commands.
+#
+# For more details, see: https://repmgr.org/docs/current/configuration-service-commands.html
+
+service_start_command = '/bin/sudo /usr/bin/systemctl start {{ pg_service }}'
+service_stop_command = '/bin/sudo /usr/bin/systemctl stop {{ pg_service }}'
+service_restart_command = '/bin/sudo /usr/bin/systemctl restart {{ pg_service }}'
+service_reload_command = '/bin/sudo /usr/bin/systemctl reload {{ pg_service }}'
+#service_promote_command = ''		# This parameter is intended for systems which provide a
+					# package-level promote command, such as Debian's
+					# "pg_ctlcluster". *IMPORTANT*: it is *not* a substitute
+					# for "promote_command"; do not use "repmgr standby promote"
+					# (or a script which executes "repmgr standby promote") here.
+
+# Used by "repmgr service (start|stop)" to control repmgrd
+#
+repmgrd_service_start_command = '/bin/sudo /usr/bin/systemctl start repmgr-{{ pg_version }}'
+repmgrd_service_stop_command = '/bin/sudo /usr/bin/systemctl stop repmgr-{{ pg_version }}'
+
+#------------------------------------------------------------------------------
+# Status check thresholds
+#------------------------------------------------------------------------------
+
+# Various warning/critical thresholds used by "repmgr node check".
+
+#archive_ready_warning=16		# repmgr node check --archive-ready
+#archive_ready_critical=128		#
+					# Numbers of files pending archiving via PostgreSQL's
+					# "archive_command" configuration parameter. If
+					# files can't be archived fast enough, or the archive
+					# command is failing, the buildup of files can
+					# cause various issues, such as server shutdown being
+					# delayed until all files are archived, or excessive
+					# space being occupied by unarchived files.
+					#
+					# Note that these values will be checked when executing
+					# "repmgr standby switchover" to warn about potential
+					# issues with shutting down the demotion candidate.
+
+#replication_lag_warning=300		# repmgr node check --replication-lag
+#replication_lag_critical=600		#
+					# Note that these values will be checked when executing
+					# "repmgr standby switchover" to warn about potential
+					# issues with shutting down the demotion candidate.

--- a/roles/setup_repmgr/templates/sudoers.d.repmgr.conf.j2
+++ b/roles/setup_repmgr/templates/sudoers.d.repmgr.conf.j2
@@ -1,0 +1,7 @@
+Defaults:{{ pg_owner }} !requiretty
+{{ pg_owner }} ALL = NOPASSWD: /usr/bin/systemctl stop {{ pg_service }}, \
+	/usr/bin/systemctl start {{ pg_service }}, \
+	/usr/bin/systemctl restart {{ pg_service }}, \
+	/usr/bin/systemctl reload {{ pg_service }}, \
+	/usr/bin/systemctl start repmgr-{{ pg_version }}, \
+	/usr/bin/systemctl stop repmgr-{{ pg_version }}

--- a/roles/setup_repmgr/vars/PG_Debian.yml
+++ b/roles/setup_repmgr/vars/PG_Debian.yml
@@ -1,0 +1,17 @@
+---
+repmgr_package_name: "postgresql-14-repmgr"
+repmgrd_service: repmgrd
+repmgr_configuration_file: "/etc/repmgr.conf"
+
+# Database variables
+pg_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"
+pg_bin_path: "/usr/lib/postgresql/{{ pg_version }}/bin"
+pg_ssl: true
+pg_owner: "postgres"
+pg_group: "postgres"
+pg_database: "postgres"
+pg_unix_socket_directories:
+  - "/var/run/postgresql"
+pg_port: 5432
+pg_service: "postgresql@{{ pg_version }}-{{ pg_instance_name }}"
+pg_user_home: "/var/lib/postgresql"

--- a/roles/setup_repmgr/vars/PG_RedHat.yml
+++ b/roles/setup_repmgr/vars/PG_RedHat.yml
@@ -1,0 +1,17 @@
+---
+repmgr_package_name: "repmgr_{{ pg_version }}"
+repmgrd_service: "repmgr-{{ pg_version }}"
+repmgr_configuration_file: "/etc/repmgr/{{ pg_version }}/repmgr-{{ pg_instance_name }}.conf"
+
+# Database variables
+pg_data: "/var/lib/pgsql/{{ pg_version }}/{{ pg_instance_name }}/data"
+pg_bin_path: "/usr/pgsql-{{ pg_version }}/bin"
+pg_ssl: true
+pg_owner: "postgres"
+pg_group: "postgres"
+pg_database: "postgres"
+pg_unix_socket_directories:
+  - "/var/run/postgresql"
+pg_port: 5432
+pg_service: "{{ lookup('edb_devops.edb_postgres.pg_service') }}"
+pg_user_home: "/var/lib/pgsql"


### PR DESCRIPTION
This commit introduces repmgr deployment support.

Automatic failover and repmgrd daemon setup are enabled by
default.

The following architectures are supported:
- 1 primary node, N standby nodes
- 1 primary node, N standby nodes, M witness nodes

Only PostgreSQL on CentOS/Redhat 8 and Debian 10 are supported so
far. Repmgr packages for EPAS on CentOS/Redhat are currently broken,
EPAS support will be added once the packages are fixed.

pgpool2 and barman integration will be implemented later.