### PR TITLE
fix epas < 14 install

### DIFF
--- a/roles/install_dbserver/tasks/EPAS_Debian_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_Debian_install.yml
@@ -18,6 +18,22 @@
   when: >-
     pg_version|int < 14
 
+- name: Stop the service {{ epas_service }} for EPAS < 14
+  systemd:
+    name: "{{ epas_service }}"
+    state: stopped
+  when: install_package.changed
+  become: true
+
+- name: Drop the default debian database for EPAS < 14
+  shell: >
+    {{ epas_deb_drop_cluster }} --stop {{ pg_version }} {{ deb_cluster_name }}
+  when: install_package.changed
+  register: drop_cluster
+  changed_when: drop_cluster.rc == 0
+  failed_when: drop_cluster.rc != 0
+  become: true
+
 - name: "Install EPAS >= 14 Packages"
   package:
     name:
@@ -66,14 +82,14 @@
     pg_version|int >= 14
     and install_bdr_packages|bool
 
-- name: Stop the service {{ epas_service }}
+- name: Stop the service {{ epas_service }} for EPAS >= 14
   systemd:
     name: "{{ epas_service }}"
     state: stopped
   when: install_package.changed
   become: true
 
-- name: Drop the default debian database
+- name: Drop the default debian database for EPAS >= 14
   shell: >
     {{ epas_deb_drop_cluster }} --stop {{ pg_version }} {{ deb_cluster_name }}
   when: install_package.changed

--- a/roles/install_dbserver/tasks/EPAS_Debian_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_Debian_install.yml
@@ -1,12 +1,11 @@
 ---
-- name: "Install EPAS < 14 Packages"
+- name: "Install EPAS Packages"
   package:
     name:
       - python3-pip
       - python3-psycopg2
       - edb-as{{ pg_version }}-server
       - edb-as{{ pg_version }}-server-core
-      - edb-as{{ pg_version }}-server-edb-modules
       - edb-as{{ pg_version }}-server-client
       - edb-as{{ pg_version }}-server-indexadvisor
       - edb-as{{ pg_version }}-server-sqlprofiler
@@ -15,41 +14,24 @@
     update_cache: yes
   become: true
   register: install_package
+
+- name: "Install EPAS < 14 Packages"
+  package:
+    name:
+      - edb-as{{ pg_version }}-server-edb-modules
+    state: present
+    update_cache: yes
+  become: true
   when: >-
     pg_version|int < 14
-
-- name: Stop the service {{ epas_service }} for EPAS < 14
-  systemd:
-    name: "{{ epas_service }}"
-    state: stopped
-  when: install_package.changed
-  become: true
-
-- name: Drop the default debian database for EPAS < 14
-  shell: >
-    {{ epas_deb_drop_cluster }} --stop {{ pg_version }} {{ deb_cluster_name }}
-  when: install_package.changed
-  register: drop_cluster
-  changed_when: drop_cluster.rc == 0
-  failed_when: drop_cluster.rc != 0
-  become: true
 
 - name: "Install EPAS >= 14 Packages"
   package:
     name:
-      - python3-pip
-      - python3-psycopg2
-      - edb-as{{ pg_version }}-server
-      - edb-as{{ pg_version }}-server-core
-      - edb-as{{ pg_version }}-server-client
-      - edb-as{{ pg_version }}-server-indexadvisor
-      - edb-as{{ pg_version }}-server-sqlprofiler
-      - edb-as{{ pg_version }}-server-sqlprotect
       - edb-as{{ pg_version }}-server-edb-wait-states
     state: present
     update_cache: yes
   become: true
-  register: install_package
   when: >-
     pg_version|int >= 14
 

--- a/roles/install_dbserver/tasks/EPAS_Debian_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_Debian_install.yml
@@ -64,14 +64,14 @@
     pg_version|int >= 14
     and install_bdr_packages|bool
 
-- name: Stop the service {{ epas_service }} for EPAS >= 14
+- name: Stop the service {{ epas_service }}
   systemd:
     name: "{{ epas_service }}"
     state: stopped
   when: install_package.changed
   become: true
 
-- name: Drop the default debian database for EPAS >= 14
+- name: Drop the default debian database
   shell: >
     {{ epas_deb_drop_cluster }} --stop {{ pg_version }} {{ deb_cluster_name }}
   when: install_package.changed


### PR DESCRIPTION
Adds the commands to drop default database before the variable `install_package` is called again.  