### PR TITLE
Don't configure access to EDB package repo.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,12 +1,52 @@
-name: ansible-lint
+name: edb-ansible testing
 
 on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: ansible-lint
+    name: Execute ansible-lint
     steps:
       - uses: actions/checkout@v2
       - run: |
           docker run --rm -v $(pwd):/data cytopia/ansible-lint playbook.yml
+  setup-repo:
+    runs-on: ubuntu-latest
+    name: Execute setup_repo tests for PostgreSQL 14 on RockyLinux8
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install ansible -y
+      - run: make
+      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_repo rocky8
+  install-dbserver:
+    runs-on: ubuntu-latest
+    name: Execute install_dbserver tests for PostgreSQL 14 on RockyLinux8
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install ansible -y
+      - run: make
+      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/install_dbserver rocky8
+  initdb-dbserver:
+    runs-on: ubuntu-latest
+    name: Execute init_dbserver tests for PostgreSQL 14 on RockyLinux8
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install ansible -y
+      - run: make
+      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/init_dbserver rocky8
+  setup-replication:
+    runs-on: ubuntu-latest
+    name: Execute setup_replication tests for PostgreSQL 14 on RockyLinux8
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install ansible -y
+      - run: make
+      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_replication rocky8
+  manage-dbserver:
+    runs-on: ubuntu-latest
+    name: Execute manage_dbserver tests for PostgreSQL 14 on RockyLinux8
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install ansible -y
+      - run: make
+      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/manage_dbserver rocky8

--- a/README.md
+++ b/README.md
@@ -339,8 +339,8 @@ playbook:
       set_fact:
         pg_version: 13
         pg_type: "PG"
-        repo_username: ""
-        repo_password: ""
+        repo_username: "<edb-package-repository-username>"
+        repo_password: "<edb-package-repository-password>"
         disable_logging: false
 
   roles:
@@ -378,6 +378,18 @@ playbook:
 
 You can customize the above example to install Postgres, EPAS, EFM or PEM or
 limit what roles you would like to execute.
+
+### Access to EDB's package repository
+
+By default, the `setup_repo` role requires to define the credentials (variables
+`repo_username` and `repo_password`) that will be used to configure the access
+to EDB's package repository. Having access to EDB package repository is
+necessary to deploy EDB softwares like EPAS, EFM or PEM.
+
+When deploying softwares coming only from the community repository (PGDG) like
+PostgreSQL, barman or pgbouncer, it's not needed to configure access to EDB's
+repository. To disable it, the variable `enable_edb_repo` must be set to
+`false`.
 
 ## Default user and passwords
 

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -6,6 +6,7 @@
 # After 06/23/2020 - Redesigned EDB Portal
 
 # EDB repository username, password and subscription token
+enable_edb_repo: true
 repo_username: ""
 repo_password: ""
 tpa_subscription_token: ""

--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -11,6 +11,7 @@
     state: present
   when:
     - ansible_distribution_major_version == "8"
+    - enable_edb_repo|bool
   become: yes
 
 - name: Download PGDG GPG key for CentOS8/RHEL8
@@ -67,6 +68,7 @@
     name: "{{ edb_rpm_repo }}"
     state: present
   become: yes
+  when: enable_edb_repo|bool
 
 - name: Set Credentials for EDB Yum Repo
   replace:
@@ -74,6 +76,7 @@
     regexp: '<username>:<password>'
     replace: "{{ repo_username }}:{{ repo_password }}"
   become: yes
+  when: enable_edb_repo|bool
 
 - name: Add additional Redhat repositories
   ansible.builtin.yum_repository:

--- a/roles/setup_repo/tasks/setup_repo.yml
+++ b/roles/setup_repo/tasks/setup_repo.yml
@@ -28,7 +28,7 @@
 - name: Validate Credentials
   fail:
       msg: "repo_username = {{ repo_username }} or repo_password = {{ repo_password }} are not valid!."
-  when: (repo_username | length < 1 or repo_password | length < 1)
+  when: enable_edb_repo|bool and (repo_username | length < 1 or repo_password | length < 1)
 
 - name: Capture if bdr_nodes_ips if defined
   set_fact:

--- a/tests/Makefile.mk
+++ b/tests/Makefile.mk
@@ -7,7 +7,7 @@ post-build:
 	python3 ../../scripts/build-inventory.py --compose-dir .
 	python3 ../../scripts/ssh-build-add-hosts-sh.py --compose-dir . --ssh-dir .ssh
 	python3 ../../scripts/ssh-build-ssh-config.py --ssh-dir .ssh
-	
+
 centos7: export EDB_OS=centos7
 rocky8: export EDB_OS=rocky8
 debian9: export EDB_OS=debian9

--- a/tests/cases/init_dbserver/docker-compose.yml
+++ b/tests/cases/init_dbserver/docker-compose.yml
@@ -6,8 +6,9 @@ services:
       context: ../../docker
       dockerfile: Dockerfile.ansible-tester
     environment:
-    - EDB_REPO_USERNAME
-    - EDB_REPO_PASSWORD
+    - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
+    - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION
     - CASE_NAME=init_dbserver
@@ -16,6 +17,8 @@ services:
     - ../../..:/workspace
     command: "/workspace/tests/docker/exec-tests.sh"
   primary1-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
     build:
       context: ../../docker
       dockerfile: Dockerfile.rocky8

--- a/tests/cases/install_dbserver/docker-compose.yml
+++ b/tests/cases/install_dbserver/docker-compose.yml
@@ -6,8 +6,9 @@ services:
       context: ../../docker
       dockerfile: Dockerfile.ansible-tester
     environment:
-    - EDB_REPO_USERNAME
-    - EDB_REPO_PASSWORD
+    - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
+    - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION
     - CASE_NAME=install_dbserver
@@ -16,6 +17,8 @@ services:
     - ../../..:/workspace
     command: "/workspace/tests/docker/exec-tests.sh"
   primary1-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
     build:
       context: ../../docker
       dockerfile: Dockerfile.rocky8

--- a/tests/cases/manage_dbserver/docker-compose.yml
+++ b/tests/cases/manage_dbserver/docker-compose.yml
@@ -6,8 +6,9 @@ services:
       context: ../../docker
       dockerfile: Dockerfile.ansible-tester
     environment:
-    - EDB_REPO_USERNAME
-    - EDB_REPO_PASSWORD
+    - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
+    - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION
     - CASE_NAME=manage_dbserver
@@ -16,6 +17,8 @@ services:
     - ../../..:/workspace
     command: "/workspace/tests/docker/exec-tests.sh"
   primary1-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
     build:
       context: ../../docker
       dockerfile: Dockerfile.rocky8

--- a/tests/cases/setup_replication/docker-compose.yml
+++ b/tests/cases/setup_replication/docker-compose.yml
@@ -6,8 +6,9 @@ services:
       context: ../../docker
       dockerfile: Dockerfile.ansible-tester
     environment:
-    - EDB_REPO_USERNAME
-    - EDB_REPO_PASSWORD
+    - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
+    - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION
     - CASE_NAME=setup_replication
@@ -16,6 +17,8 @@ services:
     - ../../..:/workspace
     command: "/workspace/tests/docker/exec-tests.sh"
   primary1-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
     build:
       context: ../../docker
       dockerfile: Dockerfile.rocky8
@@ -26,6 +29,8 @@ services:
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
   standby1-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
     build:
       context: ../../docker
       dockerfile: Dockerfile.rocky8
@@ -36,6 +41,8 @@ services:
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
   standby2-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
     build:
       context: ../../docker
       dockerfile: Dockerfile.rocky8

--- a/tests/cases/setup_repo/docker-compose.yml
+++ b/tests/cases/setup_repo/docker-compose.yml
@@ -6,16 +6,19 @@ services:
       context: ../../docker
       dockerfile: Dockerfile.ansible-tester
     environment:
-    - EDB_REPO_USERNAME
-    - EDB_REPO_PASSWORD
-    - EDB_PG_TYPE
-    - EDB_PG_VERSION
-    - EDB_OS
-    - CASE_NAME=setup_repo
+      - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
+      - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+      - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
+      - EDB_PG_TYPE
+      - EDB_PG_VERSION
+      - EDB_OS
+      - CASE_NAME=setup_repo
     volumes:
     - ../../..:/workspace
     command: "/workspace/tests/docker/exec-tests.sh"
   primary1-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
     build:
       context: ../../docker
       dockerfile: Dockerfile.rocky8

--- a/tests/docker/exec-tests.sh
+++ b/tests/docker/exec-tests.sh
@@ -11,6 +11,7 @@ ANSIBLE_PIPELINING=1 ansible-playbook \
 	-i /workspace/tests/cases/${CASE_NAME}/inventory.yml \
 	--extra-vars "repo_username=${EDB_REPO_USERNAME}" \
 	--extra-vars "repo_password=${EDB_REPO_PASSWORD}" \
+	--extra-vars "enable_edb_repo=${EDB_ENABLE_REPO}" \
 	--extra-vars "pg_type=${EDB_PG_TYPE}" \
 	--extra-vars "pg_version=${EDB_PG_VERSION}" \
 	--extra-vars "@/workspace/tests/cases/${CASE_NAME}/vars.json" \

--- a/tests/scripts/build-inventory.py
+++ b/tests/scripts/build-inventory.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
         container = docker.DockerOSContainer(c['ID'], os)
         inventory_vars["%s_ip" % inventory_name] = container.ip()
 
-    templates_dir = env.compose_dir
+    templates_dir = str(env.compose_dir)
     file_loader = FileSystemLoader(templates_dir)
     jenv = Environment(loader=file_loader, trim_blocks=True)
     template = jenv.get_template('inventory.yml.j2')

--- a/tests/test-runner.py
+++ b/tests/test-runner.py
@@ -46,7 +46,8 @@ def load_configuration(configuration):
 
 
 def exec_test_case(case_name, case_config, edb_repo_username,
-                   edb_repo_password, pg_version_list, pg_type_list, os_list):
+                   edb_repo_password, pg_version_list, pg_type_list, os_list,
+                   edb_enable_repo):
     n_success = 0
     n_executed = 0
     for os in case_config['os']:
@@ -67,7 +68,8 @@ def exec_test_case(case_name, case_config, edb_repo_username,
                     edb_repo_password,
                     os,
                     pg_type,
-                    pg_version
+                    pg_version,
+                    edb_enable_repo,
                 )
                 n_executed += 1
                 if success:
@@ -76,11 +78,12 @@ def exec_test_case(case_name, case_config, edb_repo_username,
 
 
 def exec_test(case_name, edb_repo_username, edb_repo_password, os, pg_type,
-              pg_version):
+              pg_version, edb_enable_repo):
     env = os_.environ.copy()
     env.update({
         'EDB_REPO_USERNAME': edb_repo_username,
         'EDB_REPO_PASSWORD': edb_repo_password,
+        'EDB_ENABLE_REPO': edb_enable_repo,
         'EDB_PG_VERSION': pg_version,
         'EDB_PG_TYPE': pg_type,
     })
@@ -170,15 +173,22 @@ if __name__ == '__main__':
         '--edb-repo-username',
         dest='edb_repo_username',
         type=str,
+        default='',
         help="EDB package repository username",
-        required=True,
     )
     parser.add_argument(
         '--edb-repo-password',
         dest='edb_repo_password',
         type=str,
+        default='',
         help="EDB package repository password",
-        required=True,
+    )
+    parser.add_argument(
+        '--edb-enable-repo',
+        dest='edb_enable_repo',
+        choices=['true', 'false'],
+        default='true',
+        help="Use EDB package repository",
     )
     parser.add_argument(
         '--pg-version',
@@ -231,7 +241,7 @@ if __name__ == '__main__':
 
         test_cases.append(
             (name, config, env.edb_repo_username, env.edb_repo_password,
-             env.pg_version, env.pg_type, env.os)
+             env.pg_version, env.pg_type, env.os, env.edb_enable_repo)
         )
 
 

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -16,6 +16,8 @@ EDB_INVENTORY = os.getenv('EDB_INVENTORY')
 EDB_PG_VERSION = os.getenv('EDB_PG_VERSION')
 # Postgres type
 EDB_PG_TYPE = os.getenv('EDB_PG_TYPE')
+# Use EDB repo
+EDB_ENABLE_REPO = (os.getenv('EDB_ENABLE_REPO').lower() in ['true', '1'])
 # SSH parameters
 EDB_SSH_USER = os.getenv('EDB_SSH_USER', 'root')
 EDB_SSH_KEY = os.getenv('EDB_SSH_KEY', '../.ssh/id_rsa')

--- a/tests/tests/test_setup_repo.py
+++ b/tests/tests/test_setup_repo.py
@@ -6,9 +6,13 @@ from conftest import (
     get_os,
     get_pg_type,
     get_primary,
+    EDB_ENABLE_REPO,
 )
 
 def test_setup_repo_edb_centos():
+    if not EDB_ENABLE_REPO:
+        pytest.skip()
+
     if not get_os().startswith('centos') and not get_os().startswith('rocky'):
         pytest.skip()
 
@@ -34,6 +38,9 @@ def test_setup_repo_pgdg_centos():
         "Access to the PGDG package repository not configured"
 
 def test_setup_repo_edb_debian():
+    if not EDB_ENABLE_REPO:
+        pytest.skip()
+
     if not (get_os().startswith('debian') or get_os().startswith('ubuntu')):
         pytest.skip()
 


### PR DESCRIPTION
When the variable enable_edb_repo is set to false.

This commit adds new github actions executing the test we currently
have on every git push. This is now possible because using EDB
credentials is not required anymore when deploying software coming
from the community package repository.