### PR TITLE
Ansible core upgrade 2.13

### DIFF
--- a/plugins/lookup/etcd_cluster_nodes.py
+++ b/plugins/lookup/etcd_cluster_nodes.py
@@ -59,8 +59,8 @@ class LookupModule(LookupBase):
             filter_etcd_cluster_name = terms[0]
 
         # etcd can be deployed on BDR, barman and proxy nodes
-        for group in ( 'primary', 'standby', 'pemserver', 'pgbouncer', 'pgpool2',
-            'barmanserver', 'witness', 'proxy', 'pgbackrestserver', ):
+        for group in ['primary', 'standby', 'pemserver', 'pgbouncer', 'pgpool2',
+                      'barmanserver', 'witness', 'proxy', 'pgbackrestserver']:
 
             if group not in variables['groups']:
                 continue
@@ -83,12 +83,10 @@ class LookupModule(LookupBase):
 
                     etcd_node = dict(
                         ansible_host=hostvars['ansible_host'],
-                        hostname=hostvars.get(
-                            'hostname', hostvars.get('ansible_hostname')
-                        ),
+                        hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
                         private_ip=hostvars['private_ip'],
                         inventory_hostname=hostvars['inventory_hostname'],
-                        etcd_cluster_name=hostvars.get['etcd_cluster_name'],
+                        etcd_cluster_name=hostvars.get('etcd_cluster_name', hostvars['etcd_cluster_name']),
                     )
 
                     etcd_nodes.append(etcd_node)

--- a/roles/setup_pgpool2/tasks/setup_pgpool2.yml
+++ b/roles/setup_pgpool2/tasks/setup_pgpool2.yml
@@ -101,7 +101,7 @@
 - name: Build the list of pgpool2 IPs
   ansible.builtin.set_fact:
     _pgpool2_ip_list: >-
-      {{ _pgpool2_ip_list | default([]) + [ server.private_ip | string ] }}
+      {{ _pgpool2_ip_list | default([]) + [server.private_ip | string] }}
   loop: "{{ _pgpool2_nodes }}"
   loop_control:
     loop_var: server
@@ -109,7 +109,7 @@
 - name: Build the list of pgpool2 nodes when not use_hostname
   ansible.builtin.set_fact:
     _pgpool2_node_list: >-
-      {{ _pgpool2_node_list | default([]) + [ server.private_ip | string ] }}
+      {{ _pgpool2_node_list | default([]) + [server.private_ip | string] }}
   loop: "{{ _pgpool2_nodes }}"
   loop_control:
     loop_var: server
@@ -118,8 +118,8 @@
 
 - name: Build the list of pgpool2 nodes when use_hostname
   ansible.builtin.set_fact:
-    _pgpool2_node_list: >- 
-      {{ _pgpool2_node_list | default ([]) + [ server.hostname | string ] }}
+    _pgpool2_node_list: >-
+      {{ _pgpool2_node_list | default([]) + [server.hostname | string] }}
   loop: "{{ _pgpool2_nodes }}"
   loop_control:
     loop_var: server

--- a/roles/setup_pgpool2/tasks/setup_pgpool2.yml
+++ b/roles/setup_pgpool2/tasks/setup_pgpool2.yml
@@ -100,14 +100,16 @@
 
 - name: Build the list of pgpool2 IPs
   ansible.builtin.set_fact:
-    _pgpool2_ip_list: "{{ _pgpool2_ip_list }} + [ '{{ server.private_ip }}' ]"
+    _pgpool2_ip_list: >-
+      {{ _pgpool2_ip_list | default([]) + [ server.private_ip | string ] }}
   loop: "{{ _pgpool2_nodes }}"
   loop_control:
     loop_var: server
 
 - name: Build the list of pgpool2 nodes when not use_hostname
   ansible.builtin.set_fact:
-    _pgpool2_node_list: "{{ _pgpool2_node_list }} + [ '{{ server.private_ip }}' ]"
+    _pgpool2_node_list: >-
+      {{ _pgpool2_node_list | default([]) + [ server.private_ip | string ] }}
   loop: "{{ _pgpool2_nodes }}"
   loop_control:
     loop_var: server
@@ -116,7 +118,8 @@
 
 - name: Build the list of pgpool2 nodes when use_hostname
   ansible.builtin.set_fact:
-    _pgpool2_node_list: "{{ _pgpool2_node_list }} + [ '{{ server.hostname }}' ]"
+    _pgpool2_node_list: >- 
+      {{ _pgpool2_node_list | default ([]) + [ server.hostname | string ] }}
   loop: "{{ _pgpool2_nodes }}"
   loop_control:
     loop_var: server


### PR DESCRIPTION
The breaking point between `ansible-core` 2.12 and 2.13 involved jinja templating performing concatenation and arithmetic operations. 

In the original line, `"{{ _pgpool2_node_list }} + [ '{{ server.hostname }}' ]"`, the default set `_pgpool2_node_list` was square brackets, `[]`. When concatenating `+ ['{{ server.hostname }}']` in `ansible-core` 2.12, the expected result of `['192.168.92.3']` was achieved through one loop. In `ansible-core` 2.13, the output of this operation was a list of all characters individually, `['[', ']', ' ', '+', ' ', '[', ' ', '1', '9', '2', '.', ...`. To modify to achieve the desired result, all operations must occur within the same jinja template, 
`{{ _pgpool2_node_list | default([]) + [server.private_ip | string] }}`. 

This operation only occurred in the `setup_pgpool2` role. All roles were tested with an `ansible-core` 2.13 PG Rocky8 instance. The `setup_pgpool2` role was tested with `ansible-core` 2.12 as well. 

When testing all roles, I received a TypeError on the `setup_patroni` role when calling the `etcd_cluster_nodes` lookup function. I modified the lookup function to run successfully. 