### PR TITLE
efm-api-node-state support

### DIFF
--- a/roles/setup_efm/defaults/main.yml
+++ b/roles/setup_efm/defaults/main.yml
@@ -80,6 +80,16 @@ efm_packages_debian:
   - openjdk-8-jdk
   - edb-efm{{ efm_install_version }}
 
+# Enable efm-api-node-state deployment
+efm_api_node_state: false
+efm_api_node_state_version: "0.1.0"
+efm_api_node_state_port: 8000
+efm_api_node_state_listen_addr: "0.0.0.0"
+efm_api_node_state_supported_os:
+  - CentOS7
+  - RedHat7
+  - OracleLinux7
+
 # Integration with pgpoolII
 pgpool2_version: 4.1
 efm_pgpool2_integration: false

--- a/roles/setup_efm/tasks/efm_api_node_state_setup.yml
+++ b/roles/setup_efm/tasks/efm_api_node_state_setup.yml
@@ -1,0 +1,41 @@
+---
+- name: Gather service facts
+  service_facts:
+
+- name: Install efm-api-node-state package
+  ansible.builtin.package:
+    name: "https://github.com/EnterpriseDB/efm-api-node-state/releases/download/v{{ efm_api_node_state_version }}/efm-api-node-state-{{ efm_api_node_state_version }}-1.el7.x86_64.rpm"
+    state: present
+  become: true
+  when:
+    - ansible_distribution_major_version == '7'
+    - ansible_os_family == 'RedHat'
+
+- name: Build efm-api-node-state configuration file
+  ansible.builtin.template:
+    src: efm-api-node-state-config.toml.template
+    dest: /etc/edb/efm-api-node-state/config.toml
+    owner: root
+    group: root
+    mode: 0644
+  become: true
+
+- name: Open TCP port {{ efm_api_node_state_port }}
+  ansible.posix.firewalld:
+    port: "{{ efm_api_node_state_port }}/tcp"
+    permanent: yes
+    state: enabled
+    immediate: true
+  when:
+    - ansible_facts.services['firewalld.service'] is defined
+    - ansible_facts.services['firewalld.service'].state == 'running'
+    - ansible_facts.services['firewalld.service'].status == 'enabled'
+  become: true
+
+- name: Enable and start efm-api-node-state service
+  ansible.builtin.systemd:
+    name: efm-api-node-state
+    enabled: true
+    daemon_reload: yes
+    state: started
+  become: true

--- a/roles/setup_efm/tasks/setup_efm.yml
+++ b/roles/setup_efm/tasks/setup_efm.yml
@@ -8,6 +8,13 @@
     msg: "Operating System = {{ os }} not supported."
   when: os not in supported_os
 
+- name: Check EFM API node state support
+  fail:
+    msg: "EFM API node state not supported on {{ os }}"
+  when:
+    - efm_api_node_state
+    - os not in efm_api_node_state_supported_os
+
 - name: Check supported versions for Database engine
   fail:
     msg: "Database Engine Version = {{ pg_version }} not supported.
@@ -163,6 +170,13 @@
 - name: EFM parameters settings
   include_tasks: efm_cluster_set_params.yml
   no_log: "{{ disable_logging }}"
+
+
+- name: EFM API node state setup
+  include_tasks: efm_api_node_state_setup.yml
+  no_log: "{{ disable_logging }}"
+  when:
+    - efm_api_node_state
 
 - name: Reset the variables used in this role
   set_fact:

--- a/roles/setup_efm/templates/efm-api-node-state-config.toml.template
+++ b/roles/setup_efm/templates/efm-api-node-state-config.toml.template
@@ -1,0 +1,8 @@
+[config]
+primary_command = "/usr/edb/efm-api-node-state/scripts/efm_check_primary.sh {{ efm_version }} {{ efm_cluster_name }}"
+standby_command = "/usr/edb/efm-api-node-state/scripts/efm_check_standby.sh {{ efm_version }} {{ efm_cluster_name }}"
+listen_addr = "{{ efm_api_node_state_listen_addr }}"
+port = {{ efm_api_node_state_port }}
+shell = "/bin/sh"
+# DEBUG, INFO, WARN, ERROR
+log_level = "INFO"

--- a/tests/cases/setup_efm_api/Makefile
+++ b/tests/cases/setup_efm_api/Makefile
@@ -1,0 +1,11 @@
+include ../../Makefile.mk
+
+build-centos7:
+	docker compose up primary1-centos7 -d
+	docker compose up standby1-centos7 -d
+	docker compose up standby2-centos7 -d
+
+build-oraclelinux7:
+	docker compose up primary1-oraclelinux7 -d
+	docker compose up standby1-oraclelinux7 -d
+	docker compose up standby2-oraclelinux7 -d

--- a/tests/cases/setup_efm_api/docker-compose.yml
+++ b/tests/cases/setup_efm_api/docker-compose.yml
@@ -1,0 +1,84 @@
+version: '3'
+
+services:
+  ansible-tester:
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ansible-tester
+    environment:
+    - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
+    - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
+    - EDB_PG_TYPE
+    - EDB_PG_VERSION
+    - CASE_NAME=setup_efm_api
+    - EDB_OS
+    volumes:
+    - ../../..:/workspace
+    command: "/workspace/tests/docker/exec-tests.sh"
+  primary1-centos7:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.centos7
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-centos7:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.centos7
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-centos7:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.centos7
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  primary1-oraclelinux7:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.oraclelinux7
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-oraclelinux7:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.oraclelinux7
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-oraclelinux7:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.oraclelinux7
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init

--- a/tests/cases/setup_efm_api/inventory.yml.j2
+++ b/tests/cases/setup_efm_api/inventory.yml.j2
@@ -1,0 +1,20 @@
+---
+all:
+  children:
+    primary:
+      hosts:
+        primary1:
+          ansible_host: {{ inventory_vars['primary1_ip'] }}
+          private_ip: {{ inventory_vars['primary1_ip'] }}
+    standby:
+      hosts:
+        standby1:
+          ansible_host: {{ inventory_vars['standby1_ip'] }}
+          private_ip: {{ inventory_vars['standby1_ip'] }}
+          replication_type: synchronous
+          upstream_node_private_ip: {{ inventory_vars['primary1_ip'] }}
+        standby2:
+          ansible_host: {{ inventory_vars['standby2_ip'] }}
+          private_ip: {{ inventory_vars['standby2_ip'] }}
+          replication_type: asynchronous
+          upstream_node_private_ip: {{ inventory_vars['primary1_ip'] }}

--- a/tests/cases/setup_efm_api/playbook.yml
+++ b/tests/cases/setup_efm_api/playbook.yml
@@ -1,0 +1,28 @@
+---
+- hosts: all
+  name: Postgres deployment playbook
+  become: yes
+  gather_facts: yes
+
+  collections:
+    - edb_devops.edb_postgres
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        disable_logging: false
+        efm_version: 4.5
+        efm_api_node_state: true
+        efm_api_node_state_port: 8000
+
+  roles:
+    - role: setup_repo
+      when: "'setup_repo' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: install_dbserver
+      when: "'install_dbserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: init_dbserver
+      when: "'init_dbserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: setup_replication
+      when: "'setup_replication' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: setup_efm
+      when: "'setup_efm' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"

--- a/tests/cases/setup_efm_api/vars.json
+++ b/tests/cases/setup_efm_api/vars.json
@@ -1,0 +1,5 @@
+{
+  "use_hostname": false,
+  "pg_data": "/opt/pgdata",
+  "pg_wal": "/opt/pgwal"
+}

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -313,3 +313,16 @@ cases:
     - debian9
     - debian10
     - ubuntu20
+  setup_efm_api:
+    pg_version:
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    pg_type:
+    - PG
+    - EPAS
+    os:
+    - centos7
+    - oraclelinux7

--- a/tests/tests/test_setup_efm_api.py
+++ b/tests/tests/test_setup_efm_api.py
@@ -1,0 +1,23 @@
+import pytest
+import json
+
+from conftest import (
+    get_pg_cluster_nodes
+)
+
+def test_setup_efm_api_package():
+    for (_, host) in get_pg_cluster_nodes():
+        assert host.package("efm-api-node-state").is_installed, \
+            "Package efm-api-node-state not installed"
+
+def test_setup_efm_api_service():
+    for (_, host) in get_pg_cluster_nodes():
+        assert host.service("efm-api-node-state").is_running, \
+            "efm-api-node-state service not running"
+        assert host.service("efm-api-node-state").is_enabled, \
+            "efm-api-node-state service not enabled"
+
+def test_setup_efm_api_port():
+    for (_, host) in get_pg_cluster_nodes():
+        assert host.socket("tcp://0.0.0.0:8000").is_listening, \
+            "efm-api-node is not listening on 0.0.0.0:8000"


### PR DESCRIPTION
This commit adds support to the EFM api component on EL7.

For enabling it, the efm_api_node_state var must be set to true.