### PR TITLE
update workflow tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_repo rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_repo rocky8
   install-dbserver:
     runs-on: ubuntu-20.04
     name: Execute install_dbserver tests for PostgreSQL 14 on RockyLinux8
@@ -27,7 +27,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/install_dbserver rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/install_dbserver rocky8
   initdb-dbserver:
     runs-on: ubuntu-20.04
     name: Execute init_dbserver tests for PostgreSQL 14 on RockyLinux8
@@ -36,7 +36,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/init_dbserver rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/init_dbserver rocky8
   setup-replication:
     runs-on: ubuntu-20.04
     name: Execute setup_replication tests for PostgreSQL 14 on RockyLinux8
@@ -45,7 +45,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_replication rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_replication rocky8
   manage-dbserver:
     runs-on: ubuntu-20.04
     name: Execute manage_dbserver tests for PostgreSQL 14 on RockyLinux8
@@ -54,7 +54,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/manage_dbserver rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/manage_dbserver rocky8
   setup-pgpool2:
     runs-on: ubuntu-20.04
     name: Execute setup_pgpool2 tests for PostgreSQL 14 on RockyLinux8
@@ -63,7 +63,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_pgpool2 rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_pgpool2 rocky8
   manage-pgpool2:
     runs-on: ubuntu-20.04
     name: Execute manage_pgpool2 tests for PostgreSQL 14 on RockyLinux8
@@ -72,7 +72,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/manage_pgpool2 rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/manage_pgpool2 rocky8
   setup-pgbouncer:
     runs-on: ubuntu-20.04
     name: Execute setup_pgbouncer tests for PostgreSQL 14 on RockyLinux8
@@ -81,7 +81,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_pgbouncer rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_pgbouncer rocky8
   manage-pgbouncer:
     runs-on: ubuntu-20.04
     name: Execute manage_pgbouncer tests for PostgreSQL 14 on RockyLinux8
@@ -90,7 +90,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/manage_pgbouncer rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/manage_pgbouncer rocky8
   setup-repmgr:
     runs-on: ubuntu-20.04
     name: Execute setup_repmgr tests for PostgreSQL 14 on RockyLinux8
@@ -99,7 +99,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_repmgr rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_repmgr rocky8
   setup-hammerdbserver:
     runs-on: ubuntu-20.04
     name: Execute setup_hammerdbserver tests for PostgreSQL 14 on RockyLinux8
@@ -108,7 +108,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_hammerdbserver rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_hammerdbserver rocky8
   setup-dbt2-driver:
     runs-on: ubuntu-20.04
     name: Execute setup_dbt2_driver tests for PostgreSQL 14 on RockyLinux8
@@ -117,7 +117,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_dbt2_driver rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_dbt2_driver rocky8
   setup-dbt2-client:
     runs-on: ubuntu-20.04
     name: Execute setup_dbt2_client tests for PostgreSQL 14 on RockyLinux8
@@ -126,7 +126,7 @@ jobs:
       - run: sudo apt install python3-pip -y
       - run: sudo pip3 install ansible-core
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_dbt2_client rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_dbt2_client rocky8
   setup-dbt2:
     runs-on: ubuntu-20.04
     name: Execute setup_dbt2 tests for PostgreSQL 14 on RockyLinux8
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: sudo apt install ansible -y
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_dbt2 rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_dbt2 rocky8
   setup-dbt3:
     runs-on: ubuntu-20.04
     name: Execute setup_dbt3 tests for PostgreSQL 14 on RockyLinux8
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: sudo apt install ansible -y
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_dbt3 rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_dbt3 rocky8
   setup-dbt7:
     runs-on: ubuntu-20.04
     name: Execute setup_dbt7 tests for PostgreSQL 14 on RockyLinux8
@@ -150,4 +150,4 @@ jobs:
       - uses: actions/checkout@v2
       - run: sudo apt install ansible -y
       - run: make
-      - run: EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_dbt7 rocky8
+      - run: ANSIBLE_CORE_VERSION=2.12 EDB_PG_TYPE=PG EDB_PG_VERSION=14 EDB_ENABLE_REPO=false make -C tests/cases/setup_dbt7 rocky8


### PR DESCRIPTION
Update workflow tests in `push.yml` to include the `ANSIBLE_CORE_VERSION` environment variable. If it is not set, the test will be unable to build the `ansible-tester` docker image and it will fail. 