### PR TITLE
Adding edb_audit_directory as a parameter

### DIFF
--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -21,6 +21,7 @@ pass_dir: "~/.edb"
 pg_wal: ""
 pg_data: "/var/lib/pgsql/{{ pg_version }}/data"
 pg_default_data: "/var/lib/pgsql/{{ pg_version }}/data"
+edb_audit_directory: ""
 pg_encoding: ""
 
 # log directory and filename

--- a/roles/init_dbserver/tasks/create_directories.yml
+++ b/roles/init_dbserver/tasks/create_directories.yml
@@ -25,7 +25,7 @@
     mode: 0700
     state: directory
   become: yes
-  when: pg_log|length > 0 and not pg_data in pg_log
+  when: pg_log|length > 0 and pg_data not in pg_log
 
 - name: Ensure postgres wal directory exists
   file:
@@ -35,7 +35,7 @@
     mode: 0700
     state: directory
   become: yes
-  when: pg_wal|length > 0 and not pg_data in pg_wal
+  when: pg_wal|length > 0 and pg_data not in pg_wal
 
 - name: Create unix socket domain directories
   file:
@@ -49,6 +49,18 @@
     loop_var: line_item
   become: yes
   when: pg_unix_socket_directories|length > 0
+
+- name: Create edb_audit_directory if defined
+  file:
+    path: "{{ edb_audit_directory }}"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: 0700
+    state: directory
+  become: yes
+  when: >
+    edb_audit_directory|length > 0 and pg_data not in edb_audit_directory
+    and edb_audit_directory.startswith('/')
 
 - name: Create hidden edb directory if not exists
   file:

--- a/roles/init_dbserver/tasks/pg_initdb.yml
+++ b/roles/init_dbserver/tasks/pg_initdb.yml
@@ -5,7 +5,7 @@
   become: yes
   register: pg_version_stat
 
-- name: Verify pg_wal and accordingly add the in the initdb
+- name: Verify pg_wal and accordingly add in initdb
   set_fact:
     pg_initdb_options: "{{ pg_initdb_options + ' --waldir=' + pg_wal }}"
   when: pg_wal|length > 0  and not pg_data in pg_wal

--- a/roles/init_dbserver/tasks/rm_initdb.yml
+++ b/roles/init_dbserver/tasks/rm_initdb.yml
@@ -6,6 +6,7 @@
   systemd:
     name: "{{ efm_service }}"
     state: stopped
+    enabled: false
   when:
     - ansible_facts.services[efm_service] is defined
     - ansible_facts.services[efm_service].state == 'running'
@@ -15,6 +16,7 @@
   systemd:
     name: "{{ pg_service }}"
     state: stopped
+    enabled: false
   when:
     - ansible_facts.services[pg_service] is defined
     - ansible_facts.services[pg_service].state == 'running'

--- a/roles/init_dbserver/templates/postgresql.conf.template
+++ b/roles/init_dbserver/templates/postgresql.conf.template
@@ -10,6 +10,9 @@ max_replication_slots = 10
 wal_compression = on
 wal_log_hints = on
 {{ 'wal_keep_segments = 10' if pg_version is version('13','<') else 'wal_keep_size = 160' }}
+{% if edb_audit_directory|length > 0 and pg_data not in edb_audit_directory and edb_audit_directory.startswith('/') %}
+edb_audit_directory = '{{ edb_audit_directory }}'
+{% endif %}
 checkpoint_timeout = 15min
 password_encryption = 'scram-sha-256'
 checkpoint_completion_target = 0.9

--- a/roles/setup_efm/defaults/main.yml
+++ b/roles/setup_efm/defaults/main.yml
@@ -2,7 +2,7 @@
 # efm credentials
 os: ""
 pg_version: ""
-efm_version: 4.2
+efm_version: 4.4
 
 pg_instance_name: main
 disable_logging: true
@@ -106,6 +106,8 @@ supported_pg_version:
   - 14
 
 supported_efm_version:
+  - "4.4"
+  - "4.3"
   - "4.2"
   - "4.1"
   - "4.0"

--- a/roles/setup_efm/tasks/rm_efm_install_config.yml
+++ b/roles/setup_efm/tasks/rm_efm_install_config.yml
@@ -3,6 +3,9 @@
   systemd:
     name: "{{ efm_service }}"
     state: stopped
+  when:
+      - ansible_facts.services[efm_service + '.service'] is defined
+      - ansible_facts.services[efm_service + '.service']['state'] != 'running'
   become: yes
 
 - name: Remove EFM properties File

--- a/roles/setup_pemagent/defaults/main.yml
+++ b/roles/setup_pemagent/defaults/main.yml
@@ -13,7 +13,7 @@ pg_ssl: true
 
 pem_server_exists: false
 # efm information
-efm_version: "4.2"
+efm_version: "4.4"
 efm_bin_path: "/usr/edb/efm-{{ efm_version }}/bin"
 efm_cluster_name: "{{ pg_instance_name }}"
 

--- a/roles/setup_pemserver/defaults/main.yml
+++ b/roles/setup_pemserver/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 pg_instance_name: main
-pg_version: "12"
+pg_version: "14"
 use_hostname: true
 pem_agent: false
 pass_dir: "~/.edb"
@@ -11,7 +11,7 @@ pg_pem_admin_password: ""
 pg_ssl: true
 
 # efm information
-efm_version: "4.2"
+efm_version: "4.4"
 efm_bin_path: "/usr/edb/efm-{{ efm_version }}/bin"
 efm_cluster_name: "efm"
 

--- a/roles/setup_replication/defaults/main.yml
+++ b/roles/setup_replication/defaults/main.yml
@@ -32,6 +32,7 @@ standby_physical_slots: []
 etc_hosts_lists: []
 upstream_public_ip: ""
 upstream_hostname: ""
+edb_audit_directory: ""
 
 supported_os:
   - CentOS7

--- a/roles/setup_replication/tasks/create_directories.yml
+++ b/roles/setup_replication/tasks/create_directories.yml
@@ -49,7 +49,7 @@
     mode: 0700
     state: directory
   become: yes
-  when: pg_log|length > 0 and not pg_data in pg_log
+  when: pg_log|length > 0 and pg_data not in pg_log
 
 - name: Ensure postgres wal directory exists
   file:
@@ -59,7 +59,7 @@
     mode: 0700
     state: directory
   become: yes
-  when: pg_wal|length > 0 and not pg_data in pg_wal
+  when: pg_wal|length > 0 and pg_data not in pg_wal
 
 - name: Create unix socket domain directories
   file:
@@ -95,6 +95,18 @@
     - pg_default_data != pg_data
     - not sym.stat.islnk
   become: yes
+
+- name: Create edb_audit_directory if defined
+  file:
+    path: "{{ edb_audit_directory }}"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: 0700
+    state: directory
+  become: yes
+  when: >
+    edb_audit_directory|length > 0 and pg_data not in edb_audit_directory
+    and edb_audit_directory.startswith('/')
 
 - name: Ensure pg_data has symlink to default if pg_data is not default
   file:


### PR DESCRIPTION
This PR allows users to use edb_audit_directory as a parameter and can be declared in a playbook.