### PR TITLE
Fix os checking in DBT-* playbooks

### DIFF
--- a/roles/setup_dbt2/tasks/dbt2_install_packages_client.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_client.yml
@@ -1,6 +1,5 @@
 ---
-
-- name: Install packages for DBT-2
+- name: Install packages for DBT-2 Client
   dnf:
     name:
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{dbt2_version }}/dbt2-client-{{ dbt2_version }}-1.el8.x86_64.rpm'
@@ -9,6 +8,7 @@
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-pgsql-plpgsql-{{ dbt2_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: yes
+  when: ansible_os_family == "RedHat"
   become: yes
 
 - name: Install additional supporting packages
@@ -18,5 +18,5 @@
       - rsync
       - tmux
     state: present
-  when: os in ['RedHat8','CentOS8','Rocky8']
+  when: ansible_os_family == "RedHat"
   become: yes

--- a/roles/setup_dbt2/tasks/dbt2_install_packages_db.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_db.yml
@@ -9,6 +9,7 @@
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-scripts-{{ dbt2_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: yes
+  when: ansible_os_family == "RedHat"
   become: yes
 
 - name: Install additional supporting packages
@@ -18,5 +19,5 @@
       - rsync
       - tmux
     state: present
-  when: os in ['RedHat8','CentOS8','Rocky8']
+  when: ansible_os_family == "RedHat"
   become: yes

--- a/roles/setup_dbt2/tasks/dbt2_install_packages_driver.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_driver.yml
@@ -11,6 +11,7 @@
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-pgsql-plpgsql-{{ dbt2_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: yes
+  when: ansible_os_family == "RedHat"
   become: yes
 
 - name: Install additional supporting packages
@@ -21,5 +22,5 @@
       - rsync
       - tmux
     state: present
-  when: os in ['RedHat8','CentOS8','Rocky8']
+  when: ansible_os_family == "RedHat"
   become: yes

--- a/roles/setup_dbt3/tasks/dbt3_install_packages.yml
+++ b/roles/setup_dbt3/tasks/dbt3_install_packages.yml
@@ -13,7 +13,7 @@
       - sysstat
       - tmux
     state: present
-  when: os in ['RedHat8','CentOS8','Rocky8']
+  when: ansible_os_family == "RedHat"
   become: yes
 
 - name: Install packages for DBT-3 Database
@@ -22,4 +22,5 @@
       - 'https://github.com/osdldbt/dbt3-packaging/releases/download/v{{ dbt3_version }}/dbt3-{{ dbt3_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: yes
+  when: ansible_os_family == "RedHat"
   become: yes

--- a/roles/setup_dbt7/tasks/dbt7_install_packages.yml
+++ b/roles/setup_dbt7/tasks/dbt7_install_packages.yml
@@ -14,7 +14,7 @@
       - sysstat
       - tmux
     state: present
-  when: os in ['RedHat8','CentOS8','Rocky8']
+  when: ansible_os_family == "RedHat"
   become: yes
 
 - name: Install packages for DBT-7 Database
@@ -23,4 +23,5 @@
       - 'https://github.com/osdldbt/dbt7-packaging/releases/download/v{{ dbt7_version }}/dbt7-{{ dbt7_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: yes
+  when: ansible_os_family == "RedHat"
   become: yes


### PR DESCRIPTION
os wasn't being set in these playbooks.  Just use ansible_os_family.  We
can check the major version when we actually support more than one major
version in these playbooks.