### PR TITLE
Use inventory_hostname with delegate_to

### DIFF
--- a/roles/setup_barman/tasks/configure_barman.yml
+++ b/roles/setup_barman/tasks/configure_barman.yml
@@ -10,9 +10,9 @@
   when:
     - _barman_server_info|length == 0
 
-- name: Set _barman_server_public_ip
+- name: Set _barman_server_inventory_hostname
   set_fact:
-    _barman_server_public_ip: "{{ _barman_server_info[0].ansible_host }}"
+    _barman_server_inventory_hostname: "{{ _barman_server_info[0].inventory_hostname }}"
 
 - name: Set _pg_host when not using hostname
   set_fact:
@@ -41,7 +41,7 @@
     owner: "{{ barman_user }}"
     group: "{{ barman_group }}"
     mode: 0700
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   become: yes
   vars:
     pg_host: "{{ _pg_host }}"

--- a/roles/setup_barman/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_barman/tasks/exchange_ssh_keys.yml
@@ -10,9 +10,9 @@
   when:
     - _barman_server_info|length == 0
 
-- name: Set _barman_server_public_ip
+- name: Set _barman_server_inventory_hostname
   set_fact:
-    _barman_server_public_ip: "{{ _barman_server_info[0].ansible_host }}"
+    _barman_server_inventory_hostname: "{{ _barman_server_info[0].inventory_hostname }}"
 
 - name: Set _pg_host and _barman_host when not using hostname
   set_fact:
@@ -31,7 +31,7 @@
 - name: Fetch barman server SSH public key
   slurp:
     src: "{{ barman_home + '/.ssh/id_rsa.pub' }}"
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   register: _barman_server_ssh_public_key_b64
   become: yes
 
@@ -57,7 +57,7 @@
     mode: 0600
     line: "{{ _pg_ssh_public_key }}"
     create: yes
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   become: yes
 
 - name: Ensure {{ barman_user }} SSH public key is on the Postgres server
@@ -72,7 +72,7 @@
 - name: Run ssh-keyscan from the Barman server
   command: ssh-keyscan {{ _pg_host }}
   register: _barman_ssh_keyscan_output
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   become: yes
   changed_when: false
 
@@ -84,7 +84,7 @@
   with_items: "{{ _barman_ssh_keyscan_output.stdout_lines }}"
   loop_control:
     loop_var: _item
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   become: yes
   become_user: "{{ barman_user }}"
   no_log: "{{ disable_logging }}"

--- a/roles/setup_barman/tasks/post_configure_barman.yml
+++ b/roles/setup_barman/tasks/post_configure_barman.yml
@@ -10,9 +10,9 @@
   when:
     - _barman_server_info|length == 0
 
-- name: Set _barman_server_public_ip
+- name: Set _barman_server_inventory_hostname
   ansible.builtin.set_fact:
-    _barman_server_public_ip: "{{ _barman_server_info[0].ansible_host }}"
+    _barman_server_inventory_hostname: "{{ _barman_server_info[0].inventory_hostname }}"
 
 - name: Set _pg_host when not using hostname
   ansible.builtin.set_fact:
@@ -31,13 +31,13 @@
     line: "0 0 * * * barman /usr/bin/barman backup {{ inventory_hostname }}-{{ pg_instance_name }}"
     state: present
     path: /etc/cron.d/barman
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   become: true
 
 - name: Start barman cron
   ansible.builtin.command:
     cmd: "/usr/bin/barman cron"
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   changed_when: false
   become: true
   become_user: barman
@@ -45,7 +45,7 @@
 - name: Execute ssh command for testing
   ansible.builtin.command:
     cmd: "ssh {{ pg_owner }}@{{ _pg_host }} /bin/true"
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   changed_when: false
   become: true
   become_user: barman
@@ -53,7 +53,7 @@
 - name: Archive the first WAL file using barman
   ansible.builtin.command:
     cmd: "/usr/bin/barman switch-wal {{ inventory_hostname }}-{{ pg_instance_name }} --archive"
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   become: true
   become_user: barman
   when:
@@ -62,7 +62,7 @@
 - name: Execute barman check
   ansible.builtin.command:
     cmd: "/usr/bin/barman check {{ inventory_hostname }}-{{ pg_instance_name }}"
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   become: true
   become_user: barman
   when:
@@ -71,7 +71,7 @@
 - name: Take a barman backup
   ansible.builtin.command:
     cmd: "/usr/bin/barman backup {{ inventory_hostname }}-{{ pg_instance_name }}"
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   become: true
   become_user: barman
   when:

--- a/roles/setup_barman/tasks/update_barman_pgpass.yml
+++ b/roles/setup_barman/tasks/update_barman_pgpass.yml
@@ -10,9 +10,9 @@
   when:
     - _barman_server_info|length == 0
 
-- name: Set _barman_server_public_ip
+- name: Set _barman_server_inventory_hostname
   set_fact:
-    _barman_server_public_ip: "{{ _barman_server_info[0].ansible_host }}"
+    _barman_server_inventory_hostname: "{{ _barman_server_info[0].inventory_hostname }}"
 
 - name: Set _pg_host when use_hostname is false
   set_fact:
@@ -43,7 +43,7 @@
     line: "{{ _pg_host }}:{{ pg_port }}:*:{{ barman_pg_user }}:{{ barman_pg_password }}"
     regexp: "^{{ _pg_host | regex_escape() }}:{{ pg_port }}:\\*:{{ barman_pg_user | regex_escape() }}:.*"
     create: yes
-  delegate_to: "{{ _barman_server_public_ip }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
   throttle: 1
   become: yes
 

--- a/roles/setup_efm/tasks/setup_efm.yml
+++ b/roles/setup_efm/tasks/setup_efm.yml
@@ -107,7 +107,7 @@
 
 - name: Get the primary information
   set_fact:
-    primary_public_ip: "{{ node.ansible_host }}"
+    primary_inventory_hostname: "{{ node.inventory_hostname }}"
     primary_private_ip: "{{ node.private_ip }}"
   when: node.node_type == 'primary'
   loop: "{{ efm_cluster_nodes }}"
@@ -120,7 +120,7 @@
   import_tasks: create_efm_user.yml
   run_once: true
   no_log: "{{ disable_logging }}"
-  delegate_to: "{{ primary_public_ip }}"
+  delegate_to: "{{ primary_inventory_hostname }}"
 
 - name: Update /etc/hosts based on use_hostname
   block:
@@ -166,6 +166,6 @@
 - name: Reset the variables used in this role
   set_fact:
      efm_nodes_list: ""
-     primary_public_ip: ""
+     primary_inventory_hostname: ""
      input_password: ""
      pg_allow_ip_addresses: []

--- a/roles/setup_pemagent/tasks/pem_agent_hba.yml
+++ b/roles/setup_pemagent/tasks/pem_agent_hba.yml
@@ -35,7 +35,7 @@
     name: manage_dbserver
     tasks_from: manage_hba_conf
     apply:
-      delegate_to: "{{ node.ansible_host }}"
+      delegate_to: "{{ node.inventory_hostname }}"
   vars:
     pg_hba_ip_addresses: "{{ pg_allow_ip_addresses }}"
   loop: "{{ pem_server_info }}"

--- a/roles/setup_pemagent/tasks/pem_agent_register_db_remote.yml
+++ b/roles/setup_pemagent/tasks/pem_agent_register_db_remote.yml
@@ -5,7 +5,7 @@
     path: "{{ pem_agent_bin_path }}/../etc/.{{ inventory_hostname }}-{{ pg_port }}-registered"
   become: true
   register: server_registered
-  delegate_to: "{{ pem_server_info[0].ansible_host }}"
+  delegate_to: "{{ pem_server_info[0].inventory_hostname }}"
   no_log: "{{ disable_logging }}"
 
 - name: Get the pg_pem_agent_password
@@ -54,7 +54,7 @@
   failed_when: "'Database Server registered with Postgres Enterprise Manager Server successfully!' not in output.stdout"
   when: not server_registered.stat.exists and efm_enabled
   become: yes
-  delegate_to: "{{ pem_server_info[0].ansible_host }}"
+  delegate_to: "{{ pem_server_info[0].inventory_hostname }}"
   no_log: "{{ disable_logging }}"
 
 - name: Register remote dbserver
@@ -85,5 +85,5 @@
   failed_when: "'Database Server registered with Postgres Enterprise Manager Server successfully!' not in output.stdout"
   when: not server_registered.stat.exists and not efm_enabled
   become: yes
-  delegate_to: "{{ pem_server_info[0].ansible_host }}"
+  delegate_to: "{{ pem_server_info[0].inventory_hostname }}"
   no_log: "{{ disable_logging }}"

--- a/roles/setup_pemagent/tasks/setup_pemagent.yml
+++ b/roles/setup_pemagent/tasks/setup_pemagent.yml
@@ -50,7 +50,7 @@
     set -eu
     {{ pem_agent_bin_path }}/pemagent --version|cut -d":" -f2|head -n2|tail -n1
   changed_when: false
-  delegate_to: "{{ pem_server_info[0].ansible_host }}"
+  delegate_to: "{{ pem_server_info[0].inventory_hostname }}"
   register: pem_server_version_output
   become: yes
   no_log: "{{ disable_logging }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_create_db_user.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_create_db_user.yml
@@ -21,7 +21,7 @@
     name: manage_dbserver
     tasks_from: manage_users
     apply:
-      delegate_to: "{{ pgpool2_primary_public_ip }}"
+      delegate_to: "{{ pgpool2_primary_inventory_hostname }}"
   vars:
     pg_users:
        - name: "{{ pg_pgpool_user }}"
@@ -36,7 +36,7 @@
     name: manage_dbserver
     tasks_from: manage_privileges
     apply:
-      delegate_to: "{{ pgpool2_primary_public_ip }}"
+      delegate_to: "{{ pgpool2_primary_inventory_hostname }}"
   vars:
     pg_grant_privileges:
        - roles: "{{ pg_pgpool_user }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_setup_sr_mode.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup_sr_mode.yml
@@ -16,7 +16,7 @@
     name: manage_dbserver
     tasks_from: manage_users
     apply:
-      delegate_to: "{{ pgpool2_primary_public_ip }}"
+      delegate_to: "{{ pgpool2_primary_inventory_hostname }}"
   vars:
     pg_users:
       - name: "{{ pgpool2_sr_check_user }}"
@@ -24,8 +24,8 @@
         role_attr_flags: login
   run_once: true
   when:
-    - pgpool2_primary_public_ip is defined
-    - pgpool2_primary_public_ip|length > 0
+    - pgpool2_primary_inventory_hostname is defined
+    - pgpool2_primary_inventory_hostname|length > 0
 
 # grant monitoring privilege to pgpool2 user for replication status
 - name: Grant execute privileges on system functions to pgpoolII sr user
@@ -33,15 +33,15 @@
     name: manage_dbserver
     tasks_from: manage_privileges
     apply:
-      delegate_to: "{{ pgpool2_primary_public_ip }}"
+      delegate_to: "{{ pgpool2_primary_inventory_hostname }}"
   vars:
     pg_grant_roles:
        - user: "{{ pgpool2_sr_check_user }}"
          role: "pg_monitor"
   run_once: true
   when:
-    - pgpool2_primary_public_ip is defined
-    - pgpool2_primary_public_ip|length > 0
+    - pgpool2_primary_inventory_hostname is defined
+    - pgpool2_primary_inventory_hostname|length > 0
 
 - name: Build pgpoolII SR configuration
   set_fact:

--- a/roles/setup_pgpool2/tasks/setup_pgpool2.yml
+++ b/roles/setup_pgpool2/tasks/setup_pgpool2.yml
@@ -48,7 +48,7 @@
     _pgpool2_backends: []
     _pgpool2_node_list: []
     _pgpool2_ip_list: []
-    _pgpool2_primary_public_ip: ""
+    _pgpool2_primary_inventory_hostname: ""
     _pg_cluster_nodes: "{{ lookup('edb_devops.edb_postgres.pg_sr_cluster_nodes', hostvars[inventory_hostname].primary_private_ip, wantlist=True) }}"
     _pgpool2_nodes: "{{ lookup('edb_devops.edb_postgres.pgpool2_nodes', hostvars[inventory_hostname].primary_private_ip, wantlist=True) }}"
 
@@ -94,9 +94,9 @@
   when:
     - use_hostname|bool
 
-- name: Set the _pgpool2_primary_public_ip variable
+- name: Set the _pgpool2_primary_inventory_hostname variable
   set_fact:
-    _pgpool2_primary_public_ip: "{{ server.ansible_host }}"
+    _pgpool2_primary_inventory_hostname: "{{ server.inventory_hostname }}"
   when:
     - server.node_type == 'primary'
   loop: "{{ _pg_cluster_nodes }}"
@@ -149,7 +149,7 @@
   include_tasks: pgpool2_configure_backends.yml
   when:
     - _pgpool2_backends|length > 0
-    - _pgpool2_primary_public_ip|length > 0
+    - _pgpool2_primary_inventory_hostname|length > 0
   vars:
     pgpool2_backends: "{{ _pgpool2_backends }}"
 
@@ -157,9 +157,9 @@
   include_tasks: pgpool2_setup_sr_mode.yml
   when:
     - _pgpool2_backends|length > 0
-    - _pgpool2_primary_public_ip|length > 0
+    - _pgpool2_primary_inventory_hostname|length > 0
   vars:
-    pgpool2_primary_public_ip: "{{ _pgpool2_primary_public_ip }}"
+    pgpool2_primary_inventory_hostname: "{{ _pgpool2_primary_inventory_hostname }}"
 
 - name: Include the pgpool2_setup_ssl
   include_tasks: pgpool2_setup_ssl.yml
@@ -175,7 +175,7 @@
   include_tasks:
     file: pgpool2_configure_backend_pg_hba.yml
     apply:
-      delegate_to: "{{ server.ansible_host }}"
+      delegate_to: "{{ server.inventory_hostname }}"
   loop: "{{ _pg_cluster_nodes }}"
   loop_control:
     loop_var: server
@@ -203,7 +203,7 @@
 - name: Create and update pgpool2 database user
   include_tasks: pgpool2_create_db_user.yml
   vars:
-    pgpool2_primary_public_ip: "{{ _pgpool2_primary_public_ip }}"
+    pgpool2_primary_inventory_hostname: "{{ _pgpool2_primary_inventory_hostname }}"
 
 - name: Create pcp user for pgpool2
   include_tasks: pgpool2_create_pcp_user.yml

--- a/roles/setup_replication/tasks/setup_replication.yml
+++ b/roles/setup_replication/tasks/setup_replication.yml
@@ -45,7 +45,7 @@
 
 - name: Get the primary information
   set_fact:
-    primary_public_ip: "{{ node.ansible_host }}"
+    primary_inventory_hostname: "{{ node.inventory_hostname }}"
   loop: "{{ pg_cluster_nodes }}"
   loop_control:
     loop_var: node
@@ -72,7 +72,7 @@
   import_tasks: primary_settings.yml
   run_once: true
   no_log: "{{ disable_logging }}"
-  delegate_to: "{{ primary_public_ip }}"
+  delegate_to: "{{ primary_inventory_hostname }}"
 
 - name: Update /etc/hosts based on use_hostname
   block:
@@ -102,13 +102,13 @@
   import_tasks: primary_synchronous_param.yml
   when: synchronous_standbys|length > 0
   run_once: true
-  delegate_to: "{{ primary_public_ip }}"
+  delegate_to: "{{ primary_inventory_hostname }}"
   no_log: "{{ disable_logging }}"
 
 - name: Reset the variables based on the user input
   set_fact:
       primary_private_ip: ""
-      primary_public_ip: ""
+      primary_inventory_hostname: ""
       primary_host_name: ""
       standby_names: []
       pg_allow_ip_addresses: []

--- a/roles/setup_replication/tasks/upstream_node.yml
+++ b/roles/setup_replication/tasks/upstream_node.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: Get upstream node public ip
+- name: Get upstream node info
   set_fact:
-    upstream_public_ip: "{{ node.ansible_host }}"
+    upstream_inventory_hostname: "{{ node.inventory_hostname }}"
     upstream_hostname: "{{ node.inventory_hostname if use_hostname|bool else '' }}"
   when:
     - hostvars[inventory_hostname].upstream_node_private_ip is defined
@@ -13,4 +13,4 @@
 
 - name: Add standby slot in upstream node
   import_tasks: upstream_node_slots.yml
-  delegate_to: "{{ upstream_public_ip }}"
+  delegate_to: "{{ upstream_inventory_hostname }}"

--- a/roles/setup_repmgr/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_repmgr/tasks/exchange_ssh_keys.yml
@@ -13,7 +13,7 @@
 - name: Fetch remote server SSH public key
   ansible.builtin.slurp:
     src: "{{ pg_user_home + '/.ssh/id_rsa.pub' }}"
-  delegate_to: "{{ remote_node.ansible_host }}"
+  delegate_to: "{{ remote_node.inventory_hostname }}"
   register: _remote_server_ssh_public_key_b64
   become: true
 
@@ -39,7 +39,7 @@
     mode: 0600
     line: "{{ _local_ssh_public_key }}"
     create: true
-  delegate_to: "{{ remote_node.ansible_host }}"
+  delegate_to: "{{ remote_node.inventory_hostname }}"
   become: true
 
 - name: Ensure remote {{ pg_owner }} SSH public key is on the local server
@@ -54,7 +54,7 @@
 - name: Run ssh-keyscan from the remote server
   ansible.builtin.command: ssh-keyscan {{ _local_host }}
   register: _remote_ssh_keyscan_output
-  delegate_to: "{{ remote_node.ansible_host }}"
+  delegate_to: "{{ remote_node.inventory_hostname }}"
   become: true
   changed_when: false
 
@@ -66,7 +66,7 @@
   with_items: "{{ _remote_ssh_keyscan_output.stdout_lines }}"
   loop_control:
     loop_var: _item
-  delegate_to: "{{ remote_node.ansible_host }}"
+  delegate_to: "{{ remote_node.inventory_hostname }}"
   become: true
   become_user: "{{ pg_owner }}"
   no_log: "{{ disable_logging }}"


### PR DESCRIPTION
Using ansible_host with delegate_to works only when using the SSH
connector and the default SSH port (22).

Using inventory_hostname is more portable and allows different SSH
port without needing additional SSH configuration.