### PR TITLE
add ubuntu support to pgbackrest roles

### DIFF
--- a/roles/setup_pgbackrest/defaults/main.yml
+++ b/roles/setup_pgbackrest/defaults/main.yml
@@ -25,3 +25,4 @@ supported_os:
   - RHEL8
   - Rocky8
   - Debian10
+  - Ubuntu20

--- a/roles/setup_pgbackrestserver/defaults/main.yml
+++ b/roles/setup_pgbackrestserver/defaults/main.yml
@@ -55,6 +55,7 @@ supported_os:
   - RHEL8
   - Rocky8
   - Debian10
+  - Ubuntu20
 
 supported_log_level:
   - off

--- a/tests/cases/setup_pgbackrest/Makefile
+++ b/tests/cases/setup_pgbackrest/Makefile
@@ -14,3 +14,8 @@ build-debian10:
 	docker compose up primary1-debian10 -d
 	docker compose up standby1-debian10 -d
 	docker compose up pgbackrest1-debian10 -d
+
+build-ubuntu20:
+	docker compose up primary1-ubuntu20 -d
+	docker compose up standby1-ubuntu20 -d
+	docker compose up pgbackrest1-ubuntu20 -d

--- a/tests/cases/setup_pgbackrest/docker-compose.yml
+++ b/tests/cases/setup_pgbackrest/docker-compose.yml
@@ -117,3 +117,48 @@ services:
     volumes:
       - .:/workspace
       - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+  primary1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  standby1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  pgbackrest1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock

--- a/tests/cases/setup_pgbackrest/vars.json
+++ b/tests/cases/setup_pgbackrest/vars.json
@@ -4,5 +4,6 @@
   "pgbackrest_user": "pgbackrest",
   "pgbackrest_group": "pgbackrest",
   "pgbackrest_configuration_file": "/etc/pgbackrest.conf",
-  "pgbackrest_home": "/var/lib/pgbackrest"
+  "pgbackrest_home": "/var/lib/pgbackrest",
+  "repo_cipher_password": "acbd"
 }

--- a/tests/cases/setup_pgbackrestserver/Makefile
+++ b/tests/cases/setup_pgbackrestserver/Makefile
@@ -14,3 +14,8 @@ build-debian10:
 	docker compose up primary1-debian10 -d
 	docker compose up standby1-debian10 -d
 	docker compose up pgbackrest1-debian10 -d
+
+build-ubuntu20:
+	docker compose up primary1-ubuntu20 -d
+	docker compose up standby1-ubuntu20 -d
+	docker compose up pgbackrest1-ubuntu20 -d

--- a/tests/cases/setup_pgbackrestserver/docker-compose.yml
+++ b/tests/cases/setup_pgbackrestserver/docker-compose.yml
@@ -117,3 +117,48 @@ services:
     volumes:
       - .:/workspace
       - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+  primary1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  standby1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  pgbackrest1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock

--- a/tests/cases/setup_pgbackrestserver/vars.json
+++ b/tests/cases/setup_pgbackrestserver/vars.json
@@ -4,5 +4,6 @@
   "pgbackrest_user": "pgbackrest",
   "pgbackrest_group": "pgbackrest",
   "pgbackrest_configuration_file": "/etc/pgbackrest.conf",
-  "pgbackrest_home": "/var/lib/pgbackrest"
+  "pgbackrest_home": "/var/lib/pgbackrest",
+  "repo_cipher_password": "acbd"
 }

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -338,6 +338,7 @@ cases:
     - rocky8
     - centos7
     - debian10
+    - ubuntu20
   setup_pgbackrestserver:
     pg_version:
     - 14
@@ -350,4 +351,5 @@ cases:
     - rocky8
     - centos7
     - debian10
+    - ubuntu20
 


### PR DESCRIPTION
Passed tests with PG 12, 13, and 14 and EPAS 14. EPAS 12 and 13 are returning an error in the `init_dbserver` role so I skipped them for now.