### PR TITLE
Prevent Postgres service hanging when stopping it

### DIFF
--- a/roles/init_dbserver/tasks/pg_setup_systemd.yml
+++ b/roles/init_dbserver/tasks/pg_setup_systemd.yml
@@ -27,5 +27,8 @@
     - line: "PIDFile={{ pg_default_data }}/postmaster.pid"
       regexp: "^PIDFile=.*"
       insertafter: "^\\[Service\\]$"
+    - line: "ExecStopPost=+/usr/bin/systemctl daemon-reload"
+      regexp: "^ExecStopPost=.*"
+      insertafter: "^\\[Service\\]$"
   when:
     - ansible_distribution in ['RedHat', 'CentOS', 'Rocky']


### PR DESCRIPTION
This bug has been found on RockyLinux 8.4/8.5 with systemd 239.
Working around this issue consist in executing systemctl
daemon-reload right after the systemctl stop command.