### PR TITLE
add ubuntu support to pgbouncer roles

### DIFF
--- a/roles/manage_pgbouncer/defaults/main.yml
+++ b/roles/manage_pgbouncer/defaults/main.yml
@@ -12,3 +12,4 @@ supported_os:
   - Rocky8
   - Debian10
   - OracleLinux7
+  - Ubuntu20

--- a/roles/setup_pgbouncer/defaults/main.yml
+++ b/roles/setup_pgbouncer/defaults/main.yml
@@ -66,3 +66,4 @@ supported_os:
   - Rocky8
   - Debian10
   - OracleLinux7
+  - Ubuntu20

--- a/tests/cases/manage_pgbouncer/Makefile
+++ b/tests/cases/manage_pgbouncer/Makefile
@@ -11,3 +11,8 @@ build-rocky8:
 build-oraclelinux7:
 	docker compose up primary1-oraclelinux7 -d
 	docker compose up pooler1-oraclelinux7 -d
+
+build-ubuntu20:
+	docker compose up primary1-ubuntu20 -d
+	docker compose up pooler1-ubuntu20 -d
+

--- a/tests/cases/manage_pgbouncer/docker-compose.yml
+++ b/tests/cases/manage_pgbouncer/docker-compose.yml
@@ -82,3 +82,33 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  pooler1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock

--- a/tests/cases/setup_pgbouncer/Makefile
+++ b/tests/cases/setup_pgbouncer/Makefile
@@ -19,3 +19,8 @@ build-debian9:
 build-oraclelinux7:
 	docker compose up primary1-oraclelinux7 -d
 	docker compose up pooler1-oraclelinux7 -d
+
+build-ubuntu20:
+	docker compose up primary1-ubuntu20 -d
+	docker compose up pooler1-ubuntu20 -d
+

--- a/tests/cases/setup_pgbouncer/docker-compose.yml
+++ b/tests/cases/setup_pgbouncer/docker-compose.yml
@@ -132,3 +132,33 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  pooler1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -172,6 +172,7 @@ cases:
     - rocky8
     - debian10
     - oraclelinux7
+    - ubuntu20
   manage_pgbouncer:
     pg_version:
     - 10
@@ -187,6 +188,7 @@ cases:
     - rocky8
     - debian10
     - oraclelinux7
+    - ubuntu20
   setup_barmanserver:
     pg_version:
     - 10


### PR DESCRIPTION
Passed tests with PG 12, 13, and 14 and EPAS 14. EPAS 12 and 13 are returning an error in the `init_dbserver` role so I skipped them for now.