### PR TITLE
Allow pemagent only configuration

### DIFF
--- a/roles/setup_pemagent/defaults/main.yml
+++ b/roles/setup_pemagent/defaults/main.yml
@@ -14,6 +14,8 @@ pg_pem_agent_password: ""
 pg_ssl: true
 disable_logging: true
 
+node_ssh_to_pemserver: true
+enable_pemagent_monitor_barman: false
 pem_server_exists: false
 # efm information
 efm_version: "4.5"

--- a/roles/setup_pemagent/tasks/pem_agent_install.yml
+++ b/roles/setup_pemagent/tasks/pem_agent_install.yml
@@ -12,4 +12,5 @@
     state: present
   become: yes
   no_log: "{{ disable_logging }}"
-  when: pem_server_version_int|int >= 840
+  when: >
+      pem_server_version_int|int >= 840 or enable_pemagent_monitor_barman

--- a/roles/setup_pemagent/tasks/setup_pemagent.yml
+++ b/roles/setup_pemagent/tasks/setup_pemagent.yml
@@ -53,16 +53,19 @@
   delegate_to: "{{ pem_server_info[0].inventory_hostname }}"
   register: pem_server_version_output
   become: yes
+  when: node_ssh_to_pemserver
   no_log: "{{ disable_logging }}"
 
 - name: Register PEM server version as integer
   set_fact:
       pem_server_version_int: "{{ pem_server_version_output.stdout |replace('.','')|int }}"
+  when: node_ssh_to_pemserver
   no_log: "{{ disable_logging }}"
 
 - name: Debug message for Pemagent version
   debug:
       var: pem_server_version_int
+  when: node_ssh_to_pemserver
   no_log: "{{ disable_logging }}"
 
 - name: Remove pem agent based on force_pemserver/force_initdb/force_pemagent
@@ -78,7 +81,9 @@
 
 - name: Fetch PEM admin user password
   import_tasks: pem_agent_fetch_adm_password.yml
-  when: pem_server_exists
+  when:
+    - pem_server_exists
+    - node_ssh_to_pemserver
   no_log: "{{ disable_logging }}"
 
 - name: Create pemagent user on primary
@@ -102,6 +107,7 @@
   # We limit the number of worker for this task to avoid any concurrency issue
   # while updating PEM server HBA file.
   throttle: 2
+  when: node_ssh_to_pemserver
   no_log: "{{ disable_logging }}"
 
 - name: Install and configure pemagent on nodes
@@ -142,7 +148,7 @@
     - import_tasks: pem_agent_barman_config.yml
   become: yes
   when:
-    - pem_server_version_int|int >= 840
+    - (node_ssh_to_pemserver and pem_server_version_int|int >= 840) or enable_pemagent_monitor_barman
     - group_names | select('search', 'barmanserver') | list | count > 0
   no_log: "{{ disable_logging }}"
 


### PR DESCRIPTION
This commit allows users to configure pemagent in case the user doesn't have access to ssh to the PEM server. To make it possible, we have added the following options:
1. node_ssh_to_pemserver: true
2. enable_pemagent_barman: true