### PR TITLE
adapt restart condition in manage_postgres_params 

### DIFF
--- a/roles/manage_dbserver/tasks/manage_postgres_params.yml
+++ b/roles/manage_dbserver/tasks/manage_postgres_params.yml
@@ -21,7 +21,7 @@
     params_restart_required: True
   when:
     - pg_postgres_conf_params|length > 0
-    - line_item.restart_required
+    - line_item.changed and line_item.restart_required
   with_items: "{{ params.results }}"
   loop_control:
     loop_var: line_item


### PR DESCRIPTION
Executing the role "autotuning" comes at the cost of restarting the postgres server no matter if it is needed.
This is due to the fact, that the task "Register the restart requirements" traverses all params and if one of them has restart_required attached to it, the fact "params_restart_required" is set to true.

If I execute the role "autotuning" it will include "autovacuum_max_workers".
This has "restart_required" attached to it.
However it also has "changed" set to false.

ok: [primary1] => (item={'name': 'autovacuum_max_workers', 'restart_required': True, 'prev_val_pretty': '5', 'value_pretty': '5', 'context': 'postmaster', 'changed': False, 'invocation': {'module_args': {'login_unix_socket': '/var/run/postgresql', 'port': 5432, 'db': 'postgres', 'login_user': 'postgres', 'name': 'autovacuum_max_workers', 'value': '5', 'login_password': '', 'login_host': '', 'ssl_mode': 'prefer', 'reset': False, 'trust_input': True, 'ca_cert': None, 'session_role': None}}, 'failed': False, 'line_item': {'name': 'autovacuum_max_workers', 'value': '5'}, 'ansible_loop_var': 'line_item'})

I think it is not the best way to restart the server, if the parameters in question did not change.
Therefore I would propose to look for line_item.restart_required as well as line_item.changed to determine if params_restart_required should be set to true.
