### PR TITLE
dbt2 related udpates

### DIFF
--- a/roles/setup_dbt2/defaults/main.yml
+++ b/roles/setup_dbt2/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-dbt2_version: "0.48.3"
+dbt2_version: "0.48.4"
 dbttools_version: "0.3.1"
 driver_pub_key: ""
 pg_dbt2_dbname: dbt2

--- a/roles/setup_dbt2/tasks/dbt2_install_packages_driver.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_driver.yml
@@ -32,6 +32,7 @@
   ansible.builtin.package:
     name:
       - perf
+      - postgresql
       - python3-docutils
       - rsync
       - tmux

--- a/roles/setup_dbt2_client/defaults/main.yml
+++ b/roles/setup_dbt2_client/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 dbt2_client_port: 30000
-dbt2_version: "0.48.3"
+dbt2_version: "0.48.4"
 
 # The following variables are set by the respective vars file.
 pg_data: ""

--- a/roles/setup_dbt2_driver/defaults/main.yml
+++ b/roles/setup_dbt2_driver/defaults/main.yml
@@ -8,7 +8,7 @@ supported_os:
   - Rocky8
   - OracleLinux7
 
-dbt2_version: "0.48.3"
+dbt2_version: "0.48.4"
 dbttools_version: "0.3.1"
 
 # These variables are set in the respective vars file.


### PR DESCRIPTION
Bump the dbt2 version to [v0.48.4](https://github.com/osdldbt/dbt2/blob/v0.48.4/ChangeLog), which contains fixes for capturing postgresql database statistics from DBaaS systems.

The DBT2 driver system also needs to have psql installed.