### PR TITLE
ansible-lint: ignore new checks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,6 @@
-#skip_list:
-#- '503'
-#- '403'
 warn_list:
   - command-instead-of-module  # Using command rather than module
   - no-handler  # Tasks that run when changed should likely be handlers
   - package-latest  # Package installs should not use latest
+  - args[module]  # Validating module arguments.
+  - experimental  # all rules tagged as experimental


### PR DESCRIPTION
Example of a new error we can ignore:

```
args[module]: value of contype must be one of: local, host, hostssl, hostnossl, hostgssenc, hostnogssenc, got: {{ line_item.contype | default('hostssl') }}
roles/manage_dbserver/tasks/manage_hba_conf.yml:15 Task/Handler: Manage ip address entries into pg_hba file
```