### PR TITLE
OracleLinux7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ $ ansible-playbook playbook.yml \
 | --------------------------------- |:----------------:|:----------------:|:----------------:|:----------------:|:----------------:|
 | CentOS 7                          |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | Red Hat Linux 7                   |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+| Oracle Linux 7                    |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | RockyLinux 8                      |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | Red Hat Linux 8                   |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | Ubuntu 20.04 LTS (Focal) - x86_64 |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
@@ -326,6 +327,7 @@ $ ansible-playbook playbook.yml \
 | --------------------------------- |:----------------:|:----------------:|:----------------:|:----------------:|:----------------:|
 | CentOS 7                          |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | Red Hat Linux 7                   |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+| Oracle Linux 7                    |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | RockyLinux 8                      |               :x:|               :x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | Red Hat Linux 8                   |               :x:|               :x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | Ubuntu 20.04 LTS (Focal) - x86_64 |               :x:|               :x:|               :x:|:white_check_mark:|:white_check_mark:|

--- a/roles/autotuning/defaults/main.yml
+++ b/roles/autotuning/defaults/main.yml
@@ -13,3 +13,4 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - OracleLinux7

--- a/roles/autotuning/tasks/setup_tuned.yml
+++ b/roles/autotuning/tasks/setup_tuned.yml
@@ -21,17 +21,19 @@
       {{ [ ((ansible_memtotal_mb - ansible_swaptotal_mb) / ansible_memtotal_mb * 100) | int,
            50 ] | max }}
 
-- name: Set the variable tuned_disk_elevator for CentOS/RHEL 7
+- name: Set the variable tuned_disk_elevator on EL7
   set_fact:
     tuned_disk_elevator: "deadline"
   when:
-    - os in ['CentOS7', 'RHEL7']
+    - ansible_distribution_major_version == '7'
+    - ansible_os_family == 'RedHat'
 
-- name: Set the variable tuned_disk_elevator for CentOS/RHEL 8/Rocky 8
+- name: Set the variable tuned_disk_elevator on EL8
   set_fact:
     tuned_disk_elevator: "mq-deadline"
   when:
-    - os in ['CentOS8', 'RHEL8', 'Rocky8']
+    - ansible_distribution_major_version == '8'
+    - ansible_os_family == 'RedHat'
 
 - name: Set the variable tuned_disk_elevator for Debian
   set_fact:

--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -71,6 +71,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - OracleLinux7
 
 supported_pg_type:
   - EPAS

--- a/roles/init_dbserver/tasks/pg_setup_systemd.yml
+++ b/roles/init_dbserver/tasks/pg_setup_systemd.yml
@@ -10,7 +10,7 @@
     group: root
   become: true
   when:
-    - ansible_distribution in ['RedHat', 'CentOS', 'Rocky']
+    - ansible_os_family == 'RedHat'
 
 - name: Update systemd unit file
   ansible.builtin.lineinfile:
@@ -31,4 +31,4 @@
       regexp: "^ExecStopPost=.*"
       insertafter: "^\\[Service\\]$"
   when:
-    - ansible_distribution in ['RedHat', 'CentOS', 'Rocky']
+    - ansible_os_family == 'RedHat'

--- a/roles/install_dbserver/defaults/main.yml
+++ b/roles/install_dbserver/defaults/main.yml
@@ -19,6 +19,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - OracleLinux7
 
 supported_pg_type:
   - EPAS

--- a/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
@@ -1,22 +1,23 @@
 ---
-- name: Install python packages
+
+- name: Install python packages on EL7
   package:
     name:
       - python-pip
       - python-psycopg2
       - python-ipaddress
     state: present
-  when: os in ['RedHat7','CentOS7']
-  become: yes
+  when: ansible_distribution_major_version == '7'
+  become: true
 
-- name: Install python packages
+- name: Install python packages on EL8
   package:
     name:
       - python3-pip
       - python3-psycopg2
     state: present
-  when: os in ['RedHat8','CentOS8','Rocky8']
-  become: yes
+  when: ansible_distribution_major_version == '8'
+  become: true
 
 - name: "Install EPAS 10 packages"
   package:

--- a/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
@@ -23,21 +23,20 @@
     state: absent
   become: yes
 
-- name: Remove python packages
+- name: Remove python packages on EL7
   package:
     name:
       - python-pip
       - python-psycopg2
     state: absent
-  when: os in ['RedHat7','CentOS7']
-  become: yes
+  when: ansible_distribution_major_version == '7'
+  become: true
 
-- name: Remove python packages
+- name: Remove python packages on EL8
   package:
     name:
       - python3-pip
       - python3-psycopg2
     state: absent
-  when: os in ['RedHat8','CentOS8','Rocky8']
-  become: yes
-
+  when: ansible_distribution_major_version == '8'
+  become: true

--- a/roles/install_dbserver/tasks/PG_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_install.yml
@@ -8,10 +8,10 @@
   changed_when: disable_builtin_postgres.rc == 0
   failed_when: disable_builtin_postgres.rc != 0
   ignore_errors: yes
-  become: yes
-  when: os in ['RedHat8','CentOS8', 'Rocky8']
+  become: true
+  when: ansible_distribution_major_version == '8'
 
-- name: Install require python package
+- name: Install require python package on EL7
   package:
     name:
       - python-pycurl
@@ -19,18 +19,18 @@
       - python-psycopg2
       - python-ipaddress
     state: present
-  when: os in ['RedHat7','CentOS7']
-  become: yes
+  when: ansible_distribution_major_version == '7'
+  become: true
 
-- name: Install require python package
+- name: Install require python package on EL8
   package:
     name:
       - python3-pycurl
       - python3-libselinux
       - python3-psycopg2
     state: present
-  become: yes
-  when: os in ['RedHat8','CentOS8','Rocky8']
+  become: true
+  when: ansible_distribution_major_version == '8'
 
 - name: Install Postgres
   package:

--- a/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
@@ -5,7 +5,7 @@
     state: stopped
   become: yes
 
-- name: Remove require python package
+- name: Remove require python package on EL7
   package:
     name:
       - python-pycurl
@@ -13,18 +13,18 @@
       - python-psycopg2
       - python-ipaddress
     state: absent
-  when: os in ['RedHat7','CentOS7']
-  become: yes
+  when: ansible_distribution_major_version == '7'
+  become: true
 
-- name: Remove require python package
+- name: Remove require python package on EL8
   package:
     name:
       - python3-pycurl
       - python3-libselinux
       - python3-psycopg2
     state: absent
-  become: yes
-  when: os in ['RedHat8','CentOS8','Rocky8']
+  become: true
+  when: ansible_distribution_major_version == '8'
 
 - name: Remove Postgres
   package:

--- a/roles/manage_pgbouncer/defaults/main.yml
+++ b/roles/manage_pgbouncer/defaults/main.yml
@@ -20,3 +20,5 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Debian10
+  - OracleLinux7

--- a/roles/manage_pgpool2/defaults/main.yml
+++ b/roles/manage_pgpool2/defaults/main.yml
@@ -9,6 +9,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - OracleLinux7
 
 supported_pg_version:
   - 10

--- a/roles/setup_barman/defaults/main.yml
+++ b/roles/setup_barman/defaults/main.yml
@@ -16,3 +16,4 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - OracleLinux7

--- a/roles/setup_barmanserver/defaults/main.yml
+++ b/roles/setup_barmanserver/defaults/main.yml
@@ -22,3 +22,4 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - OracleLinux7

--- a/roles/setup_barmanserver/tasks/install_packages.yml
+++ b/roles/setup_barmanserver/tasks/install_packages.yml
@@ -1,45 +1,45 @@
 ---
 
-- name: Set package names for CentOS/RHEL/Rocky
+- name: Set package names for RedHat distribution
   set_fact:
     _barman_package: >-
       {{ barman_package }}.*el{{ os[-1:] }}
     _barman_cli_package: >-
       {{ barman_cli_package }}.*el{{ os[-1:] }}
-  when: os is search("(CentOS|RHEL|Rocky)")
+  when:
+    - ansible_os_family == 'RedHat'
 
-- name: Install Barman packages for CentOS/RHEL 8/Rocky 8
-  dnf:
-    name:
-      - "{{ _barman_package }}"
-      - "{{ _barman_cli_package }}"
-    state: present
-  when: os in ['CentOS8', 'RHEL8', 'Rocky8']
-  become: yes
-
-- name: Remove require python package
+# Remove default python-psycopg2 package, if any. Barman installation will
+# later pull the right version. We need to remove it first because the version
+# coming from barman repo is a replacement of the default package, not an
+# upgrade.
+- name: Remove require python package on EL7
   package:
     name:
       - python-psycopg2
     state: absent
-  when: os in ['RedHat7','CentOS7']
-  become: yes
+  when:
+    - ansible_distribution_major_version == '7'
+    - ansible_os_family == 'RedHat'
+  become: true
 
-- name: Install Barman packages for CentOS/RHEL 7
-  yum:
+- name: Install Barman packages on EL
+  package:
     name:
       - "{{ _barman_package }}"
       - "{{ _barman_cli_package }}"
     state: present
-  when: os in ['CentOS7', 'RHEL7']
-  become: yes
+  when:
+    - ansible_os_family == 'RedHat'
+  become: true
 
-- name: Install Barman packages for Debian
+- name: Install Barman packages on Debian
   apt:
     name:
       - barman
       - barman-cli
       - barman-cli-cloud
     state: present
-  when: ansible_os_family == 'Debian'
-  become: yes
+  when:
+    - ansible_distribution == 'Debian'
+  become: true

--- a/roles/setup_dbt2/defaults/main.yml
+++ b/roles/setup_dbt2/defaults/main.yml
@@ -13,3 +13,4 @@ supported_os:
   - RedHat7
   - RedHat8
   - Rocky8
+  - OracleLinux7

--- a/roles/setup_dbt2_driver/defaults/main.yml
+++ b/roles/setup_dbt2_driver/defaults/main.yml
@@ -12,3 +12,4 @@ supported_os:
   - RedHat7
   - RedHat8
   - Rocky8
+  - OracleLinux7

--- a/roles/setup_efm/defaults/main.yml
+++ b/roles/setup_efm/defaults/main.yml
@@ -93,6 +93,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - OracleLinux7
 
 supported_pg_type:
   - EPAS

--- a/roles/setup_pemagent/defaults/main.yml
+++ b/roles/setup_pemagent/defaults/main.yml
@@ -41,6 +41,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - OracleLinux7
 
 supported_pg_type:
   - EPAS

--- a/roles/setup_pemserver/defaults/main.yml
+++ b/roles/setup_pemserver/defaults/main.yml
@@ -63,6 +63,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - OracleLinux7
 
 supported_pg_type:
   - EPAS

--- a/roles/setup_pgbouncer/defaults/main.yml
+++ b/roles/setup_pgbouncer/defaults/main.yml
@@ -82,3 +82,5 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Debian10
+  - OracleLinux7

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -53,6 +53,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - OracleLinux7
 
 supported_pg_version:
   - 10

--- a/roles/setup_pgpool2/tasks/pgpool2_install.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_install.yml
@@ -1,36 +1,40 @@
 ---
-- name: Install pgpoolII package on CentOS7 or RHEL7
-  yum:
-    name: "{{ pgpool2_package_name }}"
-  when: os in ['CentOS7', 'RHEL7']
-  become: yes
-
-- name: Install pgpoolII package on CentOS8 or RHEL8 or Rocky8
-  dnf:
-    name: "{{ pgpool2_package_name }}"
-  when: os in ['CentOS8', 'RHEL8', 'Rocky8']
-  become: yes
-
-- name: Install openssl package on CentOS7 or RHEL7
-  yum:
-    name: "openssl"
+- name: Disable builtin postgresql module on EL8
+  shell: >
+    dnf -qy module disable postgresql
+  args:
+    executable: /bin/bash
+  register: disable_builtin_postgres
+  changed_when: disable_builtin_postgres.rc == 0
+  failed_when: disable_builtin_postgres.rc != 0
+  ignore_errors: yes
+  become: true
   when:
-    - os in ['CentOS7', 'RHEL7']
-    - pgpool2_ssl
-  become: yes
+    - ansible_distribution_major_version == '8'
+    - ansible_os_family == 'RedHat'
 
-- name: Install pgpool-II-pcp package on CentOS7 or RHEL7 or Rocky8
-  package:
+- name: Install pgpoolII package on RedHat
+  ansible.builtin.package:
+    name: "{{ pgpool2_package_name }}"
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+  become: true
+
+- name: Install openssl package on RedHat
+  ansible.builtin.package:
+    name: "openssl"
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - pgpool2_ssl
+  become: true
+
+- name: Install pgpool-II-pcp package on RedHat
+  ansible.builtin.package:
     name: "pgpool-II-pcp"
+    state: present
   when:
-    - os in ['CentOS7', 'RHEL7', 'Rocky8']
+    - ansible_os_family == 'RedHat'
     - pg_type == 'PG'
-  become: yes
-
-- name: Install openssl package on CentOS8 or RHEL8 or Rocky8
-  dnf:
-    name: "openssl"
-  when:
-    - os in ['CentOS8', 'RHEL8', 'Rocky8']
-    - pgpool2_ssl
-  become: yes
+  become: true

--- a/roles/setup_replication/defaults/main.yml
+++ b/roles/setup_replication/defaults/main.yml
@@ -43,6 +43,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - OracleLinux7
 
 supported_pg_type:
   - EPAS

--- a/roles/setup_repmgr/defaults/main.yml
+++ b/roles/setup_repmgr/defaults/main.yml
@@ -40,6 +40,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - OracleLinux7
 
 supported_pg_type:
   - PG

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -54,6 +54,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - OracleLinux7
 
 supported_pg_type:
   - EPAS

--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -5,62 +5,62 @@
     state: latest
   become: true
 
-- name: Download EDB GPG key for RedhHat 8
+- name: Download EDB GPG key for EL8
   rpm_key:
     key: "{{ edb_gpg_key_8 }}"
     state: present
   when:
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version == '8'
     - enable_edb_repo|bool
   become: yes
 
-- name: Download PGDG GPG key for CentOS8/RHEL8
+- name: Download PGDG GPG key for EL8
   rpm_key:
     key: "{{ pg_gpg_key_8 }}"
     state: present
   when:
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version == '8'
     - pg_type == 'PG'
   become: yes
 
-- name: Download EPEL GPG key for RedHat 8
+- name: Download EPEL GPG key for EL8
   rpm_key:
     key: "{{ epel_gpg_key_8 }}"
     state: present
   when:
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version == '8'
   become: yes
 
-- name: Install EPEL repo for RedHat 7
+- name: Install EPEL repo for EL7
   package:
     name: "{{ epel_repo_7 }}"
     state: present
-  when: ansible_distribution_major_version == "7"
+  when: ansible_distribution_major_version == '7'
   become: yes
 
-- name: Install PG repo for RedHat 7
+- name: Install PG repo for EL7
   package:
     name: "{{ pg_rpm_repo_7 }}"
     state: present
   become: yes
   when:
-    - ansible_distribution_major_version == "7"
+    - ansible_distribution_major_version == '7'
     - pg_type == 'PG'
 
-- name: Install EPEL repo for RedHat 8
+- name: Install EPEL repo for EL8
   package:
     name: "{{ epel_repo_8 }}"
     state: present
-  when: ansible_distribution_major_version == "8"
+  when: ansible_distribution_major_version == '8'
   become: yes
 
-- name: Install PG repo for RedHat 8
+- name: Install PG repo for EL8
   package:
     name: "{{ pg_rpm_repo_8 }}"
     state: present
   become: yes
   when:
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version == '8'
     - pg_type == 'PG'
 
 - name: Install EPAS repo for RedHat


### PR DESCRIPTION
This commit adds OracleLinux7 support and revisits how the OS family detection is performed. In the future, adding support to other OS' from the RedHat family will be easier.