### PR TITLE
Add ubuntu support to barman roles

### DIFF
--- a/roles/setup_barman/defaults/main.yml
+++ b/roles/setup_barman/defaults/main.yml
@@ -23,3 +23,4 @@ supported_os:
   - RHEL8
   - Rocky8
   - OracleLinux7
+  - Ubuntu20

--- a/roles/setup_barmanserver/defaults/main.yml
+++ b/roles/setup_barmanserver/defaults/main.yml
@@ -25,3 +25,4 @@ supported_os:
   - RHEL8
   - Rocky8
   - OracleLinux7
+  - Ubuntu20

--- a/roles/setup_barmanserver/tasks/install_packages.yml
+++ b/roles/setup_barmanserver/tasks/install_packages.yml
@@ -41,5 +41,5 @@
       - barman-cli-cloud
     state: present
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_os_family == 'Debian'
   become: true

--- a/tests/cases/setup_barman/Makefile
+++ b/tests/cases/setup_barman/Makefile
@@ -15,3 +15,8 @@ build-debian10:
 build-oraclelinux7:
 	docker compose up primary1-oraclelinux7 -d
 	docker compose up barman1-oraclelinux7 -d
+
+build-ubuntu20:
+	docker compose up primary1-ubuntu20 -d
+	docker compose up barman1-ubuntu20 -d
+

--- a/tests/cases/setup_barman/docker-compose.yml
+++ b/tests/cases/setup_barman/docker-compose.yml
@@ -112,3 +112,33 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  barman1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock

--- a/tests/cases/setup_barmanserver/Makefile
+++ b/tests/cases/setup_barmanserver/Makefile
@@ -15,3 +15,8 @@ build-debian10:
 build-oraclelinux7:
 	docker compose up primary1-oraclelinux7 -d
 	docker compose up barman1-oraclelinux7 -d
+
+build-ubuntu20:
+	docker compose up primary1-ubuntu20 -d
+	docker compose up barman1-ubuntu20 -d
+

--- a/tests/cases/setup_barmanserver/docker-compose.yml
+++ b/tests/cases/setup_barmanserver/docker-compose.yml
@@ -112,3 +112,33 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  barman1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -202,6 +202,7 @@ cases:
     - rocky8
     - debian10
     - oraclelinux7
+    - ubuntu20
   setup_barman:
     pg_version:
     - 10
@@ -217,6 +218,7 @@ cases:
     - rocky8
     - debian10
     - oraclelinux7
+    - ubuntu20
   setup_repmgr:
     pg_version:
     - 10

--- a/tests/test-runner.py
+++ b/tests/test-runner.py
@@ -234,7 +234,8 @@ if __name__ == '__main__':
         execute_test = False if len(env.keyword) > 0 else True
 
         for k in env.keyword:
-            if re.search(re.escape(k), name):
+            # if re.search(re.escape(k), name):
+            if re.search(k, name):
                 execute_test = True
 
         if not execute_test:

--- a/tests/test-runner.py
+++ b/tests/test-runner.py
@@ -234,8 +234,7 @@ if __name__ == '__main__':
         execute_test = False if len(env.keyword) > 0 else True
 
         for k in env.keyword:
-            # if re.search(re.escape(k), name):
-            if re.search(k, name):
+            if re.search(re.escape(k), name):
                 execute_test = True
 
         if not execute_test:


### PR DESCRIPTION
Passed tests with PG 12, 13, and 14 and EPAS 14. EPAS 12 and 13 are returning an error in the `init_dbserver` role so I skipped them for now. 