### PR TITLE
Adding support for EDB Repos 2.0 in setup_repo role

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ playbook:
         pg_type: "EPAS"
         repo_username: "<edb-package-repository-username>"
         repo_password: "<edb-package-repository-password>"
+        repo_token: "<edb-package-repository-token>"
         disable_logging: false
 
   roles:
@@ -257,7 +258,7 @@ limit what roles you would like to execute.
 ### Access to EDB's package repository
 
 By default, the `setup_repo` role requires to define credentials (variables
-`repo_username` and `repo_password`) that will be used to configure the access
+`repo_username` and `repo_password` or `repo_token`) that will be used to configure the access
 to EDB's package repository. Having access to EDB package repository is
 necessary to deploy EDB softwares like EPAS, EFM or PEM.
 
@@ -307,6 +308,13 @@ $ ansible-playbook playbook.yml \
   -u <ssh-user> \
   --private-key <ssh-private-key> \
   --extra-vars="pg_version=12 pg_type=EPAS repo_username=<edb-repo-username> repo_password=<edb-repo-password>"
+# OR
+$ ansible-playbook playbook.yml \
+  -i inventory.yml \
+  -u <ssh-user> \
+  --private-key <ssh-private-key> \
+  --extra-vars="pg_version=12 pg_type=EPAS repo_token=<edb-repo-token>"
+
 ```
 
 ## Database engines supported

--- a/playbook-examples/pem_server_primary_two_standbys/playbook.yml
+++ b/playbook-examples/pem_server_primary_two_standbys/playbook.yml
@@ -14,6 +14,7 @@
         pg_type: "PG"
         repo_username: ""
         repo_password: ""
+        repo_token: ""
         disable_logging: false
 
   roles:

--- a/playbook-examples/primary_two_standbys_with_efm/playbook.yml
+++ b/playbook-examples/primary_two_standbys_with_efm/playbook.yml
@@ -12,8 +12,9 @@
       set_fact:
         pg_version: 13         # Postgres Version
         pg_type: "PG"          # Postgres type: EPAS/PG
-        repo_username: "xxxx"   # EDB Repo username
-        repo_password: "xxxx"   # EDB Repo password
+        repo_username: "xxxx"  # EDB Repo username
+        repo_password: "xxxx"  # EDB Repo password
+        repo_token: "xxxx"     # EDB Repo token
 
   roles:
     - role: setup_repo

--- a/playbook.yml
+++ b/playbook.yml
@@ -14,6 +14,7 @@
         pg_type: "PG"
         repo_username: ""
         repo_password: ""
+        repo_token: ""
         disable_logging: false
 
   roles:

--- a/roles/setup_repo/README.md
+++ b/roles/setup_repo/README.md
@@ -42,12 +42,17 @@ When executing the role via Ansible these are the required variables:
   * **repo_username**
 
   Username used to access EDB package repository.
-  Required when **enable_edb_repo** is set to `true`.
+  Required when **enable_edb_repo** is set to `true` and **repo_token** isn't used.
 
   * **repo_password**
 
   Password used to access EDB package repository.
-  Required when **enable_edb_repo** is set to `true`.
+  Required when **enable_edb_repo** is set to `true` and **repo_token** isn't used.
+
+  * **repo_token**
+
+  EDB repository token used to access EDB package repository.
+  Required when **enable_edb_repo** is set to `true` and **repo_username** and **repo_password** aren't used.
 
   * **yum_additional_repos**
 
@@ -139,6 +144,7 @@ repositories access to EDB Postgres Advanced Server packages in version 14:
         pg_type: "EPAS"
         repo_username: "<edb-repo-username>"
         repo_password: "<edb-repo-password>"
+        repo_token: "<edb-repo-token>"
 
   roles:
     - setup_repo
@@ -218,6 +224,11 @@ $ ansible-playbook playbook.yml \
   -u <ssh-user> \
   --private-key <ssh-private-key> \
   --extra-vars="pg_type=EPAS pg_version=14 repo_username=<edb-repo-username> repo_password=<edb-repo-password>"
+# OR
+$ ansible-playbook playbook.yml \
+  -u <ssh-user> \
+  --private-key <ssh-private-key> \
+  --extra-vars="pg_type=EPAS pg_version=14 repo_token=<edb-repo-token>"
 ```
 
 ## License

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -7,6 +7,7 @@
 
 # EDB repository username, password and subscription token
 enable_edb_repo: true
+repo_token: ""
 repo_username: ""
 repo_password: ""
 tpa_subscription_token: ""
@@ -18,6 +19,7 @@ edb_2q_base_repo_link: "https://techsupport.enterprisedb.com/api/repository/{{ t
 edb_2q_repositories:
   - bdr4/release
   - harp/release
+edb_repo_script_link: "https://downloads.enterprisedb.com/{{ repo_token }}/enterprise/setup.{{ 'rpm' if ansible_os_family == 'RedHat' else 'deb' }}.sh"
 
 # debian/ubuntu Repo
 edb_deb_repo_url: "deb [arch=amd64] https://apt.enterprisedb.com/{{ ansible_distribution_release }}-edb/ {{ ansible_distribution_release }} main"

--- a/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
@@ -3,7 +3,8 @@
   stat:
     path: "{{ edb_auth_conf }}"
   register: auth_conf
-  when: os != 'Debian9'
+  when: >
+    os != 'Debian9' and enable_edb_repo|bool and repo_token|length < 1
   become: true
 
 - name: Build EDB auth conf
@@ -17,6 +18,7 @@
   when:
     - os != 'Debian9'
     - not auth_conf.stat.exists or auth_conf.stat.size == 0
+    - enable_edb_repo|bool and repo_token|length < 1
   become: true
 
 - name: Install gpg
@@ -36,13 +38,16 @@
     url: "{{ edb_deb_keys }}"
     state: present
   become: true
+  when: >
+    enable_edb_repo|bool and repo_token|length < 1
 
 - name: Add EDB Debian repo
   apt_repository:
     repo: "{{ edb_deb_repo_url }}"
     state: present
     filename: "edb-{{ ansible_distribution_release }}"
-  when: os != 'Debian9'
+  when: >
+    os != 'Debian9' and enable_edb_repo|bool and repo_token|length < 1
   become: true
 
 - name: Install apt-transport-https
@@ -57,7 +62,8 @@
     repo: "{{ edb_deb_9_repo_url }}"
     state: present
     filename: "edb-{{ ansible_distribution_release }}"
-  when: os == 'Debian9'
+  when: >
+      os == 'Debian9' and enable_edb_repo|bool and repo_token|length < 1
   become: true
 
 - name: Add PG Debian keys
@@ -83,3 +89,16 @@
   become: true
   loop: "{{ apt_additional_repos }}"
   when: apt_additional_repos | length > 0
+
+- name: Install EDB repository 2.0
+  ansible.builtin.shell: >
+      set -o pipefail;
+      curl -1sLf "{{ edb_repo_script_link }}" | bash
+  args:
+    executable: /bin/bash
+  register: reposub
+  become: true
+  failed_when: >
+    reposub.rc != 0 or 'error: ' in reposub.stdout.lower()
+  when: >
+    enable_edb_repo|bool and repo_token|length > 0

--- a/roles/setup_repo/tasks/PG_RedHat_rm_repos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_rm_repos.yml
@@ -16,6 +16,7 @@
     - "/etc/yum.repos.d/pgdg-redhat-all.repo"
     - "/etc/yum.repos.d/edb.repo"
     - "/etc/yum.repos.d/edb.repo.rpmsave"
+    - "/etc/yum.repos.d/enterprisedb-enterprise.repo"
   loop_control:
     loop_var: item_file
   become: yes

--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -68,7 +68,8 @@
     name: "{{ edb_rpm_repo }}"
     state: present
   become: yes
-  when: enable_edb_repo|bool
+  when: >
+    enable_edb_repo|bool and repo_token|length < 1
 
 - name: Set Credentials for EDB Yum Repo
   replace:
@@ -76,7 +77,8 @@
     regexp: '<username>:<password>'
     replace: "{{ repo_username }}:{{ repo_password }}"
   become: yes
-  when: enable_edb_repo|bool
+  when: >
+    enable_edb_repo|bool and repo_token|length < 1
 
 - name: Add additional Redhat repositories
   ansible.builtin.yum_repository:
@@ -124,3 +126,16 @@
     bdr_nodes_ips is defined and ansible_host in bdr_nodes_ips
     and pg_version|int >= 13
   loop: "{{ edb_2q_repositories }}"
+
+- name: Install EDB repository 2.0
+  ansible.builtin.shell: >
+      set -o pipefail;
+      curl -1sLf "{{ edb_repo_script_link }}" | bash
+  args:
+    executable: /bin/bash
+  register: reposub
+  become: true
+  failed_when: >
+    reposub.rc != 0 or 'error: ' in reposub.stdout.lower()
+  when: >
+    enable_edb_repo|bool and repo_token|length > 0

--- a/roles/setup_repo/tasks/setup_repo.yml
+++ b/roles/setup_repo/tasks/setup_repo.yml
@@ -2,6 +2,7 @@
 - name: Set the os variable
   set_fact:
     os: "{{ ansible_distribution }}{{ ansible_distribution_major_version }}"
+    os_family: "{{ ansible_distribution }}"
 
 - name: Check support for Operating System
   fail:
@@ -27,8 +28,10 @@
 
 - name: Validate Credentials
   fail:
-      msg: "repo_username = {{ repo_username }} or repo_password = {{ repo_password }} are not valid!."
-  when: enable_edb_repo|bool and (repo_username | length < 1 or repo_password | length < 1)
+      msg: "repo_username = {{ repo_username }} or repo_password = {{ repo_password }} or repo_token = {{ repo_token }} are not valid!."
+  when:
+    - enable_edb_repo|bool
+    - repo_token | length < 1 and (repo_username | length < 1 or repo_password | length < 1)
 
 - name: Capture if bdr_nodes_ips if defined
   set_fact:


### PR DESCRIPTION
This PR adds the support of EDB Repos 2.0.
Details of EDB Repos 2.0 is given below:
```
* Currently available for EDB Enterprise and EDB Standard
* Token-based authentication
* Single, simple URL for all download types
* Currently supporting Red Hat Enterprise Linux (RHEL), Oracle Linux (OL), CentOS, Rocky Linux, AlmaLinux, Debian, Ubuntu, and SUSE Linux Enterprise Server (SLES)
```