### PR TITLE
Only install sslutils packages when pg_ssl is enabled

### DIFF
--- a/roles/install_dbserver/defaults/main.yml
+++ b/roles/install_dbserver/defaults/main.yml
@@ -12,6 +12,7 @@ epas_service: "edb-as@{{ pg_version }}-main"
 pg_deb_drop_cluster: "/usr/bin/pg_dropcluster"
 deb_cluster_name: "main"
 pg_service: "postgresql@{{ pg_version }}-main"
+pg_ssl: true
 
 sysctl_params:
   - { "name": "kernel.core_pattern", "value": "/var/coredumps/core-%e-%p", "state": "present"}

--- a/roles/install_dbserver/tasks/EPAS_Debian_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_Debian_install.yml
@@ -13,7 +13,7 @@
       - edb-as{{ pg_version }}-server-sqlprotect
     state: present
     update_cache: yes
-  become: yes
+  become: true
   register: install_package
   when: >-
     pg_version|int < 14
@@ -32,7 +32,7 @@
       - edb-as{{ pg_version }}-server-edb-wait-states
     state: present
     update_cache: yes
-  become: yes
+  become: true
   register: install_package
   when: >-
     pg_version|int >= 14
@@ -42,7 +42,7 @@
     name:
       - edb-as{{ pg_version }}-server-sslutils
     state: present
-  become: yes
+  become: true
   when: pg_ssl
 
 - name: Install python-psycopg2
@@ -53,14 +53,14 @@
     state: present
     update_cache: yes
   when: os in ['Ubuntu18', 'Debian9', 'Debian10']
-  become: yes
+  become: true
 
 - name: Stop the service {{ epas_service }}
   systemd:
     name: "{{ epas_service }}"
     state: stopped
   when: install_package.changed
-  become: yes
+  become: true
 
 - name: Drop the default debian database
   shell: >
@@ -69,4 +69,4 @@
   register: drop_cluster
   changed_when: drop_cluster.rc == 0
   failed_when: drop_cluster.rc != 0
-  become: yes
+  become: true

--- a/roles/install_dbserver/tasks/EPAS_Debian_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_Debian_install.yml
@@ -8,14 +8,12 @@
       - edb-as{{ pg_version }}-server-core
       - edb-as{{ pg_version }}-server-edb-modules
       - edb-as{{ pg_version }}-server-client
-      - edb-as{{ pg_version }}-server-sslutils
       - edb-as{{ pg_version }}-server-indexadvisor
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
-      - edb-as{{ pg_version }}-server-sslutils
     state: present
     update_cache: yes
-  become: true
+  become: yes
   register: install_package
   when: >-
     pg_version|int < 14
@@ -28,18 +26,24 @@
       - edb-as{{ pg_version }}-server
       - edb-as{{ pg_version }}-server-core
       - edb-as{{ pg_version }}-server-client
-      - edb-as{{ pg_version }}-server-sslutils
       - edb-as{{ pg_version }}-server-indexadvisor
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
-      - edb-as{{ pg_version }}-server-sslutils
       - edb-as{{ pg_version }}-server-edb-wait-states
     state: present
     update_cache: yes
-  become: true
+  become: yes
   register: install_package
   when: >-
     pg_version|int >= 14
+
+- name: Install sslutils
+  package:
+    name:
+      - edb-as{{ pg_version }}-server-sslutils
+    state: present
+  become: yes
+  when: pg_ssl
 
 - name: Install python-psycopg2
   package:
@@ -49,14 +53,14 @@
     state: present
     update_cache: yes
   when: os in ['Ubuntu18', 'Debian9', 'Debian10']
-  become: true
+  become: yes
 
 - name: Stop the service {{ epas_service }}
   systemd:
     name: "{{ epas_service }}"
     state: stopped
   when: install_package.changed
-  become: true
+  become: yes
 
 - name: Drop the default debian database
   shell: >
@@ -65,4 +69,4 @@
   register: drop_cluster
   changed_when: drop_cluster.rc == 0
   failed_when: drop_cluster.rc != 0
-  become: true
+  become: yes

--- a/roles/install_dbserver/tasks/EPAS_Debian_rm_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_Debian_rm_install.yml
@@ -3,7 +3,7 @@
   systemd:
     name: "{{ epas_service }}"
     state: stopped
-  become: yes
+  become: true
 
 - name: Remove sslutils
   package:
@@ -11,7 +11,7 @@
       - edb-as{{ pg_version }}-server-sslutils
     state: absent
     update_cache: yes
-  become: yes
+  become: true
   when: pg_ssl
 
 - name: Remove EPAS Packages
@@ -28,7 +28,7 @@
       - edb-as{{ pg_version }}-server-sqlprotect
     state: absent
     update_cache: yes
-  become: yes
+  become: true
 
 - name: Remove python-psycopg2
   package:
@@ -38,4 +38,4 @@
     state: absent
     update_cache: yes
   when: os in ['Ubuntu18', 'Debian9']
-  become: yes
+  become: true

--- a/roles/install_dbserver/tasks/EPAS_Debian_rm_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_Debian_rm_install.yml
@@ -3,7 +3,16 @@
   systemd:
     name: "{{ epas_service }}"
     state: stopped
-  become: true
+  become: yes
+
+- name: Remove sslutils
+  package:
+    name:
+      - edb-as{{ pg_version }}-server-sslutils
+    state: absent
+    update_cache: yes
+  become: yes
+  when: pg_ssl
 
 - name: Remove EPAS Packages
   package:
@@ -14,14 +23,12 @@
       - edb-as{{ pg_version }}-server-core
       - edb-as{{ pg_version }}-server-edb-modules
       - edb-as{{ pg_version }}-server-client
-      - edb-as{{ pg_version }}-server-sslutils
       - edb-as{{ pg_version }}-server-indexadvisor
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
-      - edb-as{{ pg_version }}-server-sslutils
     state: absent
     update_cache: yes
-  become: true
+  become: yes
 
 - name: Remove python-psycopg2
   package:
@@ -31,4 +38,4 @@
     state: absent
     update_cache: yes
   when: os in ['Ubuntu18', 'Debian9']
-  become: true
+  become: yes

--- a/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
@@ -26,11 +26,9 @@
       - edb-as{{ pg_version }}-server-contrib
       - edb-as{{ pg_version }}-server-libs
       - edb-as{{ pg_version }}-server-client
-      - edb-as{{ pg_version }}-server-sslutils
       - edb-as{{ pg_version }}-server-indexadvisor
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
-      - edb-as{{ pg_version }}-server-sslutils
     state: present
   become: yes
   when: >-
@@ -46,11 +44,9 @@
       - edb-as{{ pg_version }}-server-libs
       - edb-as{{ pg_version }}-server-client
       - edb-as{{ pg_version }}-server-llvmjit
-      - edb-as{{ pg_version }}-server-sslutils
       - edb-as{{ pg_version }}-server-indexadvisor
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
-      - edb-as{{ pg_version }}-server-sslutils
     state: present
   become: yes
   when: >-
@@ -65,13 +61,19 @@
       - edb-as{{ pg_version }}-server-libs
       - edb-as{{ pg_version }}-server-client
       - edb-as{{ pg_version }}-server-llvmjit
-      - edb-as{{ pg_version }}-server-sslutils
       - edb-as{{ pg_version }}-server-indexadvisor
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
-      - edb-as{{ pg_version }}-server-sslutils
       - edb-as{{ pg_version }}-server-edb_wait_states
     state: present
   become: yes
   when: >-
     pg_version|int >= 14
+
+- name: Install sslutils
+  package:
+    name:
+      - edb-as{{ pg_version }}-server-sslutils
+    state: present
+  become: yes
+  when: pg_ssl

--- a/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
@@ -7,7 +7,7 @@
       - python-ipaddress
     state: present
   when: os in ['RedHat7','CentOS7']
-  become: yes
+  become: true
 
 - name: Install python packages
   package:
@@ -16,7 +16,7 @@
       - python3-psycopg2
     state: present
   when: os in ['RedHat8','CentOS8','Rocky8']
-  become: yes
+  become: true
 
 - name: "Install EPAS 10 packages"
   package:
@@ -30,7 +30,7 @@
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
     state: present
-  become: yes
+  become: true
   when: >-
     pg_version|int < 11
 
@@ -48,7 +48,7 @@
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
     state: present
-  become: yes
+  become: true
   when: >-
     pg_version|int > 10 and pg_version|int < 14
 
@@ -66,7 +66,7 @@
       - edb-as{{ pg_version }}-server-sqlprotect
       - edb-as{{ pg_version }}-server-edb_wait_states
     state: present
-  become: yes
+  become: true
   when: >-
     pg_version|int >= 14
 
@@ -75,5 +75,5 @@
     name:
       - edb-as{{ pg_version }}-server-sslutils
     state: present
-  become: yes
+  become: true
   when: pg_ssl

--- a/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
@@ -3,14 +3,14 @@
   systemd:
     name: "{{ epas_service }}"
     state: stopped
-  become: yes
+  become: true
 
 - name: Remove sslutils
   package:
     name:
       - edb-as{{ pg_version }}-server-sslutils
     state: absent
-  become: yes
+  become: true
   when: pg_ssl
 
 - name: Remove EPAS packages
@@ -27,7 +27,7 @@
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
     state: absent
-  become: yes
+  become: true
 
 - name: Remove python packages
   package:
@@ -36,7 +36,7 @@
       - python-psycopg2
     state: absent
   when: os in ['RedHat7','CentOS7']
-  become: yes
+  become: true
 
 - name: Remove python packages
   package:
@@ -45,5 +45,5 @@
       - python3-psycopg2
     state: absent
   when: os in ['RedHat8','CentOS8','Rocky8']
-  become: yes
+  become: true
 

--- a/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
@@ -3,7 +3,15 @@
   systemd:
     name: "{{ epas_service }}"
     state: stopped
-  become: true
+  become: yes
+
+- name: Remove sslutils
+  package:
+    name:
+      - edb-as{{ pg_version }}-server-sslutils
+    state: absent
+  become: yes
+  when: pg_ssl
 
 - name: Remove EPAS packages
   package:
@@ -15,11 +23,9 @@
       - edb-as{{ pg_version }}-server-libs
       - edb-as{{ pg_version }}-server-client
       - edb-as{{ pg_version }}-server-llvmjit
-      - edb-as{{ pg_version }}-server-sslutils
       - edb-as{{ pg_version }}-server-indexadvisor
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
-      - edb-as{{ pg_version }}-server-sslutils
     state: absent
   become: yes
 

--- a/roles/install_dbserver/tasks/PG_Debian_install.yml
+++ b/roles/install_dbserver/tasks/PG_Debian_install.yml
@@ -11,7 +11,7 @@
     state: present
     update_cache: yes
   register: install_package
-  become: yes
+  become: true
 
 - name: Install sslutils
   package:
@@ -19,7 +19,7 @@
       - postgresql-{{ pg_version }}-sslutils
     state: present
     update_cache: yes
-  become: yes
+  become: true
   when: pg_ssl
 
 - name: Install python-psycopg2
@@ -30,14 +30,14 @@
     state: present
     update_cache: yes
   when: os in ['Ubuntu18','Debian9', 'Debian10']
-  become: yes
+  become: true
 
 - name: Stop the service {{ pg_service }}
   systemd:
     name: "{{ pg_service }}"
     state: stopped
   when: install_package.changed
-  become: yes
+  become: true
 
 - name: Drop the default debian database
   shell: >
@@ -48,4 +48,4 @@
   register: drop_cluster
   changed_when: drop_cluster.rc == 0
   failed_when: drop_cluster.rc != 0
-  become: yes
+  become: true

--- a/roles/install_dbserver/tasks/PG_Debian_install.yml
+++ b/roles/install_dbserver/tasks/PG_Debian_install.yml
@@ -8,11 +8,19 @@
       - postgresql-{{ pg_version }}
       - postgresql-{{ pg_version }}
       - postgresql-server-dev-{{ pg_version }}
-      - postgresql-{{ pg_version }}-sslutils
     state: present
     update_cache: yes
   register: install_package
-  become: true
+  become: yes
+
+- name: Install sslutils
+  package:
+    name:
+      - postgresql-{{ pg_version }}-sslutils
+    state: present
+    update_cache: yes
+  become: yes
+  when: pg_ssl
 
 - name: Install python-psycopg2
   package:
@@ -22,14 +30,14 @@
     state: present
     update_cache: yes
   when: os in ['Ubuntu18','Debian9', 'Debian10']
-  become: true
+  become: yes
 
 - name: Stop the service {{ pg_service }}
   systemd:
     name: "{{ pg_service }}"
     state: stopped
   when: install_package.changed
-  become: true
+  become: yes
 
 - name: Drop the default debian database
   shell: >
@@ -40,4 +48,4 @@
   register: drop_cluster
   changed_when: drop_cluster.rc == 0
   failed_when: drop_cluster.rc != 0
-  become: true
+  become: yes

--- a/roles/install_dbserver/tasks/PG_Debian_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_Debian_rm_install.yml
@@ -3,7 +3,7 @@
   systemd:
     name: "{{ pg_service }}"
     state: stopped
-  become: yes
+  become: true
 
 - name: Remove postgreSQL
   package:
@@ -16,7 +16,7 @@
       - postgresql-server-dev-{{ pg_version }}
     state: absent
     update_cache: yes
-  become: yes
+  become: true
 
 - name: Remove sslutils
   package:
@@ -24,7 +24,7 @@
       - postgresql-{{ pg_version }}-sslutils
     state: absent
     update_cache: yes
-  become: yes
+  become: true
   when: pg_ssl
 
 - name: Remove python-psycopg2
@@ -35,4 +35,4 @@
     state: absent
     update_cache: yes
   when: os in ['Ubuntu18','Debian9', 'Debian10']
-  become: yes
+  become: true

--- a/roles/install_dbserver/tasks/PG_Debian_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_Debian_rm_install.yml
@@ -3,7 +3,7 @@
   systemd:
     name: "{{ pg_service }}"
     state: stopped
-  become: true
+  become: yes
 
 - name: Remove postgreSQL
   package:
@@ -14,10 +14,18 @@
       - postgresql-{{ pg_version }}
       - postgresql-{{ pg_version }}
       - postgresql-server-dev-{{ pg_version }}
+    state: absent
+    update_cache: yes
+  become: yes
+
+- name: Remove sslutils
+  package:
+    name:
       - postgresql-{{ pg_version }}-sslutils
     state: absent
     update_cache: yes
-  become: true
+  become: yes
+  when: pg_ssl
 
 - name: Remove python-psycopg2
   package:
@@ -27,4 +35,4 @@
     state: absent
     update_cache: yes
   when: os in ['Ubuntu18','Debian9', 'Debian10']
-  become: true
+  become: yes

--- a/roles/install_dbserver/tasks/PG_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_install.yml
@@ -40,6 +40,13 @@
       - postgresql{{ pg_version }}
       - postgresql{{ pg_version }}-server
       - postgresql{{ pg_version }}-contrib
+    state: present
+  become: yes
+
+- name: Install sslutils
+  package:
+    name:
       - sslutils_{{ pg_version }}
     state: present
   become: yes
+  when: pg_ssl

--- a/roles/install_dbserver/tasks/PG_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_install.yml
@@ -8,7 +8,7 @@
   changed_when: disable_builtin_postgres.rc == 0
   failed_when: disable_builtin_postgres.rc != 0
   ignore_errors: yes
-  become: yes
+  become: true
   when: os in ['RedHat8','CentOS8', 'Rocky8']
 
 - name: Install require python package
@@ -20,7 +20,7 @@
       - python-ipaddress
     state: present
   when: os in ['RedHat7','CentOS7']
-  become: yes
+  become: true
 
 - name: Install require python package
   package:
@@ -29,7 +29,7 @@
       - python3-libselinux
       - python3-psycopg2
     state: present
-  become: yes
+  become: true
   when: os in ['RedHat8','CentOS8','Rocky8']
 
 - name: Install Postgres
@@ -41,12 +41,12 @@
       - postgresql{{ pg_version }}-server
       - postgresql{{ pg_version }}-contrib
     state: present
-  become: yes
+  become: true
 
 - name: Install sslutils
   package:
     name:
       - sslutils_{{ pg_version }}
     state: present
-  become: yes
+  become: true
   when: pg_ssl

--- a/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
@@ -3,7 +3,7 @@
   systemd:
     name: postgresql-{{ pg_version }}
     state: stopped
-  become: yes
+  become: true
 
 - name: Remove require python package
   package:
@@ -14,7 +14,7 @@
       - python-ipaddress
     state: absent
   when: os in ['RedHat7','CentOS7']
-  become: yes
+  become: true
 
 - name: Remove require python package
   package:
@@ -23,7 +23,7 @@
       - python3-libselinux
       - python3-psycopg2
     state: absent
-  become: yes
+  become: true
   when: os in ['RedHat8','CentOS8','Rocky8']
 
 - name: Remove Postgres
@@ -34,4 +34,4 @@
       - postgresql{{ pg_version }}-contrib
       - sslutils_{{ pg_version }}
     state: absent
-  become: yes
+  become: true


### PR DESCRIPTION
This allows trying early releases of PG/EPAS when sslutils packages aren't available yet.