### PR TITLE
Synchronization check in manage_dbpatches

### DIFF
--- a/roles/manage_dbpatches/defaults/main.yml
+++ b/roles/manage_dbpatches/defaults/main.yml
@@ -12,6 +12,9 @@ disable_logging: true
 pass_dir: "~/.edb"
 use_hostname: true
 
+skip_primary: false
+skip_standby: false
+
 pg_efm_user: "efm"
 pg_efm_user_password: ""
 pg_ssl: true
@@ -22,6 +25,7 @@ efm_json_output: ""
 efm_switchover_output: ""
 
 prefer_standby_as_primary: ""
+sleep_between_sync_checks: "3" # in seconds
 
 efm_cluster_name: "{{ pg_instance_name }}"
 efm_service: "edb-efm-{{ efm_cluster_name }}-{{ efm_version }}"

--- a/roles/manage_dbpatches/tasks/apply_db_patches_one_node.yml
+++ b/roles/manage_dbpatches/tasks/apply_db_patches_one_node.yml
@@ -1,0 +1,39 @@
+---
+- name: Stop user defined services
+  ansible.builtin.include_tasks: stop_user_defined_services.yml
+  loop: "{{ user_defined_services }}"
+  loop_control:
+    loop_var: service_name
+  when: user_defined_services|length > 0
+
+- name: Set efm_listen_host
+  set_fact:
+    efm_listen_host: "{{ hostvars[inventory_hostname].private_ip }}"
+
+- name: Stop efm pg services
+  ansible.builtin.include_tasks: stop_efm_pg_services.yml
+
+- name: Update database packages
+  package:
+    name: "{{ pg_package_list }}"
+    state: latest
+  when: >
+    ('primary' in group_names or 'standby' in group_names)
+     and pg_package_list|length > 0
+
+- name: Update other packages packages
+  package:
+    name: "{{ user_package_list }}"
+    state: latest
+  when:
+  - user_package_list|length > 0
+
+- name: Start efm pg services
+  ansible.builtin.include_tasks: start_efm_pg_services.yml
+
+- name: Start user defined services
+  ansible.builtin.include_tasks: start_user_defined_services.yml
+  loop: "{{ user_defined_services }}"
+  loop_control:
+    loop_var: service_name
+  when: user_defined_services|length > 0

--- a/roles/manage_dbpatches/tasks/apply_primary_patches.yml
+++ b/roles/manage_dbpatches/tasks/apply_primary_patches.yml
@@ -67,8 +67,40 @@
   ansible.builtin.import_tasks: start_efm_pg_services.yml
   delegate_to: "{{ efm_cluster_primary_ssh_host }}"
 
+- name: Prepare query for synchronization check
+  set_fact:
+    primary_catchup_sql: "DO $BODY$
+                          DECLARE
+                              sleep_seconds bigint := {{ sleep_between_sync_checks }};
+                          BEGIN
+                              WHILE NOT (
+                                      SELECT
+                                          (sent_lsn - replay_lsn) = 0
+                                      FROM
+                                          pg_stat_replication
+                                      WHERE
+                                          application_name = '{{ efm_old_cluster_primary }}')
+                              LOOP
+                                  PERFORM pg_sleep(sleep_seconds);
+                              END LOOP;
+                              RAISE NOTICE '{{ efm_old_cluster_primary }} is synchronized';
+                          END;
+                          $BODY$
+                          LANGUAGE plpgsql;"
+
+- name: Verify the synchronization state with new primary
+  include_role:
+    name: manage_dbserver
+    tasks_from: execute_sql_scripts
+    apply:
+       delegate_to: "{{ efm_cluster_primary_ssh_host }}"
+  vars:
+    pg_query:
+        - query: "{{ primary_catchup_sql }}"
+          db: "{{ pg_database }}"
+
 - name: Perform switchover to "{{ efm_old_cluster_primary }}"
-  ansible.builtin.shell: | 
+  ansible.builtin.shell: |
       set -o pipefail
       {{ efm_bin_path }}/efm set-priority {{ efm_cluster_name }} {{ efm_old_cluster_primary }} 1
       {{ efm_bin_path }}/efm promote {{ efm_cluster_name }} -switchover

--- a/roles/manage_dbpatches/tasks/manage_dbpatches.yml
+++ b/roles/manage_dbpatches/tasks/manage_dbpatches.yml
@@ -4,21 +4,24 @@
     os: "{{ ansible_distribution }}{{ ansible_distribution_major_version }}"
 
 - name: Check support for Operating System
-  fail:
-    msg: "Operating System = {{ os }} not supported."
-  when: os not in supported_os
+  ansible.builtin.assert:
+    that: os in supported_os
+    fail_msg: "Operating System = {{ os }} not supported."
+    success_msg: "Operating System = {{ os }} is supported."
 
 - name: Check supported versions for Database engine
-  fail:
-    msg: "Database Engine Version = {{ pg_version }} not supported.
-          Supported versions are {{ supported_pg_version }}"
-  when: pg_version|int not in supported_pg_version
+  ansible.builtin.assert:
+    that: pg_version|int in supported_pg_version
+    fail_msg: "Database Engine Version = {{ pg_version }} not supported.
+               Supported versions are {{ supported_pg_version }}"
+    success_msg: "Database Engine Version = {{ pg_version }} is supported."
 
 - name: Check support for efm
-  fail:
-    msg: "efm version = {{ efm_version }} not supported.
-         Supported versions are {{ supported_efm_version }}"
-  when: efm_version | string not in supported_efm_version
+  ansible.builtin.assert:
+    that: efm_version | string in supported_efm_version
+    fail_msg: "efm version = {{ efm_version }} not supported.
+               Supported versions are {{ supported_efm_version }}"
+    success_msg: "efm version = {{ efm_version }} is supported."
 
 - name: Reference variables
   include_vars: "{{ pg_type }}_{{ ansible_os_family }}.yml"
@@ -47,13 +50,15 @@
   ansible.builtin.import_tasks: validate_efm_cluster.yml
 
 - name: Update standby servers to latest package one at a time
-  throttle: 1
-  block:
-    - name: Include apply db patches tasks
-      ansible.builtin.include_tasks: apply_db_patches.yml
+  ansible.builtin.include_tasks: update_standby_sequential.yml
+  loop: "{{ efm_cluster_nodes }}"
+  loop_control:
+      loop_var: node
+  run_once: true
   when:
-  - "'standby' in group_names"
+  - node.node_type == 'standby'
   - run_in_sequence|bool
+  - not skip_standby
   - pg_package_list|length > 0 or user_package_list|length > 0
 
 - name: Update standby servers to latest package in parallel
@@ -62,9 +67,11 @@
   - "'standby' in group_names"
   - not run_in_sequence|bool
   - pg_package_list|length > 0 or user_package_list|length > 0
+  - not skip_standby
 
 - name: Update primary server to latest package
   ansible.builtin.include_tasks: apply_primary_patches.yml
   when:
   - "'primary' in group_names"
   - pg_package_list|length > 0 or user_package_list|length > 0
+  - not skip_primary

--- a/roles/manage_dbpatches/tasks/update_standby_sequential.yml
+++ b/roles/manage_dbpatches/tasks/update_standby_sequential.yml
@@ -1,0 +1,8 @@
+---
+- name: Update standby servers to latest package one at a time
+  block:
+    - name: Include apply db patches tasks
+      ansible.builtin.include_tasks: apply_db_patches.yml
+  when:
+  - pg_package_list|length > 0 or user_package_list|length > 0
+  delegate_to: "{{ node.inventory_hostname }}"


### PR DESCRIPTION
Adding checks for synchronization of old primary before switchover. This PR also add capabilities where user can choose if they want to apply patches to only primary or standbys.