### PR TITLE
setup_repo testing framework update

### DIFF
--- a/tests/tests/test_setup_repo.py
+++ b/tests/tests/test_setup_repo.py
@@ -34,7 +34,7 @@ def test_setup_repo_pgdg_centos():
     cmd = host.run("yum repolist")
     assert cmd.succeeded, \
         "Unable to list the package repository list on %s" % host
-    assert "PostgreSQL common RPMs for RHEL/CentOS" in cmd.stdout, \
+    assert "PostgreSQL common RPMs for RHEL / Rocky 8" in cmd.stdout, \
         "Access to the PGDG package repository not configured"
 
 def test_setup_repo_edb_debian():


### PR DESCRIPTION
yum repolist no longer lists "PostgreSQL common RPMs for RHEL/CentOS" and instead lists "PostgreSQL common RPMs for RHEL / Rocky 8"