### PR TITLE
Hammerdb update

### DIFF
--- a/roles/setup_hammerdb/defaults/main.yml
+++ b/roles/setup_hammerdb/defaults/main.yml
@@ -8,6 +8,8 @@ supported_os:
   - CentOS8
   - RHEL8
   - Rocky8
+  - Debian10
+  - Ubuntu20
 
 supported_tshirt_size:
   - small

--- a/roles/setup_hammerdb/tasks/install_tproc-c_load_scripts.yml
+++ b/roles/setup_hammerdb/tasks/install_tproc-c_load_scripts.yml
@@ -26,8 +26,8 @@
     src: loader.tcl.template
     mode: 0644
   become: false
-  vars:
-    primary_private_ip: "{{ primary_private_ip }}"
+#  vars:
+#    primary_private_ip: "{{ primary_private_ip }}"
 
 - name: Create TPROC-C load script
   ansible.builtin.template:

--- a/roles/setup_hammerdb/tasks/install_tproc-c_load_scripts.yml
+++ b/roles/setup_hammerdb/tasks/install_tproc-c_load_scripts.yml
@@ -26,8 +26,6 @@
     src: loader.tcl.template
     mode: 0644
   become: false
-#  vars:
-#    primary_private_ip: "{{ primary_private_ip }}"
 
 - name: Create TPROC-C load script
   ansible.builtin.template:

--- a/roles/setup_hammerdb/tasks/main.yml
+++ b/roles/setup_hammerdb/tasks/main.yml
@@ -19,9 +19,10 @@
   ansible.builtin.include_tasks: update_pg_hba.yml
 
 - name: Install packages
-  ansible.builtin.yum:
+  ansible.builtin.package:
     name:
       - tmux
+      - curl
   become: true
   failed_when: false
 
@@ -30,11 +31,6 @@
     name: setup_hammerdbserver
     tasks_from: install_hammerdb
 
-#- name: Include Touchstone installation
-#  ansible.builtin.include_role:
-#    name: setup_touchstone
-#    tasks_from: main
-
 - name: Include the TPROC-C load script tasks
   ansible.builtin.include_tasks: install_tproc-c_load_scripts.yml
 
@@ -42,14 +38,13 @@
   ansible.builtin.set_fact:
     _sys_memtotal_mb: "{{ (ansible_memtotal_mb * 1.048576) | int }}"
 
-- name: Set the variable _pg_shared_buffers_mb for HammerDB TPROC-C
+- name: Set the variable _pg_shared_buffers_mb for HammerDB TPROC-C to the lesser of half system memory or 24576
   ansible.builtin.set_fact:
-    _pg_shared_buffers_mb: 24576
+    _pg_shared_buffers_mb: "{{ [(_sys_memtotal_mb | int // 2) | int, 24576] | min }}"
 
-- name: Set the variable _pg_effective_cache_size_mb for HammerDB TPROC-C
+- name: Set the variable _pg_effective_cache_size_mb for HammerDB TPROC-C to a quarter of system memory
   ansible.builtin.set_fact:
-    _pg_effective_cache_size_mb: >-
-      {{ ((_sys_memtotal_mb | int - _pg_shared_buffers_mb | int) - 4096) }}
+    _pg_effective_cache_size_mb: "{{ (_sys_memtotal_mb | int // 4) }}"
 
 - name: Re-initialize the Postgres parameters for t-shirt size {{ tshirt_size }}
   ansible.builtin.set_fact:

--- a/roles/setup_hammerdb/tasks/main.yml
+++ b/roles/setup_hammerdb/tasks/main.yml
@@ -30,10 +30,10 @@
     name: setup_hammerdbserver
     tasks_from: install_hammerdb
 
-- name: Include Touchstone installation
-  ansible.builtin.include_role:
-    name: setup_touchstone
-    tasks_from: main
+#- name: Include Touchstone installation
+#  ansible.builtin.include_role:
+#    name: setup_touchstone
+#    tasks_from: main
 
 - name: Include the TPROC-C load script tasks
   ansible.builtin.include_tasks: install_tproc-c_load_scripts.yml

--- a/roles/setup_hammerdbserver/defaults/main.yml
+++ b/roles/setup_hammerdbserver/defaults/main.yml
@@ -5,3 +5,5 @@ supported_os:
   - CentOS8
   - RHEL8
   - Rocky8
+  - Debian10
+  - Ubuntu20

--- a/roles/setup_hammerdbserver/defaults/main.yml
+++ b/roles/setup_hammerdbserver/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-hammerdb_version: 3.3
+hammerdb_version: 4.6
 supported_os:
   - CentOS8
   - RHEL8

--- a/roles/setup_hammerdbserver/tasks/main.yml
+++ b/roles/setup_hammerdbserver/tasks/main.yml
@@ -14,7 +14,7 @@
   run_once: true
   no_log: "{{ disable_logging }}"
 
-- name: Install packages
+- name: Install packages on RedHat distributions
   ansible.builtin.yum:
     name:
       - curl
@@ -25,11 +25,19 @@
       - tmux
   become: true
   failed_when: false
+  when: ansible_os_family == 'RedHat'
 
-#- name: Include Touchstone installation
-#  ansible.builtin.include_role:
-#    name: setup_touchstone
-#    tasks_from: main
+- name: Install packages on Debian distributions
+  ansible.builtin.package:
+    name:
+      - curl
+      - patch
+      - postgresql
+      - tcl
+      - tmux
+  become: true
+  failed_when: false
+  when: ansible_os_family == 'Debian'
 
 - name: Include HammerDB installation
   ansible.builtin.include_tasks: install_hammerdb.yml

--- a/roles/setup_hammerdbserver/tasks/main.yml
+++ b/roles/setup_hammerdbserver/tasks/main.yml
@@ -26,10 +26,10 @@
   become: true
   failed_when: false
 
-- name: Include Touchstone installation
-  ansible.builtin.include_role:
-    name: setup_touchstone
-    tasks_from: main
+#- name: Include Touchstone installation
+#  ansible.builtin.include_role:
+#    name: setup_touchstone
+#    tasks_from: main
 
 - name: Include HammerDB installation
   ansible.builtin.include_tasks: install_hammerdb.yml

--- a/tests/cases/setup_hammerdb/Makefile
+++ b/tests/cases/setup_hammerdb/Makefile
@@ -3,3 +3,11 @@ include ../../Makefile.mk
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up hammerdb1-rocky8 -d
+
+build-debian10:
+	docker compose up primary1-debian10 -d
+	docker compose up hammerdb1-debian10 -d
+
+build-ubuntu20:
+	docker compose up primary1-ubuntu20 -d
+	docker compose up hammerdb1-ubuntu20 -d

--- a/tests/cases/setup_hammerdb/docker-compose.yml
+++ b/tests/cases/setup_hammerdb/docker-compose.yml
@@ -41,3 +41,63 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-debian10:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.debian10
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  hammerdb1-debian10:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.debian10
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  primary1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  hammerdb1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock

--- a/tests/cases/setup_hammerdbserver/Makefile
+++ b/tests/cases/setup_hammerdbserver/Makefile
@@ -3,3 +3,11 @@ include ../../Makefile.mk
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up hammerdb1-rocky8 -d
+
+build-debian10:
+	docker compose up primary1-debian10 -d
+	docker compose up hammerdb1-debian10 -d
+
+build-ubuntu20:
+	docker compose up primary1-ubuntu20 -d
+	docker compose up hammerdb1-ubuntu20 -d

--- a/tests/cases/setup_hammerdbserver/docker-compose.yml
+++ b/tests/cases/setup_hammerdbserver/docker-compose.yml
@@ -41,3 +41,63 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-debian10:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.debian10
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  hammerdb1-debian10:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.debian10
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  primary1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  hammerdb1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -257,6 +257,8 @@ cases:
     - EPAS
     os:
     - rocky8
+    - debian10
+    - ubuntu20
   setup_hammerdb:
     pg_version:
     - 10
@@ -269,6 +271,8 @@ cases:
     - EPAS
     os:
     - rocky8
+    - debian10
+    - ubuntu20
   setup_dbt2_driver:
     pg_version:
     - 10


### PR DESCRIPTION
Changes version of hammerdb to v4.6.
Removes touchstone tasks from both hammerdb roles. 
Adds support for Debian10 and Ubuntu20 for both hammerdb roles. 