### PR TITLE
Allow VIP usage with Barman

### DIFF
--- a/roles/setup_barman/tasks/configure_barman.yml
+++ b/roles/setup_barman/tasks/configure_barman.yml
@@ -30,9 +30,9 @@
 
 - name: Set _pg_host when using virtual ip address
   set_fact:
-    _pg_host: "{{ hostvars[inventory_hostname].primary_vip }}"
+    _pg_host: "{{ hostvars[inventory_hostname].barman_primary_vip }}"
   when:
-    - hostvars[inventory_hostname].primay_vip is defined
+    - hostvars[inventory_hostname].barman_primary_vip is defined
 
 - name: Ensure the barman configuration for the current host is present
   template:

--- a/roles/setup_barman/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_barman/tasks/exchange_ssh_keys.yml
@@ -20,7 +20,6 @@
     _barman_host: "{{ _barman_server_info[0].private_ip }}"
   when:
     - "not use_hostname|bool"
-    - hostvars[inventory_hostname].primary_vip is not defined
 
 - name: Set _pg_host and _barman_host when using hostname
   set_fact:
@@ -28,14 +27,6 @@
     _barman_host: "{{ _barman_server_info[0].inventory_hostname }}"
   when:
     - use_hostname|bool
-    - hostvars[inventory_hostname].primary_vip is not defined
-
-- name: Set _pg_host and _barman_host when using virtual ip
-  set_fact:
-    _pg_host: "{{ hostvars[inventory_hostname].primary_vip }}"
-    _barman_host: "{{ _barman_server_info[0].inventory_hostname }}"
-  when:
-    - hostvars[inventory_hostname].primary_vip is defined
 
 - name: Fetch barman server SSH public key
   slurp:

--- a/roles/setup_barman/tasks/post_configure_barman.yml
+++ b/roles/setup_barman/tasks/post_configure_barman.yml
@@ -19,20 +19,12 @@
     _pg_host: "{{ hostvars[inventory_hostname].private_ip }}"
   when:
     - "not use_hostname|bool"
-    - hostvars[inventory_hostname].primary_vip is not defined
 
 - name: Set _pg_host when using hostname
   ansible.builtin.set_fact:
     _pg_host: "{{ inventory_hostname }}"
   when:
     - use_hostname|bool
-    - hostvars[inventory_hostname].primary_vip is not defined
-
-- name: Set _pg_host when not using virtual ip address
-  ansible.builtin.set_fact:
-    _pg_host: "{{ hostvars[inventory_hostname].primary_vip }}"
-  when:
-    - hostvars[inventory_hostname].primary_vip is defined
 
 - name: Add a crontab entry for barman backup at 00:00 every day
   ansible.builtin.lineinfile:

--- a/roles/setup_barman/tasks/setup_barman.yml
+++ b/roles/setup_barman/tasks/setup_barman.yml
@@ -17,6 +17,13 @@
   when: >
     barman_backup_method not in ['postgres', 'rsync']
 
+- name: Fail if barman_primary_vip is defined and barman_backup_method is not Postgres
+  fail:
+    msg: "The hostvar barman_primary_vip is not compatible with rsync backups"
+  when:
+    - hostvars[inventory_hostname].barman_primary_vip is defined
+    - barman_backup_method != 'postgres'
+
 - name: Check support for Operating System
   fail:
     msg: "Operating System = {{ os }} not supported."
@@ -64,9 +71,18 @@
 
 - name: Include the barman configuration tasks
   include_tasks: configure_barman.yml
+  when: >
+    hostvars[inventory_hostname].barman_no_configuration is not defined
+    or hostvars[inventory_hostname].barman_no_configuration|bool == False
 
 - name: Include the Postgres configuration tasks for backup
   include_tasks: configure_pg_backup.yml
+  when: >
+    hostvars[inventory_hostname].barman_no_configuration is not defined
+    or hostvars[inventory_hostname].barman_no_configuration|bool == False
 
 - name: Include the barman post configuration tasks
   include_tasks: post_configure_barman.yml
+  when: >
+    hostvars[inventory_hostname].barman_no_configuration is not defined
+    or hostvars[inventory_hostname].barman_no_configuration|bool == False

--- a/roles/setup_barman/tasks/update_barman_pgpass.yml
+++ b/roles/setup_barman/tasks/update_barman_pgpass.yml
@@ -19,20 +19,20 @@
     _pg_host: "{{ hostvars[inventory_hostname].private_ip }}"
   when:
     - not use_hostname|bool
-    - hostvars[inventory_hostname].primary_vip is not defined
+    - hostvars[inventory_hostname].barman_primary_vip is not defined
 
 - name: Set _pg_host when use_hostname is true
   set_fact:
     _pg_host: "{{ inventory_hostname }}"
   when:
     - use_hostname|bool
-    - hostvars[inventory_hostname].primary_vip is not defined
+    - hostvars[inventory_hostname].barman_primary_vip is not defined
 
 - name: Set _pg_host using virtual ip address
   set_fact:
-    _pg_host: "{{ hostvars[inventory_hostname].primary_vip }}"
+    _pg_host: "{{ hostvars[inventory_hostname].barman_primary_vip }}"
   when:
-    - hostvars[inventory_hostname].primary_vip is defined
+    - hostvars[inventory_hostname].barman_primary_vip is defined
 
 - name: Ensure barman .pgpass file contains one entry for {{ ansible_host }}
   lineinfile:

--- a/roles/setup_barman/templates/barman.postgres.template
+++ b/roles/setup_barman/templates/barman.postgres.template
@@ -9,3 +9,4 @@ slot_name = barman
 backup_options = concurrent_backup
 immediate_checkpoint = true
 recovery_options = get-wal
+create_slot = auto


### PR DESCRIPTION
In the High-Availability context, when using a Virtual IP address for
routing read/write traffic to the primary node, then it's possible
to configure barman to use this VIP address as Postgres connection
endpoint. This way, in case of timeline change (following a
failover or switchover event), barman will be able to automatically
fetch new WAL records coming from the new primary node, without
requiring any manual operation.

This configuration is only possible when using the `postgres` backup
method, which is based on backup and WAL archiving using streaming
replication.

New hostvars:
- barman_private_vip: VIP address of the primary node. This VIP
  must be already active on the primary before configuring barman.
- barman_no_configuration: Disable the creation of barman
  configuration and backups for this instance. Must be set to
  `true` for all standby nodes in this mode.