### PR TITLE
Setup_hammerdb testing framework

### DIFF
--- a/tests/cases/setup_hammerdb/Makefile
+++ b/tests/cases/setup_hammerdb/Makefile
@@ -1,0 +1,5 @@
+include ../../Makefile.mk
+
+build-rocky8:
+	docker compose up primary1-rocky8 -d
+	docker compose up hammerdb1-rocky8 -d

--- a/tests/cases/setup_hammerdb/docker-compose.yml
+++ b/tests/cases/setup_hammerdb/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3'
+
+services:
+  ansible-tester:
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ansible-tester
+    environment:
+    - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
+    - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
+    - EDB_PG_TYPE
+    - EDB_PG_VERSION
+    - CASE_NAME=setup_hammerdb
+    - EDB_OS
+    volumes:
+    - ../../..:/workspace
+    command: "/workspace/tests/docker/exec-tests.sh"
+  primary1-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  hammerdb1-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init

--- a/tests/cases/setup_hammerdb/inventory.yml.j2
+++ b/tests/cases/setup_hammerdb/inventory.yml.j2
@@ -1,0 +1,13 @@
+---
+all:
+  children:
+    primary:
+      hosts:
+        primary1:
+          ansible_host: {{ inventory_vars['primary1_ip'] }}
+          private_ip: {{ inventory_vars['primary1_ip'] }}
+    hammerdbserver:
+      hosts:
+        hammerdb1:
+          ansible_host: {{ inventory_vars['hammerdb1_ip'] }}
+          private_ip: {{ inventory_vars['hammerdb1_ip'] }}

--- a/tests/cases/setup_hammerdb/playbook.yml
+++ b/tests/cases/setup_hammerdb/playbook.yml
@@ -1,0 +1,25 @@
+---
+- hosts: all
+  name: Postgres deployment playbook
+  become: yes
+  gather_facts: yes
+
+  collections:
+    - edb_devops.edb_postgres
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        disable_logging: false
+
+  roles:
+    - role: setup_repo
+      when: "'setup_repo' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: install_dbserver
+      when: "'install_dbserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: init_dbserver
+      when: "'init_dbserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: setup_hammerdbserver
+      when: "'setup_hammerdbserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: setup_hammerdb
+      when: "'setup_hammerdb' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"

--- a/tests/cases/setup_hammerdb/vars.json
+++ b/tests/cases/setup_hammerdb/vars.json
@@ -1,0 +1,12 @@
+{
+  "use_hostname": false,
+  "pg_data": "/opt/pgdata",
+  "pg_wal": "/opt/pgwal",
+  "hammerdb": "/root/HammerDB-3.3",
+  "hammerdb_version": "3.3",
+  "load-tproc-c": "/usr/local/bin/load-tproc-c",
+  "run-tproc-c": "/usr/local/bin/run-tproc-c",
+  "max_connections": "300",
+  "max_wal_size": "50GB",
+  "tshirt_size": "small"
+}

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -228,4 +228,16 @@ cases:
     - EPAS
     os:
     - rocky8
+  setup_hammerdb:
+    pg_version:
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    pg_type:
+    - PG
+    - EPAS
+    os:
+    - rocky8
 

--- a/tests/tests/test_setup_hammerdb.py
+++ b/tests/tests/test_setup_hammerdb.py
@@ -1,0 +1,72 @@
+import pytest
+import os
+
+from conftest import (
+    load_ansible_vars,
+    get_hosts,
+    get_os,
+    get_pg_version,
+    get_pg_type,
+    get_pg_unix_socket_dir,
+    get_primary,
+    get_hammerdb
+)
+
+def test_setup_hammerdb_load_tproc_c():
+    ansible_vars = load_ansible_vars()
+    load_tproc_c = ansible_vars['load-tproc-c']
+    host = get_hammerdb()[0]
+    
+    assert host.file(load_tproc_c).exists, \
+        "Load-TProc-C wasn't sucessfully installed"
+
+def test_setup_hammerdb_run_tproc_c():
+    ansible_vars = load_ansible_vars()
+    run_tproc_c = ansible_vars['run-tproc-c']
+    host = get_hammerdb()[0]
+    
+    assert host.file(run_tproc_c).exists, \
+        "Run-TProc-C wasn't sucessfully installed"
+
+def test_setup_hammerdb_max_connections():
+    ansible_vars = load_ansible_vars()
+    pg_user = 'postgres'
+    pg_group = 'postgres'
+    max_connections = ansible_vars['max_connections']
+
+
+    if get_pg_type() == 'EPAS':
+        pg_user = 'enterprisedb'
+        pg_group = 'enterprisedb'
+
+    host = get_primary()
+    socket_dir = get_pg_unix_socket_dir()
+    with host.sudo(pg_user):
+        query = "Show max_connections"
+        cmd = host.run('psql -At -h %s -c "%s" postgres' % (socket_dir, query))
+        result = cmd.stdout.strip()
+    
+    assert result == max_connections, \
+        "Max connections was not significantly configured."
+
+def test_setup_hammerdb_max_wal_size():
+    ansible_vars = load_ansible_vars()
+    pg_user = 'postgres'
+    pg_group = 'postgres'
+    max_wal_size = ansible_vars['max_wal_size']
+
+
+    if get_pg_type() == 'EPAS':
+        pg_user = 'enterprisedb'
+        pg_group = 'enterprisedb'
+
+    host = get_primary()
+    socket_dir = get_pg_unix_socket_dir()
+    with host.sudo(pg_user):
+        query = "Show max_wal_size"
+        cmd = host.run('psql -At -h %s -c "%s" postgres' % (socket_dir, query))
+        result = cmd.stdout.strip()
+    
+    assert result == max_wal_size, \
+        "Max wal size was not significantly configured."
+


### PR DESCRIPTION
Includes the following tests:

- load-tproc-c is installed in the correct path
- run-tproc-c is installed in the correct path
- max_connections matches the default max_connections
- max_wal_size matches the default max_wal_size 

Cannot be included in Github Action Workflow because setup_hammerdb (tshirt_size = small) assumes it has at least 32 GB of free memory. The default for docker is 8 GB. 