### PR TITLE
setup_efm: execute WAL checking op. with root priv

### DIFF
--- a/roles/setup_efm/tasks/setup_efm.yml
+++ b/roles/setup_efm/tasks/setup_efm.yml
@@ -29,6 +29,7 @@
   register: waldir
   when:
     - "'witness' not in group_names"
+  become: true
 
 - name: Ensure parent WAL dir has correct permissions
   file:
@@ -38,6 +39,7 @@
     - "'witness' not in group_names"
     - waldir is defined
     - waldir.stat.islnk
+  become: true
 
 - name: Gather service facts
   service_facts:


### PR DESCRIPTION
Fixing a Permission denied error when the ssh_user does not have sufficient rights on PGDATA.