### PR TITLE
Remove standby limitation from setup_barman README.md

### DIFF
--- a/roles/setup_barman/README.md
+++ b/roles/setup_barman/README.md
@@ -72,6 +72,8 @@ Backup method. Can be:
 
 Default: `rsync`
 
+Note: When backing up standby nodes with `backup_method = rsync` the minimum supported version of Barman is 2.8.
+
 ## Dependencies
 
 This role does not have any dependencies, but packages repositories should have

--- a/roles/setup_barman/README.md
+++ b/roles/setup_barman/README.md
@@ -72,9 +72,6 @@ Backup method. Can be:
 
 Default: `rsync`
 
-Note: `rsync` backups can only be proceeded on primary nodes. Backuping
-standby nodes must be done with the `postgres` backup method.
-
 ## Dependencies
 
 This role does not have any dependencies, but packages repositories should have


### PR DESCRIPTION
Removes the limitation around using `backup_method = rsync` against standby nodes. It is now possible to backup standby nodes using `backup_method = rsync` with all currently supported PostgreSQL versions so the limitation no longer applies. This is true as long as `backup_options = concurrent_backup` which is the case in edb-ansible for both rsync and postgres backup methods.

Closes #397.