### PR TITLE
Fix PG repo setup on Debian

### DIFF
--- a/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
@@ -17,8 +17,8 @@
     mode: 0600
   when:
     - os != 'Debian9'
-    - not auth_conf.stat.exists or auth_conf.stat.size == 0
     - enable_edb_repo|bool and repo_token|length < 1
+    - not auth_conf.stat.exists or auth_conf.stat.size == 0
   become: true
 
 - name: Install gpg


### PR DESCRIPTION
Hello,

Repository setup fails on Debian because auth_conf is not set when enable_edb_repo is false, playbook terminates with the following error message :

`FAILED! => {"msg": "The conditional check 'not auth_conf.stat.exists or auth_conf.stat.size == 0' failed. The error was: error while evaluating conditional (not auth_conf.stat.exists or auth_conf.stat.size == 0): 'dict object' has no attribute 'stat'\n\nThe error appears to be in '.ansible/collections/ansible_collections/edb_devops/edb_postgres/roles/setup_repo/tasks/PG_Debian_setuprepos.yml': line 10, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Build EDB auth conf\n  ^ here\n"}`