### PR TITLE
Minor fixes of EFM eager failover

### DIFF
--- a/roles/manage_dbpatches/defaults/main.yml
+++ b/roles/manage_dbpatches/defaults/main.yml
@@ -13,6 +13,7 @@ pass_dir: "~/.edb"
 use_hostname: true
 
 skip_primary: false
+efm_eager_failover: false
 skip_standby: false
 
 pg_efm_user: "efm"

--- a/roles/setup_efm/tasks/efm_configure.yml
+++ b/roles/setup_efm/tasks/efm_configure.yml
@@ -141,9 +141,9 @@
     enabled: yes
     state: restarted
   become: yes
-  when: >-
-    ( efm_nodes_update.changed or ( properties_changes is defined and properties_changes.changed ))
-     and efm_service_file.stat.exists
+  when:
+    - ( efm_nodes_update.changed or properties_changes.changed )
+    - efm_service_file.stat.exists
 
 - name: Force systemd to reread configs of {{ pg_service }} after changes
   ansible.builtin.systemd:


### PR DESCRIPTION
Added declaration of variables of efm_eager_failover in manage_dbpatches. Also, protected properties_changes from causing any failure due to no changes.