### PR TITLE
Update dbt2 packages to install

### DIFF
--- a/roles/setup_dbt2/tasks/install_packages_client.yml
+++ b/roles/setup_dbt2/tasks/install_packages_client.yml
@@ -4,7 +4,9 @@
   dnf:
     name:
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-client-{{ dbt2_version }}-1.el8.x86_64.rpm'
+      - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-db-{{ dbt2_version }}-1.el8.x86_64.rpm'
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-scripts-{{ dbt2_version }}-1.el8.x86_64.rpm'
+      - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-pgsql-plpgsql_{{ pg_version }}-{{ dbt2_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: yes
   become: yes

--- a/roles/setup_dbt2/tasks/install_packages_db.yml
+++ b/roles/setup_dbt2/tasks/install_packages_db.yml
@@ -3,7 +3,8 @@
 - name: Install packages for DBT-2 Database
   dnf:
     name:
-      - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-pgsql_{{ pg_version }}-{{ dbt2_version }}-1.el8.x86_64.rpm'
+      - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-pgsql-c_{{ pg_version }}-{{ dbt2_version }}-1.el8.x86_64.rpm'
+      - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-db-{{ dbt2_version }}-1.el8.x86_64.rpm'
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-scripts-{{ dbt2_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: yes


### PR DESCRIPTION
Reflecting recent packaging changes such that C and pl/pgsql stored
functions have been separated.

The database node only needs to have the C stored functions.  While it
is possible to use the pl/pgsql stored functions, these playbooks are
currently designed to simplify options and use recommended
configurations.

The client node will now always install the data generator and pl/pgsql
stored functions in the event that it is used against a DBaaS option.