### PR TITLE
Update pgbackrest

### DIFF
--- a/plugins/lookup/pgbackrest_nodes.py
+++ b/plugins/lookup/pgbackrest_nodes.py
@@ -82,6 +82,7 @@ class LookupModule(LookupBase):
 
         # define empty list to place primary_node_ip
         primary_node_ip = []
+        counter = 1
 
         # find the primary pgbackrest node
         for host in variables['groups']['primary']:
@@ -94,9 +95,11 @@ class LookupModule(LookupBase):
                         inventory_hostname=hostvars['inventory_hostname'],
                         ansible_host=hostvars['ansible_host'],
                         hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
-                        private_ip=hostvars['private_ip']
+                        private_ip=hostvars['private_ip'],
+                        index_var=str(counter)
                     ))
                     primary_node_ip.append(hostvars['private_ip'])
+                    counter += 1
 
         # if no corresponding primary pgbackrest node, return empty list
         if len(primary_node_ip) == 0:
@@ -127,8 +130,10 @@ class LookupModule(LookupBase):
                                 inventory_hostname=hostvars['inventory_hostname'],
                                 ansible_host=hostvars['ansible_host'],
                                 hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
-                                private_ip=hostvars['private_ip']
+                                private_ip=hostvars['private_ip'],
+                                index_var=str(counter)
                             ))
+                            counter += 1
 
         return pgbr_nodes
 

--- a/roles/setup_pgbackrest/tasks/configure_pgbackrest.yml
+++ b/roles/setup_pgbackrest/tasks/configure_pgbackrest.yml
@@ -21,6 +21,15 @@
   when:
     - use_hostname|bool
 
+- name: Set _pgbackrest_host when using hostname
+  ansible.builtin.set_fact:
+    _standby_index_var: "{{ item.index_var }}"
+  loop: "{{ standby_node_info }}"
+  when:
+    - standby_present is defined
+    - "'standby' in group_names"
+    - item.inventory_hostname ==  inventory_hostname
+
 - name: Ensure lock directory pgbackrest_lock_path exists
   ansible.builtin.file:
     path: "{{ pgbackrest_lock_path }}"

--- a/roles/setup_pgbackrest/tasks/configure_pgbackrest.yml
+++ b/roles/setup_pgbackrest/tasks/configure_pgbackrest.yml
@@ -21,7 +21,7 @@
   when:
     - use_hostname|bool
 
-- name: Set _pgbackrest_host when using hostname
+- name: Set _standby_index_var for each standby node
   ansible.builtin.set_fact:
     _standby_index_var: "{{ item.index_var }}"
   loop: "{{ standby_node_info }}"
@@ -67,3 +67,4 @@
   ansible.builtin.set_fact:
     _pgbackrest_server_info: ""
     _pgbackrest_host: null
+    _standby_index_var: null

--- a/roles/setup_pgbackrest/tasks/define_node_variables.yml
+++ b/roles/setup_pgbackrest/tasks/define_node_variables.yml
@@ -5,12 +5,12 @@
 
 - name: Determine if standby
   ansible.builtin.set_fact:
-    _standby_list: "{{ pgbackrest_node_info | selectattr('node_type', 'equalto', 'standby') | default([]) | list }}"
+    standby_node_info: "{{ pgbackrest_node_info | selectattr('node_type', 'equalto', 'standby') | default([]) | list }}"
 
 - name: Determine if standby_present
   ansible.builtin.set_fact:
     standby_present: 'y'
-  when: _standby_list|length > 0
+  when: standby_node_info|length > 0
 
 - name: Get primary node informations
   ansible.builtin.set_fact:
@@ -69,7 +69,3 @@
   when:
     - pg_type == 'EPAS'
     - ansible_os_family == 'Debian'
-
-- name: Reset local variables
-  ansible.builtin.set_fact:
-    _standby_list: null

--- a/roles/setup_pgbackrest/tasks/post_configure_pgbackrest.yml
+++ b/roles/setup_pgbackrest/tasks/post_configure_pgbackrest.yml
@@ -27,6 +27,7 @@
   ansible.builtin.set_fact:
     _update_config: "{{ (_update_config | default([]) | union([item]) | flatten) }}"
   when: backup_standby == 'y'
+  run_once: true
   loop:
     - "{{ standby_node_hostname }}"
     - "{{ _pgbackrest_host }}"

--- a/roles/setup_pgbackrest/templates/pgbackrest_standby.async.conf.template
+++ b/roles/setup_pgbackrest/templates/pgbackrest_standby.async.conf.template
@@ -20,7 +20,7 @@ process-max={{ process_max_backup }}
 
 
 [{{ pg_instance_name }}]
-pg2-path={{ pg_data }}
+pg{{ _standby_index_var }}-path={{ pg_data }}
 {% if pg_type == 'PG' %}
 recovery-option=primary_conninfo=host={{ primary_node_hostname[0] }} user={{ replication_user }}
 {% endif %}

--- a/roles/setup_pgbackrest/templates/pgbackrest_standby.standard.conf.template
+++ b/roles/setup_pgbackrest/templates/pgbackrest_standby.standard.conf.template
@@ -11,7 +11,7 @@ lock-path={{ pgbackrest_lock_path }}
 start-fast=y
 
 [{{ pg_instance_name }}]
-pg2-path={{ pg_data }}
+pg{{ _standby_index_var }}-path={{ pg_data }}
 {% if pg_type == 'PG' %}
 recovery-option=primary_conninfo=host={{ primary_node_hostname[0] }} user={{ replication_user }}
 {% endif %}

--- a/roles/setup_pgbackrestserver/tasks/define_node_variables.yml
+++ b/roles/setup_pgbackrestserver/tasks/define_node_variables.yml
@@ -5,12 +5,12 @@
 
 - name: Determine if standby
   ansible.builtin.set_fact:
-    _standby_list: "{{ pgbackrest_node_info | selectattr('node_type', 'equalto', 'standby') | default([]) }}"
+    standby_node_info: "{{ pgbackrest_node_info | selectattr('node_type', 'equalto', 'standby') | default([]) }}"
 
 - name: Determine if backup_standby
   ansible.builtin.set_fact:
     standby_present: 'y'
-  when: _standby_list|length > 0
+  when: standby_node_info|length > 0
 
 - name: Get primary node informations
   ansible.builtin.set_fact:
@@ -38,20 +38,6 @@
     - "not use_hostname|bool"
     - standby_present is defined
 
-- name: Get num of standby nodes
-  ansible.builtin.set_fact:
-    two_standby: true
-  when:
-    - standby_present is defined
-    - _standby_list|length > 1
-
-- name: Get num of standby nodes
-  ansible.builtin.set_fact:
-    three_standby: true
-  when:
-    - standby_present is defined
-    - _standby_list|length > 2
-
 - name: Define postgres user on primary node when pg_type = PG
   ansible.builtin.set_fact:
     primary_host_user: "postgres"
@@ -61,20 +47,6 @@
   ansible.builtin.set_fact:
     primary_host_user: "enterprisedb"
   when: pg_type == 'EPAS'
-
-- name: Define postgres user on standby node when pg_type = PG
-  ansible.builtin.set_fact:
-    standby_host_user: "postgres"
-  when:
-    - pg_type == 'PG'
-    - standby_present is defined
-
-- name: Define postgres user on standby node when pg_type = EPAS
-  ansible.builtin.set_fact:
-    standby_host_user: "enterprisedb"
-  when:
-    - pg_type == 'EPAS'
-    - standby_present is defined
 
 - name: Define EPAS DB information
   ansible.builtin.set_fact:
@@ -93,7 +65,3 @@
   when:
     - pg_type == 'EPAS'
     - ansible_os_family == 'Debian'
-
-- name: Reset local variables
-  ansible.builtin.set_fact:
-    _standby_list: null

--- a/roles/setup_pgbackrestserver/tasks/generate_config.yml
+++ b/roles/setup_pgbackrestserver/tasks/generate_config.yml
@@ -1,4 +1,120 @@
 ---
+- name: Build lines about standby's
+  ansible.builtin.set_fact:
+    pgbackrest_standby_configuration: >-
+      {{ pgbackrest_standby_configuration | default([]) + [
+        { 
+          'key': 'pg' + standby_node.index_var + '-host' | string,
+          'value': standby_node.inventory_hostname
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-path' | string,
+          'value': pg_data
+        }
+      ] }}
+  loop: "{{ standby_node_info }}"
+  loop_control:
+    loop_var: standby_node
+  when:
+    - use_hostname|bool
+    - pg_type == 'PG'
+    - standby_present is defined
+
+- name: Build lines about standby's
+  ansible.builtin.set_fact:
+    pgbackrest_standby_configuration: >-
+      {{ pgbackrest_standby_configuration | default([]) + [
+        { 
+          'key': 'pg' + standby_node.index_var + '-host' | string,
+          'value': standby_node.private_ip
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-path' | string,
+          'value': pg_data
+        }
+      ] }}
+  loop: "{{ standby_node_info }}"
+  loop_control:
+    loop_var: standby_node
+  when:
+    - "not use_hostname|bool"
+    - pg_type == 'PG'
+    - standby_present is defined
+
+- name: Build lines about standby's
+  ansible.builtin.set_fact:
+    pgbackrest_standby_configuration: >-
+      {{ pgbackrest_standby_configuration | default([]) + [
+        { 
+          'key': 'pg' + standby_node.index_var + '-host' | string,
+          'value': standby_node.inventory_hostname
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-path' | string,
+          'value': pg_data
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-host-user' | string,
+          'value': 'enterprisedb'
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-database' | string,
+          'value': pg_database_name
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-port' | string,
+          'value': '5444'
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-socket-path' | string,
+          'value': pg_unix_socket_epas
+        }
+      
+      ] }}
+  loop: "{{ standby_node_info }}"
+  loop_control:
+    loop_var: standby_node
+  when:
+    - use_hostname|bool
+    - pg_type == 'EPAS'
+    - standby_present is defined
+
+- name: Build lines about standby's
+  ansible.builtin.set_fact:
+    pgbackrest_standby_configuration: >-
+      {{ pgbackrest_standby_configuration | default([]) + [
+        { 
+          'key': 'pg' + standby_node.index_var + '-host' | string,
+          'value': standby_node.private_ip
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-path' | string,
+          'value': pg_data
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-host-user' | string,
+          'value': 'enterprisedb'
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-database' | string,
+          'value': pg_database_name
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-port' | string,
+          'value': '5444'
+        },
+        {
+          'key': 'pg' + standby_node.index_var + '-socket-path' | string,
+          'value': pg_unix_socket_epas
+        }
+      ] }}
+  loop: "{{ standby_node_info }}"
+  loop_control:
+    loop_var: standby_node
+  when:
+    - "not use_hostname|bool"
+    - pg_type == 'EPAS'
+    - standby_present is defined
 
 - name: Build configuration file {{ pgbackrest_configuration_file }}
   ansible.builtin.template:
@@ -8,3 +124,18 @@
     group: "{{ pgbackrest_group }}"
     mode: 0600
   become: true
+
+- name: Add standby information to configuration file
+  ansible.builtin.lineinfile:
+    path: "{{ pgbackrest_configuration_file }}"
+    owner: "{{ pgbackrest_user }}"
+    group: "{{ pgbackrest_group }}"
+    mode: 0600
+    insertafter: "EOF"
+    line: '{{ node.key }}={{ node.value }}'
+  loop: "{{ pgbackrest_standby_configuration }}"
+  loop_control:
+    loop_var: node
+  become: true
+  when:
+    - standby_present is defined

--- a/roles/setup_pgbackrestserver/tasks/generate_config.yml
+++ b/roles/setup_pgbackrestserver/tasks/generate_config.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     pgbackrest_standby_configuration: >-
       {{ pgbackrest_standby_configuration | default([]) + [
-        { 
+        {
           'key': 'pg' + standby_node.index_var + '-host' | string,
           'value': standby_node.inventory_hostname
         },
@@ -24,7 +24,7 @@
   ansible.builtin.set_fact:
     pgbackrest_standby_configuration: >-
       {{ pgbackrest_standby_configuration | default([]) + [
-        { 
+        {
           'key': 'pg' + standby_node.index_var + '-host' | string,
           'value': standby_node.private_ip
         },
@@ -45,7 +45,7 @@
   ansible.builtin.set_fact:
     pgbackrest_standby_configuration: >-
       {{ pgbackrest_standby_configuration | default([]) + [
-        { 
+        {
           'key': 'pg' + standby_node.index_var + '-host' | string,
           'value': standby_node.inventory_hostname
         },
@@ -69,7 +69,6 @@
           'key': 'pg' + standby_node.index_var + '-socket-path' | string,
           'value': pg_unix_socket_epas
         }
-      
       ] }}
   loop: "{{ standby_node_info }}"
   loop_control:
@@ -83,7 +82,7 @@
   ansible.builtin.set_fact:
     pgbackrest_standby_configuration: >-
       {{ pgbackrest_standby_configuration | default([]) + [
-        { 
+        {
           'key': 'pg' + standby_node.index_var + '-host' | string,
           'value': standby_node.private_ip
         },

--- a/roles/setup_pgbackrestserver/templates/pgbackrest.conf.template
+++ b/roles/setup_pgbackrestserver/templates/pgbackrest.conf.template
@@ -24,33 +24,3 @@ pg1-database={{ pg_database_name }}
 pg1-port={{ pg_port_epas }}
 pg1-socket-path={{ pg_unix_socket_epas }}
 {% endif %}
-{% if standby_present is defined %}
-pg2-host={{ standby_node_hostname[0] }}
-pg2-path={{ pg_data }}
-{% if pg_type == 'EPAS' %}
-pg2-host-user={{ standby_host_user }}
-pg2-database={{ pg_database_name }}
-pg2-port={{ pg_port_epas }}
-pg2-socket-path={{ pg_unix_socket_epas }}
-{% endif %}
-{% if two_standby is defined %}
-pg3-host={{ standby_node_hostname[1] }}
-pg3-path={{ pg_data }}
-{% if pg_type == 'EPAS' %}
-pg3-host-user={{ standby_host_user }}
-pg3-database={{ pg_database_name }}
-pg3-port={{ pg_port_epas }}
-pg3-socket-path={{ pg_unix_socket_epas }}
-{% endif %}
-{% if three_standby is defined %}
-pg4-host={{ standby_node_hostname[2] }}
-pg4-path={{ pg_data }}
-{% if pg_type == 'EPAS' %}
-pg4-host-user={{ standby_host_user }}
-pg4-database={{ pg_database_name }}
-pg4-port={{ pg_port_epas }}
-pg4-socket-path={{ pg_unix_socket_epas }}
-{% endif %}
-{% endif %}
-{% endif %}
-{% endif %}

--- a/tests/cases/setup_pgbackrest/Makefile
+++ b/tests/cases/setup_pgbackrest/Makefile
@@ -3,19 +3,23 @@ include ../../Makefile.mk
 build-centos7:
 	docker compose up primary1-centos7 -d
 	docker compose up standby1-centos7 -d
+	docker compose up standby2-centos7 -d
 	docker compose up pgbackrest1-centos7 -d
 
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up standby1-rocky8 -d
+	docker compose up standby2-rocky8 -d
 	docker compose up pgbackrest1-rocky8 -d
 
 build-debian10:
 	docker compose up primary1-debian10 -d
 	docker compose up standby1-debian10 -d
+	docker compose up standby2-debian10 -d
 	docker compose up pgbackrest1-debian10 -d
 
 build-ubuntu20:
 	docker compose up primary1-ubuntu20 -d
 	docker compose up standby1-ubuntu20 -d
+	docker compose up standby2-ubuntu20 -d
 	docker compose up pgbackrest1-ubuntu20 -d

--- a/tests/cases/setup_pgbackrest/docker-compose.yml
+++ b/tests/cases/setup_pgbackrest/docker-compose.yml
@@ -43,6 +43,18 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  standby2-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   pgbackrest1-rocky8:
     # Required for running systemd containers via GitHub actions
     privileged: true
@@ -67,6 +79,17 @@ services:
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
   standby1-centos7:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.centos7
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-centos7:
     privileged: true
     build:
       context: ../../docker
@@ -111,6 +134,25 @@ services:
     volumes:
       - .:/workspace
       - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/sshd
+      - /run/lock
+  standby2-debian10:
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.debian10
+    cap_add:
+      - SYS_ADMIN
+    volumes:
+      - .:/workspace
+      - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/sshd
+      - /run/lock
   pgbackrest1-debian10:
     build:
       context: ../../docker
@@ -120,6 +162,11 @@ services:
     volumes:
       - .:/workspace
       - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/sshd
+      - /run/lock
   primary1-ubuntu20:
     privileged: true
     build:
@@ -136,6 +183,21 @@ services:
     - /run/sshd
     - /run/lock
   standby1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  standby2-ubuntu20:
     privileged: true
     build:
       context: ../../docker

--- a/tests/cases/setup_pgbackrest/inventory.yml.j2
+++ b/tests/cases/setup_pgbackrest/inventory.yml.j2
@@ -24,3 +24,11 @@ all:
           pgbackrest: true
           pgbackrest_server_private_ip: {{ inventory_vars['pgbackrest1_ip'] }}
           pgbackrest_archive_method: async
+        standby2:
+          ansible_host: {{ inventory_vars['standby2_ip'] }}
+          private_ip: {{ inventory_vars['standby2_ip'] }}
+          replication_type: asynchronous
+          upstream_node_private_ip: {{ inventory_vars['primary1_ip'] }}
+          pgbackrest: true
+          pgbackrest_server_private_ip: {{ inventory_vars['pgbackrest1_ip'] }}
+          pgbackrest_archive_method: async

--- a/tests/cases/setup_pgbackrestserver/Makefile
+++ b/tests/cases/setup_pgbackrestserver/Makefile
@@ -3,19 +3,23 @@ include ../../Makefile.mk
 build-centos7:
 	docker compose up primary1-centos7 -d
 	docker compose up standby1-centos7 -d
+	docker compose up standby2-centos7 -d
 	docker compose up pgbackrest1-centos7 -d
 
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up standby1-rocky8 -d
+	docker compose up standby2-rocky8 -d
 	docker compose up pgbackrest1-rocky8 -d
 
 build-debian10:
 	docker compose up primary1-debian10 -d
 	docker compose up standby1-debian10 -d
+	docker compose up standby2-debian10 -d
 	docker compose up pgbackrest1-debian10 -d
 
 build-ubuntu20:
 	docker compose up primary1-ubuntu20 -d
 	docker compose up standby1-ubuntu20 -d
+	docker compose up standby2-ubuntu20 -d
 	docker compose up pgbackrest1-ubuntu20 -d

--- a/tests/cases/setup_pgbackrestserver/docker-compose.yml
+++ b/tests/cases/setup_pgbackrestserver/docker-compose.yml
@@ -43,6 +43,18 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  standby2-rocky8:
+    # Required for running systemd containers via GitHub actions
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   pgbackrest1-rocky8:
     # Required for running systemd containers via GitHub actions
     privileged: true
@@ -67,6 +79,17 @@ services:
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
   standby1-centos7:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.centos7
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-centos7:
     privileged: true
     build:
       context: ../../docker
@@ -111,6 +134,25 @@ services:
     volumes:
       - .:/workspace
       - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/sshd
+      - /run/lock
+  standby2-debian10:
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.debian10
+    cap_add:
+      - SYS_ADMIN
+    volumes:
+      - .:/workspace
+      - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/sshd
+      - /run/lock
   pgbackrest1-debian10:
     build:
       context: ../../docker
@@ -120,6 +162,11 @@ services:
     volumes:
       - .:/workspace
       - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/sshd
+      - /run/lock
   primary1-ubuntu20:
     privileged: true
     build:
@@ -136,6 +183,21 @@ services:
     - /run/sshd
     - /run/lock
   standby1-ubuntu20:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu20
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  standby2-ubuntu20:
     privileged: true
     build:
       context: ../../docker

--- a/tests/cases/setup_pgbackrestserver/inventory.yml.j2
+++ b/tests/cases/setup_pgbackrestserver/inventory.yml.j2
@@ -24,3 +24,11 @@ all:
           pgbackrest: true
           pgbackrest_server_private_ip: {{ inventory_vars['pgbackrest1_ip'] }}
           pgbackrest_archive_method: async
+        standby2:
+          ansible_host: {{ inventory_vars['standby2_ip'] }}
+          private_ip: {{ inventory_vars['standby2_ip'] }}
+          replication_type: asynchronous
+          upstream_node_private_ip: {{ inventory_vars['primary1_ip'] }}
+          pgbackrest: true
+          pgbackrest_server_private_ip: {{ inventory_vars['pgbackrest1_ip'] }}
+          pgbackrest_archive_method: async

--- a/tests/test-runner.py
+++ b/tests/test-runner.py
@@ -256,7 +256,7 @@ if __name__ == '__main__':
         execute_test = False if len(env.keyword) > 0 else True
 
         for k in env.keyword:
-            if re.search(k, name):
+            if re.search(re.escape(k), name):
                 execute_test = True
 
         if not execute_test:

--- a/tests/test-runner.py
+++ b/tests/test-runner.py
@@ -256,7 +256,7 @@ if __name__ == '__main__':
         execute_test = False if len(env.keyword) > 0 else True
 
         for k in env.keyword:
-            if re.search(re.escape(k), name):
+            if re.search(k, name):
                 execute_test = True
 
         if not execute_test:


### PR DESCRIPTION
Updated pgbackrest roles to allow more than 3 standby nodes. The tests for these roles was updated to ensure standby indexing was consistent and accurate. 
An index for nodes was added to the `/lookup/pgbackrest_nodes.py` lookup function to have the indexing required in `pgbackrest.conf` stay consistent across all nodes. Using this index value, configuration lines are created and added to the end of the file. 
On the standby nodes, this index value is accessible for `pgbackrest.conf` templating.