### PR TITLE
pgpool2: disable builtin postgresql package

### DIFF
--- a/roles/setup_pgpool2/tasks/pgpool2_install.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_install.yml
@@ -5,6 +5,18 @@
   when: os in ['CentOS7', 'RHEL7']
   become: yes
 
+- name: Disable builtin postgresql module
+  shell: >
+    dnf -qy module disable postgresql
+  args:
+    executable: /bin/bash
+  register: disable_builtin_postgres
+  changed_when: disable_builtin_postgres.rc == 0
+  failed_when: disable_builtin_postgres.rc != 0
+  ignore_errors: yes
+  become: true
+  when: os in ['RHEL8','CentOS8', 'Rocky8']
+
 - name: Install pgpoolII package on CentOS8 or RHEL8 or Rocky8
   dnf:
     name: "{{ pgpool2_package_name }}"


### PR DESCRIPTION
On the os' from the redhat family in version 8, the default
postgresql meta package must be disabled if we to install packages
depending on the postgresql-X-server packages and coming from EDB
or PGDG repo.

Error was:

Problem: package pgpool-II-pcp-4.3.2-1.rhel8.x86_64 requires
postgresql14-server, but none of the providers can be installed

Reported by: Sergio Romera