### PR TITLE
Remove setup_repo for BDR dependencies on BDR nodes. 

### DIFF
--- a/roles/install_dbserver/defaults/main.yml
+++ b/roles/install_dbserver/defaults/main.yml
@@ -3,10 +3,12 @@
 os: ""
 pg_type: "PG"
 pg_version: 14
+bdr_version: 4
 pg_owner: "{{ 'enterprisedb' if pg_type == 'EPAS' else 'postgres' }}"
 enable_core_dump: false
 core_dump_directory: "/var/coredumps"
 
+install_bdr_packages: false
 epas_deb_drop_cluster: "/usr/bin/epas_dropcluster"
 epas_service: "edb-as@{{ pg_version }}-main"
 pg_deb_drop_cluster: "/usr/bin/pg_dropcluster"

--- a/roles/install_dbserver/tasks/EPAS_Debian_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_Debian_install.yml
@@ -55,6 +55,17 @@
   when: os in ['Ubuntu18', 'Debian9', 'Debian10']
   become: true
 
+- name: "Install BDR packages for EPAS >= 14"
+  package:
+    name:
+      - edb-bdr{{ bdr_version }}-{{ pg_type|lower }}{{ pg_version }}
+      - edb-bdr{{ bdr_version }}-{{ pg_type|lower }}{{ pg_version }}-debuginfo
+    state: present
+  become: true
+  when: >-
+    pg_version|int >= 14
+    and install_bdr_packages|bool
+
 - name: Stop the service {{ epas_service }}
   systemd:
     name: "{{ epas_service }}"

--- a/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
@@ -71,6 +71,17 @@
   when: >-
     pg_version|int >= 14
 
+- name: "Install BDR packages for EPAS >= 14"
+  package:
+    name:
+      - edb-bdr{{ bdr_version }}-{{ pg_type|lower }}{{ pg_version }}
+      - edb-bdr{{ bdr_version }}-{{ pg_type|lower }}{{ pg_version }}-debuginfo
+    state: present
+  become: true
+  when: >-
+    pg_version|int >= 14
+    and install_bdr_packages|bool
+
 - name: Install sslutils
   package:
     name:

--- a/roles/install_dbserver/tasks/PG_Debian_install.yml
+++ b/roles/install_dbserver/tasks/PG_Debian_install.yml
@@ -32,6 +32,17 @@
   when: os in ['Ubuntu18','Debian9', 'Debian10']
   become: true
 
+- name: "Install BDR packages for PG >= 14"
+  package:
+    name:
+      - edb-bdr{{ bdr_version }}-{{ pg_type|lower }}{{ pg_version }}
+      - edb-bdr{{ bdr_version }}-{{ pg_type|lower }}{{ pg_version }}-debuginfo
+    state: present
+  become: true
+  when: >-
+    pg_version|int >= 14
+    and install_bdr_packages|bool
+
 - name: Stop the service {{ pg_service }}
   systemd:
     name: "{{ pg_service }}"

--- a/roles/install_dbserver/tasks/PG_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_install.yml
@@ -43,6 +43,17 @@
     state: present
   become: true
 
+- name: "Install BDR packages for PG >= 14"
+  package:
+    name:
+      - edb-bdr{{ bdr_version }}-{{ pg_type|lower }}{{ pg_version }}
+      - edb-bdr{{ bdr_version }}-{{ pg_type|lower }}{{ pg_version }}-debuginfo
+    state: present
+  become: true
+  when: >-
+    pg_version|int >= 14
+    and install_bdr_packages|bool
+
 - name: Install sslutils
   package:
     name:

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -11,6 +11,7 @@ repo_token: ""
 repo_username: ""
 repo_password: ""
 tpa_subscription_token: ""
+install_bdr_packages: false
 
 # EDB RPM Repo
 edb_rpm_repo: "http://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm"

--- a/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
@@ -90,6 +90,22 @@
   loop: "{{ apt_additional_repos }}"
   when: apt_additional_repos | length > 0
 
+- name: Install BDR packages if tpa_subscription_token is given
+  ansible.builtin.shell: >
+      set -o pipefail;
+      curl -sS "{{ edb_2q_base_repo_link }}/{{ item }}/{{ pg_version }}/deb" | bash
+  args:
+    executable: /bin/bash
+  register: reposub
+  become: true
+  failed_when: >
+    reposub.rc != 0 or 'error: ' in reposub.stdout.lower()
+  when: >
+    tpa_subscription_token|length > 0
+    and install_bdr_packages|bool
+    and pg_version|int >= 14
+  loop: "{{ edb_2q_repositories }}"
+
 - name: Install EDB repository 2.0
   ansible.builtin.shell: >
       set -o pipefail;

--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -112,7 +112,7 @@
     state: present
   become: yes
 
-- name: Install BDR packages if BDR is enabled
+- name: Install BDR packages if tpa_subscription_token is given
   ansible.builtin.shell: >
       set -o pipefail;
       curl -sS "{{ edb_2q_base_repo_link }}/{{ item }}/{{ pg_version }}/rpm" | bash
@@ -123,8 +123,9 @@
   failed_when: >
     reposub.rc != 0 or 'error: ' in reposub.stdout.lower()
   when: >
-    bdr_nodes_ips is defined and ansible_host in bdr_nodes_ips
-    and pg_version|int >= 13
+    tpa_subscription_token|length > 0
+    and install_bdr_packages|bool
+    and pg_version|int >= 14
   loop: "{{ edb_2q_repositories }}"
 
 - name: Install EDB repository 2.0


### PR DESCRIPTION
Removing the bdr nodes checks for setup_repo. Now the installation of BDR packages and setup_repo are based on install_bdr_packages and tpa_subscription_token