### PR TITLE
Pg local wal archive dir

### DIFF
--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -19,6 +19,7 @@ use_hostname: true
 pass_dir: "~/.edb"
 
 pg_wal: ""
+pg_local_wal_archive_dir: ""
 pg_data: "/var/lib/pgsql/{{ pg_version }}/data"
 pg_default_data: "/var/lib/pgsql/{{ pg_version }}/data"
 edb_audit_directory: ""

--- a/roles/init_dbserver/tasks/create_directories.yml
+++ b/roles/init_dbserver/tasks/create_directories.yml
@@ -37,6 +37,16 @@
   become: yes
   when: pg_wal|length > 0 and pg_data not in pg_wal
 
+- name: Ensure postgres local wal archive directory exists
+  file:
+    path: "{{ pg_local_wal_archive_dir }}"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: 0700
+    state: directory
+  become: yes
+  when: pg_local_wal_archive_dir|length > 0
+
 - name: Create unix socket domain directories
   file:
     path: "{{ line_item }}"

--- a/roles/init_dbserver/tasks/rm_initdb.yml
+++ b/roles/init_dbserver/tasks/rm_initdb.yml
@@ -35,9 +35,16 @@
   become: yes
   when: pg_log|length > 0
 
-- name: Remove postgres wal directory exists
+- name: Remove postgres wal directory if exists
   file:
     path: "{{ pg_wal }}"
     state: absent
   become: yes
   when: pg_wal|length > 0
+
+- name: remove postgres local wal archive directory if exists
+  file:
+    path: "{{ pg_local_wal_archive_dir }}"
+    state: absent
+  become: yes
+  when: pg_local_wal_archive_dir|length > 0

--- a/roles/init_dbserver/vars/EPAS_Debian.yml
+++ b/roles/init_dbserver/vars/EPAS_Debian.yml
@@ -1,5 +1,6 @@
 ---
 pg_wal: ""
+pg_local_wal_archive_dir: ""
 pg_data: "/var/lib/edb-as/{{ pg_version }}/{{ pg_instance_name }}"
 pg_default_data: "/var/lib/edb-as/{{ pg_version }}/{{ pg_instance_name }}"
 pg_encoding: ""

--- a/roles/init_dbserver/vars/EPAS_RedHat.yml
+++ b/roles/init_dbserver/vars/EPAS_RedHat.yml
@@ -1,5 +1,6 @@
 ---
 pg_wal: ""
+pg_local_wal_archive_dir: ""
 pg_data: "/var/lib/edb/as{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_default_data: "/var/lib/edb/as{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_encoding: ""

--- a/roles/init_dbserver/vars/PG_Debian.yml
+++ b/roles/init_dbserver/vars/PG_Debian.yml
@@ -1,5 +1,6 @@
 ---
 pg_wal: ""
+pg_local_wal_archive_dir: ""
 pg_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"
 pg_default_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"
 pg_encoding: ""

--- a/roles/init_dbserver/vars/PG_RedHat.yml
+++ b/roles/init_dbserver/vars/PG_RedHat.yml
@@ -1,5 +1,6 @@
 ---
 pg_wal: ""
+pg_local_wal_archive_dir: ""
 pg_data: "/var/lib/pgsql/{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_default_data: "/var/lib/pgsql/{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_encoding: ""

--- a/roles/setup_replication/tasks/create_directories.yml
+++ b/roles/setup_replication/tasks/create_directories.yml
@@ -61,6 +61,16 @@
   become: yes
   when: pg_wal|length > 0 and pg_data not in pg_wal
 
+- name: Ensure postgres local wal archive directory exists
+  file:
+    path: "{{ pg_local_wal_archive_dir }}"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: 0700
+    state: directory
+  become: yes
+  when: pg_local_wal_archive_dir|length > 0
+
 - name: Create unix socket domain directories
   file:
     path: "{{ line_item }}"

--- a/roles/setup_replication/tasks/rm_replication.yml
+++ b/roles/setup_replication/tasks/rm_replication.yml
@@ -43,9 +43,16 @@
   become: yes
   when: pg_log|length > 0
 
-- name: remove postgres wal directory exists
+- name: remove postgres wal directory if exists
   file:
     path: "{{ pg_wal }}"
     state: absent
   become: yes
   when: pg_wal|length > 0
+
+- name: remove postgres local wal archive directory if exists
+  file:
+    path: "{{ pg_local_wal_archive_dir }}"
+    state: absent
+  become: yes
+  when: pg_local_wal_archive_dir|length > 0

--- a/roles/setup_replication/vars/EPAS_Debian.yml
+++ b/roles/setup_replication/vars/EPAS_Debian.yml
@@ -3,6 +3,7 @@ pg_data: "/var/lib/edb-as/{{ pg_version }}/{{ pg_instance_name }}"
 pg_default_data: "/var/lib/edb-as/{{ pg_version }}/{{ pg_instance_name }}"
 pg_log: "/var/log/edb"
 pg_wal: ""
+pg_local_wal_archive_dir: ""
 pg_log_filename: "{{ pg_instance_name }}-edb-%a.log"
 
 primary_host_name: ""

--- a/roles/setup_replication/vars/EPAS_RedHat.yml
+++ b/roles/setup_replication/vars/EPAS_RedHat.yml
@@ -3,6 +3,7 @@ pg_data: "/var/lib/edb/as{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_default_data: "/var/lib/edb/as{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_log: "/var/log/edb"
 pg_wal: ""
+pg_local_wal_archive_dir: ""
 pg_log_filename: "{{ pg_instance_name }}-edb-%a.log"
 pg_systemd_global_unit_file: "/usr/lib/systemd/system/edb-as-{{ pg_version }}.service"
 

--- a/roles/setup_replication/vars/PG_Debian.yml
+++ b/roles/setup_replication/vars/PG_Debian.yml
@@ -3,6 +3,7 @@ pg_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"
 pg_default_data: "/var/lib/postgresql/{{ pg_version }}/{{ pg_instance_name }}"
 pg_log: "/var/log/postgres"
 pg_wal: ""
+pg_local_wal_archive_dir: ""
 pg_log_filename: "{{ pg_instance_name }}-postgresql-%a.log"
 
 primary_host_name: ""

--- a/roles/setup_replication/vars/PG_RedHat.yml
+++ b/roles/setup_replication/vars/PG_RedHat.yml
@@ -3,6 +3,7 @@ pg_data: "/var/lib/pgsql/{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_default_data: "/var/lib/pgsql/{{ pg_version }}/{{ pg_instance_name }}/data"
 pg_log: "/var/log/postgres"
 pg_wal: ""
+pg_local_wal_archive_dir: ""
 pg_log_filename: "{{ pg_instance_name }}-postgresql-%a.log"
 pg_systemd_global_unit_file: "/usr/lib/systemd/system/postgresql-{{ pg_version }}.service"
 

--- a/tests/cases/setup_replication/vars.json
+++ b/tests/cases/setup_replication/vars.json
@@ -1,5 +1,12 @@
 {
   "use_hostname": false,
   "pg_data": "/opt/pgdata",
-  "pg_wal": "/opt/pgwal"
+  "pg_wal": "/opt/pgwal",
+  "pg_local_wal_archive_dir": "/opt/wal_archive",
+  "pg_postgres_conf_params": [
+    {
+      "name": "archive_command",
+      "value": "test ! -f /opt/wal_archive/%f && cp %p /opt/wal_archive/%f"
+    }
+  ]
 }


### PR DESCRIPTION
This pull request includes the configuration of a local wal_archive with the parameter `pg_local_wal_archive_dir`. It is based on issue #322. The roles `initdb_server` and `setup_replication` have both tasks to create or remove the directory in the filesystem. In addition, the test case for `setup_replication` is extended to use the parameter.