### PR TITLE
Avoid package conflict with python2-psycopg2

### DIFF
--- a/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
@@ -3,7 +3,7 @@
   package:
     name:
       - python-pip
-      - python-psycopg2
+      - python2-psycopg2
       - python-ipaddress
     state: present
   when: os in ['RedHat7','CentOS7']

--- a/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
@@ -27,7 +27,7 @@
   package:
     name:
       - python-pip
-      - python-psycopg2
+      - python2-psycopg2
     state: absent
   when: os in ['RedHat7','CentOS7']
   become: yes

--- a/roles/install_dbserver/tasks/PG_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_install.yml
@@ -16,7 +16,7 @@
     name:
       - python-pycurl
       - libselinux-python
-      - python-psycopg2
+      - python2-psycopg2
       - python-ipaddress
     state: present
   when: os in ['RedHat7','CentOS7']

--- a/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
@@ -10,7 +10,7 @@
     name:
       - python-pycurl
       - libselinux-python
-      - python-psycopg2
+      - python2-psycopg2
       - python-ipaddress
     state: absent
   when: os in ['RedHat7','CentOS7']

--- a/tests/tests/test_install_dbserver.py
+++ b/tests/tests/test_install_dbserver.py
@@ -30,7 +30,7 @@ def test_install_dbserver_pg_centos():
         packages += [
             'python-pycurl',
             'libselinux-python',
-            'python-psycopg2',
+            'python2-psycopg2',
             'python-ipaddress'
         ]
     elif get_os() == 'rocky8':
@@ -67,7 +67,7 @@ def test_install_dbserver_epas_centos():
     if get_os() == 'centos7':
         packages += [
             'python2-pip',
-            'python-psycopg2',
+            'python2-psycopg2',
             'python-ipaddress',
         ]
     elif get_os() == 'rocky8':


### PR DESCRIPTION
On RedHat family in version 7, the new package name of the Postgres
driver for Python is python2-psycopg2. Even if packages named with
the original name (python-psycopg2) are still available, they
shouldn't be installed because of conflicts with packages depending
on python2-psycopg2.