### PR TITLE
Allow usage of custom SSL key and certificate

### DIFF
--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -58,6 +58,13 @@ pg_superuser: "postgres"
 pg_superuser_password: ""
 pg_random_password: true
 
+# Local path to SSL server key and certificate to be sent to the server
+# if empty, they are generated
+pg_ssl_key_file: ""
+pg_ssl_cert_file: ""
+pg_ssl_ca_file: ""
+pg_ssl_crl_file: ""
+
 # Input variables
 input_user: ""
 input_password: ""

--- a/roles/init_dbserver/tasks/init_dbserver.yml
+++ b/roles/init_dbserver/tasks/init_dbserver.yml
@@ -62,6 +62,7 @@
 
 - name: Configure ssl based on pg_ssl parameter
   block:
+    - import_tasks: pg_ssl_send_files.yml
     - import_tasks: pg_ssl_check.yml
     - import_tasks: pg_ssl_config.yml
   become: yes

--- a/roles/init_dbserver/tasks/pg_ssl_send_files.yml
+++ b/roles/init_dbserver/tasks/pg_ssl_send_files.yml
@@ -1,0 +1,44 @@
+---
+- name: Send SSL key file
+  ansible.builtin.copy:
+    src: "{{ pg_ssl_key_file }}"
+    dest: "{{ pg_data }}/server.key"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: "0600"
+  become: true
+  when:
+    - pg_ssl_key_file|length > 0
+
+- name: Send SSL certificate file
+  ansible.builtin.copy:
+    src: "{{ pg_ssl_cert_file }}"
+    dest: "{{ pg_data }}/server.crt"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: "0600"
+  become: true
+  when:
+    - pg_ssl_cert_file|length > 0
+
+- name: Send SSL CA file
+  ansible.builtin.copy:
+    src: "{{ pg_ssl_ca_file }}"
+    dest: "{{ pg_data }}/root.crt"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: "0600"
+  become: true
+  when:
+    - pg_ssl_ca_file|length > 0
+
+- name: Send SSL CRL file
+  ansible.builtin.copy:
+    src: "{{ pg_ssl_crl_file }}"
+    dest: "{{ pg_data }}/root.crl"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: "0600"
+  become: true
+  when:
+    - pg_ssl_crl_file|length > 0


### PR DESCRIPTION
With the help of the new variables: pg_ssl_key_file, pg_ssl_cert_file, pg_ssl_ca_file and pg_ssl_crl_file, it is now possible to send and use existing SSL certificates/keys.