### PR TITLE
Cast use_hostname to bool

### DIFF
--- a/roles/init_dbserver/tasks/init_dbserver.yml
+++ b/roles/init_dbserver/tasks/init_dbserver.yml
@@ -48,7 +48,7 @@
   block:
     - import_tasks: linux_update_etc_hosts.yml
   become: yes
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Check and configure the node as primary or pemserver
   block:

--- a/roles/setup_barman/tasks/configure_barman.yml
+++ b/roles/setup_barman/tasks/configure_barman.yml
@@ -17,12 +17,12 @@
 - name: Set _pg_host when not using hostname
   set_fact:
     _pg_host: "{{ hostvars[inventory_hostname].private_ip }}"
-  when: "not use_hostname"
+  when: "not use_hostname|bool"
 
 - name: Set _pg_host when using hostname
   set_fact:
     _pg_host: "{{ inventory_hostname }}"
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Ensure the barman configuration for the current host is present
   template:

--- a/roles/setup_barman/tasks/configure_pg_backup.yml
+++ b/roles/setup_barman/tasks/configure_pg_backup.yml
@@ -7,12 +7,12 @@
 - name: Set _barman_host when not using hostname
   set_fact:
     _barman_host: "{{ _barman_server_info[0].private_ip }}"
-  when: "not use_hostname"
+  when: "not use_hostname|bool"
 
 - name: Set _barman_host when using hostname
   set_fact:
     _barman_host: "{{ _barman_server_info[0].inventory_hostname }}"
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Ensure wal_level is configured to replica
   include_role:

--- a/roles/setup_barman/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_barman/tasks/exchange_ssh_keys.yml
@@ -18,13 +18,13 @@
   set_fact:
     _pg_host: "{{ hostvars[inventory_hostname].private_ip }}"
     _barman_host: "{{ _barman_server_info[0].private_ip }}"
-  when: "not use_hostname"
+  when: "not use_hostname|bool"
 
 - name: Set _pg_host and _barman_host when using hostname
   set_fact:
     _pg_host: "{{ inventory_hostname }}"
     _barman_host: "{{ _barman_server_info[0].inventory_hostname }}"
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Fetch barman server SSH public key
   slurp:

--- a/roles/setup_barman/tasks/post_configure_barman.yml
+++ b/roles/setup_barman/tasks/post_configure_barman.yml
@@ -17,12 +17,12 @@
 - name: Set _pg_host when not using hostname
   ansible.builtin.set_fact:
     _pg_host: "{{ hostvars[inventory_hostname].private_ip }}"
-  when: "not use_hostname"
+  when: "not use_hostname|bool"
 
 - name: Set _pg_host when using hostname
   ansible.builtin.set_fact:
     _pg_host: "{{ inventory_hostname }}"
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Add a crontab entry for barman backup at 00:00 every day
   ansible.builtin.lineinfile:

--- a/roles/setup_barman/tasks/setup_barman.yml
+++ b/roles/setup_barman/tasks/setup_barman.yml
@@ -32,7 +32,7 @@
   block:
     - import_tasks: linux_update_etc_hosts.yml
   become: yes
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Include the package installation tasks
   include_role:

--- a/roles/setup_barman/tasks/update_barman_pgpass.yml
+++ b/roles/setup_barman/tasks/update_barman_pgpass.yml
@@ -18,13 +18,13 @@
   set_fact:
     _pg_host: "{{ hostvars[inventory_hostname].private_ip }}"
   when:
-    - not use_hostname
+    - not use_hostname|bool
 
 - name: Set _pg_host when use_hostname is true
   set_fact:
     _pg_host: "{{ inventory_hostname }}"
   when:
-    - use_hostname
+    - use_hostname|bool
 
 - name: Ensure barman .pgpass file contains one entry for {{ ansible_host }}
   lineinfile:

--- a/roles/setup_barmanserver/tasks/setup_barmanserver.yml
+++ b/roles/setup_barmanserver/tasks/setup_barmanserver.yml
@@ -16,7 +16,7 @@
   block:
     - import_tasks: linux_update_etc_hosts.yml
   become: yes
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Include the user ans group creation tasks
   include_tasks: create_user.yml

--- a/roles/setup_efm/tasks/efm_configure.yml
+++ b/roles/setup_efm/tasks/efm_configure.yml
@@ -22,7 +22,7 @@
         - { name: bind.address, value: "{{ hostvars[inventory_hostname].private_ip }}:{{ efm_port }}"}
         - { name: application.name, value: "{{ inventory_hostname }}" }
         - { name: is.witness, value: "{{ efm_witness }}" }
-  when: not use_hostname
+  when: not use_hostname|bool
 
 - name: Prepare the necessary parameters
   set_fact:
@@ -31,7 +31,7 @@
         - { name: bind.address, value: "{{ inventory_hostname }}:{{ efm_port }}"}
         - { name: application.name, value: "{{ inventory_hostname }}" }
         - { name: is.witness, value: "{{ efm_witness }}" }
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Initialize efm_lb_parameters
   set_fact:

--- a/roles/setup_efm/tasks/efm_pgpool2_integration.yml
+++ b/roles/setup_efm/tasks/efm_pgpool2_integration.yml
@@ -35,7 +35,7 @@
   run_once: true
   no_log: "{{ disable_logging }}"
   when:
-    - not use_hostname
+    - not use_hostname|bool
 
 - name: Prepare pgpool2_nodes when use_hostname
   set_fact:
@@ -46,7 +46,7 @@
   run_once: true
   no_log: "{{ disable_logging }}"
   when:
-    - use_hostname
+    - use_hostname|bool
 
 - name: Copy the pcp_control.sh to the server
   template:

--- a/roles/setup_efm/tasks/setup_efm.yml
+++ b/roles/setup_efm/tasks/setup_efm.yml
@@ -87,7 +87,7 @@
   loop: "{{ efm_cluster_nodes }}"
   loop_control:
     loop_var: node
-  when: use_hostname
+  when: use_hostname|bool
   run_once: true
   no_log: "{{ disable_logging }}"
 
@@ -95,7 +95,7 @@
   set_fact:
     efm_nodes_list: "{{ efm_nodes_list + node.private_ip + ':' + efm_port | string + ' ' }}"
   when:
-    - not use_hostname
+    - not use_hostname|bool
   loop: "{{ efm_cluster_nodes }}"
   loop_control:
     loop_var: node
@@ -126,7 +126,7 @@
   block:
     - import_tasks: linux_update_etc_hosts.yml
   become: yes
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: EFM installation
   block:

--- a/roles/setup_pemagent/tasks/setup_pemagent.yml
+++ b/roles/setup_pemagent/tasks/setup_pemagent.yml
@@ -60,7 +60,7 @@
     - import_tasks: linux_update_etc_hosts.yml
   become: yes
   when:
-    - use_hostname
+    - use_hostname|bool
 
 - name: Configure pemagent and pemserver HBA
   block:

--- a/roles/setup_pemserver/tasks/setup_pemserver.yml
+++ b/roles/setup_pemserver/tasks/setup_pemserver.yml
@@ -42,7 +42,7 @@
     - import_tasks: linux_update_etc_hosts.yml
   become: yes
   when:
-    - use_hostname
+    - use_hostname|bool
 
 - name: Remove pem server based on force_pemserver/force_initdb
   block:

--- a/roles/setup_pgpool2/tasks/setup_pgpool2.yml
+++ b/roles/setup_pgpool2/tasks/setup_pgpool2.yml
@@ -56,13 +56,13 @@
   set_fact:
     _pgpool2_current_node: "{{ hostvars[inventory_hostname].private_ip }}"
   when:
-    - not use_hostname
+    - not use_hostname|bool
 
 - name: Set _pgpool2_current_node when use_hostname
   set_fact:
     _pgpool2_current_node: "{{ ansible_hostname }}"
   when:
-    - use_hostname
+    - use_hostname|bool
 
 - name: Build the list of Postgres backends when not use_hostname
   set_fact:
@@ -77,7 +77,7 @@
   loop_control:
     loop_var: server
   when:
-    - not use_hostname
+    - not use_hostname|bool
 
 - name: Build the list of Postgres backends when use_hostname
   set_fact:
@@ -92,7 +92,7 @@
   loop_control:
     loop_var: server
   when:
-    - use_hostname
+    - use_hostname|bool
 
 - name: Set the _pgpool2_primary_public_ip variable
   set_fact:
@@ -117,7 +117,7 @@
   loop_control:
     loop_var: server
   when:
-    - not use_hostname
+    - not use_hostname|bool
 
 - name: Build the list of pgpool2 nodes when use_hostname
   set_fact:
@@ -126,7 +126,7 @@
   loop_control:
     loop_var: server
   when:
-    - use_hostname
+    - use_hostname|bool
 
 - name: Include the pgpool2_install
   include_tasks: pgpool2_install.yml
@@ -141,7 +141,7 @@
   block:
     - import_tasks: linux_update_etc_hosts.yml
   become: yes
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Include the pgpool2_configure_backends
   include_tasks: pgpool2_configure_backends.yml

--- a/roles/setup_replication/tasks/pg_basebackup.yml
+++ b/roles/setup_replication/tasks/pg_basebackup.yml
@@ -22,14 +22,14 @@
   set_fact:
     pg_basebackup: "{{ pg_basebackup + ' --host=' + hostvars[inventory_hostname].upstream_node_private_ip + ' --port=' + pg_port | string }}"
   when:
-    - not use_hostname
+    - not use_hostname|bool
     - hostvars[inventory_hostname].upstream_node_private_ip is defined
 
 - name: Set host and port
   set_fact:
     pg_basebackup: "{{ pg_basebackup + ' --host=' + upstream_hostname + ' --port=' + pg_port | string }}"
   when:
-    - use_hostname
+    - use_hostname|bool
     - hostvars[inventory_hostname].upstream_node_private_ip is defined
 
 - name: Use other supplied options if given

--- a/roles/setup_replication/tasks/setup_replication.yml
+++ b/roles/setup_replication/tasks/setup_replication.yml
@@ -79,7 +79,7 @@
     - import_tasks: linux_update_etc_hosts.yml
   become: yes
   no_log: "{{ disable_logging }}"
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Call upstream update based on the upstream node
   block:

--- a/roles/setup_replication/tasks/upstream_node.yml
+++ b/roles/setup_replication/tasks/upstream_node.yml
@@ -3,7 +3,7 @@
 - name: Get upstream node public ip
   set_fact:
     upstream_public_ip: "{{ node.ansible_host }}"
-    upstream_hostname: "{{ node.inventory_hostname if use_hostname else '' }}"
+    upstream_hostname: "{{ node.inventory_hostname if use_hostname|bool else '' }}"
   when:
     - hostvars[inventory_hostname].upstream_node_private_ip is defined
     - node.private_ip == hostvars[inventory_hostname].upstream_node_private_ip

--- a/roles/setup_replication/vars/EPAS_Debian.yml
+++ b/roles/setup_replication/vars/EPAS_Debian.yml
@@ -5,7 +5,6 @@ pg_log: "/var/log/edb"
 pg_wal: ""
 pg_log_filename: "{{ pg_instance_name }}-edb-%a.log"
 
-use_hostname: true
 primary_host_name: ""
 
 pg_owner: "enterprisedb"

--- a/roles/setup_replication/vars/EPAS_RedHat.yml
+++ b/roles/setup_replication/vars/EPAS_RedHat.yml
@@ -6,7 +6,6 @@ pg_wal: ""
 pg_log_filename: "{{ pg_instance_name }}-edb-%a.log"
 pg_systemd_global_unit_file: "/usr/lib/systemd/system/edb-as-{{ pg_version }}.service"
 
-use_hostname: true
 primary_host_name: ""
 
 pg_owner: "enterprisedb"

--- a/roles/setup_replication/vars/PG_Debian.yml
+++ b/roles/setup_replication/vars/PG_Debian.yml
@@ -5,7 +5,6 @@ pg_log: "/var/log/postgres"
 pg_wal: ""
 pg_log_filename: "{{ pg_instance_name }}-postgresql-%a.log"
 
-use_hostname: true
 primary_host_name: ""
 
 pg_owner: "postgres"

--- a/roles/setup_replication/vars/PG_RedHat.yml
+++ b/roles/setup_replication/vars/PG_RedHat.yml
@@ -6,7 +6,6 @@ pg_wal: ""
 pg_log_filename: "{{ pg_instance_name }}-postgresql-%a.log"
 pg_systemd_global_unit_file: "/usr/lib/systemd/system/postgresql-{{ pg_version }}.service"
 
-use_hostname: true
 primary_host_name: ""
 
 pg_owner: "postgres"

--- a/roles/setup_repmgr/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_repmgr/tasks/exchange_ssh_keys.yml
@@ -2,13 +2,13 @@
   ansible.builtin.set_fact:
     _local_host: "{{ local_node.inventory_hostname }}"
     _remote_host: "{{ remote_node.inventory_hostname }}"
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Set _local_host and _remote_host when not using hostname
   ansible.builtin.set_fact:
     _local_host: "{{ local_node.private_ip }}"
     _remote_host: "{{ remote_node.private_ip }}"
-  when: not use_hostname
+  when: not use_hostname|bool
 
 - name: Fetch remote server SSH public key
   ansible.builtin.slurp:

--- a/roles/setup_repmgr/tasks/setup_repmgr.yml
+++ b/roles/setup_repmgr/tasks/setup_repmgr.yml
@@ -36,7 +36,7 @@
 
 - name: Include linux_update_etc_hosts.yml
   ansible.builtin.include_tasks: linux_update_etc_hosts.yml
-  when: use_hostname
+  when: use_hostname|bool
 
 - name: Include repmgr_install.yml
   ansible.builtin.include_tasks: repmgr_install.yml

--- a/roles/setup_repmgr/templates/repmgr.conf.j2
+++ b/roles/setup_repmgr/templates/repmgr.conf.j2
@@ -32,7 +32,7 @@ node_name='{{ repmgr_node_info['inventory_hostname'] }}'			 # An arbitrary (but 
 				 # The string's maximum length is 63 characters and it should
 				 # contain only printable ASCII characters.
 
-conninfo='dbname={{ pg_repmgr_dbname }} user={{ pg_repmgr_user }} port={{ pg_port }} host={% if use_hostname %}{{ repmgr_node_info['inventory_hostname'] }}{% else %}{{ repmgr_node_info['private_ip'] }}{% endif %} connect_timeout=2'			 # Database connection information as a conninfo string.
+conninfo='dbname={{ pg_repmgr_dbname }} user={{ pg_repmgr_user }} port={{ pg_port }} host={% if use_hostname|bool %}{{ repmgr_node_info['inventory_hostname'] }}{% else %}{{ repmgr_node_info['private_ip'] }}{% endif %} connect_timeout=2'			 # Database connection information as a conninfo string.
 				 # All servers in the cluster must be able to connect to
 				 # the local node using this string.
 				 #


### PR DESCRIPTION
This is usually not necessary when use_hostname is defined in the
playbook file itself, or in an external json file. But, when
passing this boolean variable through the command line with:
-e 'use_hostname=false', in this case, the value is considered as
a string, then all the conditions based only on the value are true.

This fix may help in #306