### PR TITLE
Module linesinfile

### DIFF
--- a/plugins/modules/README.md
+++ b/plugins/modules/README.md
@@ -1,0 +1,40 @@
+# Modules
+
+## edb_devops.edb_postgres.linesinfile
+
+This in-house Ansible module is intended to provide better performance than
+the built-in `lineinfile` module when multiple lines must be managed.
+
+Instead of using a loop, with `linesinfile`, we can pass an array of lines.
+This way, the module is executed only once, whatever the number of managed
+lines is.
+
+Most of `lineinfile`'s attributes are supported and work in the same way as
+they work in `lineinfile`: `line`, `regexp`, `insertafter`, `insertbefore`,
+`state`, `backrefs`, `firstmatch`, `create`, `owner`, `group`, `mode`.
+
+A few attributes are not supported: `backup` and `search_string`.
+
+Example:
+```yaml
+- name: Manage lines in file1.txt
+  edb_devops.edb_postgres.linesinfile:
+    path: file1.txt
+    lines:
+      - regexp: "Line [0-9]+.*"
+        state: absent
+      - line: "Test..."
+        insertafter: "^Bar.*"
+        firstmatch: true
+      - line: "Line present"
+        state: present
+        insertbefore: "BOF"
+      - line: "Bar"
+      - line: 'Has been \1'
+        regexp: '.*(replaced).*'
+        backrefs: true
+    group: staff
+    owner: julien
+    mode: 0600
+    create: true
+```

--- a/plugins/modules/linesinfile.py
+++ b/plugins/modules/linesinfile.py
@@ -1,0 +1,416 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+
+import errno
+import fcntl
+import os
+import re
+import time
+import tempfile
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes, to_native, to_text
+
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: linesinfile
+short_description: Manage a list of lines in text files
+description:
+  - This module ensures a list of lines is in a file, or replace an
+    existing line using a back-referenced regular expression.
+  - This module is intended to replace the usage of the lineinfile module when multiple lines are passed.
+options:
+  path:
+    description:
+      - The file to modify.
+    type: path
+    required: true
+    aliases: [ dest, destfile, name ]
+  regexp:
+    description:
+      - The regular expression to look for in every line of the file.
+      - For C(state=present), the pattern to replace if found. Only the last line found will be replaced.
+      - For C(state=absent), the pattern of the line(s) to remove.
+      - If the regular expression is not matched, the line will be
+        added to the file in keeping with C(insertbefore) or C(insertafter)
+        settings.
+      - When modifying a line the regexp should typically match both the initial state of
+        the line as well as its state after replacement by C(line) to ensure idempotence.
+      - Uses Python regular expressions. See U(https://docs.python.org/3/library/re.html).
+    type: str
+    aliases: [ regex ]
+  state:
+    description:
+      - Whether the line should be there or not.
+    type: str
+    choices: [ absent, present ]
+    default: present
+  lines:
+    description:
+      - Array of lines to be managed
+  lines[N].line:
+    description:
+      - The line to insert/replace into the file.
+      - Required for C(state=present).
+      - If C(backrefs) is set, may contain backreferences that will get
+        expanded with the C(regexp) capture groups if the regexp matches.
+    type: str
+    aliases: [ value ]
+  lines[N].backrefs:
+    description:
+      - Used with C(state=present).
+      - If set, C(line) can contain backreferences (both positional and named)
+        that will get populated if the C(regexp) matches.
+      - This parameter changes the operation of the module slightly;
+        C(insertbefore) and C(insertafter) will be ignored, and if the C(regexp)
+        does not match anywhere in the file, the file will be left unchanged.
+      - If the C(regexp) does match, the last matching line will be replaced by
+        the expanded line parameter.
+    type: bool
+    default: no
+  lines[N].insertafter:
+    description:
+      - Used with C(state=present).
+      - If specified, the line will be inserted after the last match of specified regular expression.
+      - If the first match is required, use(firstmatch=yes).
+      - A special value is available; C(EOF) for inserting the line at the end of the file.
+      - If specified regular expression has no matches, EOF will be used instead.
+      - If C(insertbefore) is set, default value C(EOF) will be ignored.
+      - If regular expressions are passed to both C(regexp) and C(insertafter), C(insertafter) is only honored if no match for C(regexp) is found.
+      - May not be used with C(backrefs) or C(insertbefore).
+    type: str
+    choices: [ EOF, '*regex*' ]
+    default: EOF
+  lines[N].insertbefore:
+    description:
+      - Used with C(state=present).
+      - If specified, the line will be inserted before the last match of specified regular expression.
+      - If the first match is required, use C(firstmatch=yes).
+      - A value is available; C(BOF) for inserting the line at the beginning of the file.
+      - If specified regular expression has no matches, the line will be inserted at the end of the file.
+      - If regular expressions are passed to both C(regexp) and C(insertbefore), C(insertbefore) is only honored if no match for C(regexp) is found.
+      - May not be used with C(backrefs) or C(insertafter).
+    type: str
+    choices: [ BOF, '*regex*' ]
+  lines[N].firstmatch:
+    description:
+      - Used with C(insertafter) or C(insertbefore).
+      - If set, C(insertafter) and C(insertbefore) will work with the first line that matches the given regular expression.
+    type: bool
+    default: no
+  create:
+    description:
+      - Used with C(state=present).
+      - If specified, the file will be created if it does not already exist.
+      - By default it will fail if the file is missing.
+    type: bool
+    default: no
+  others:
+    description:
+      - All arguments accepted by the M(ansible.builtin.file) module also work here.
+    type: str
+author:
+    - Julien Tachoires
+
+'''
+
+EXAMPLES = r'''
+- name: Manage lines in file1.txt
+  edb_devops.edb_postgres.linesinfile:
+    path: file1.txt
+    lines:
+      - regexp: "Line [0-9]+.*"
+        state: absent
+      - line: "Test..."
+        insertafter: "^Bar.*"
+        firstmatch: true
+      - line: "Line present"
+        state: present
+        insertbefore: "BOF"
+      - line: "Bar"
+      - line: 'Has been \1'
+        regexp: '.*(replaced).*'
+        backrefs: true
+    group: staff
+    owner: julien
+    mode: 0600
+    create: true
+'''
+
+RETURN = r'''#'''
+
+
+class lopen:
+    def __init__(self, module, file, mode='r'):
+        self.file = file
+        self.mode = mode
+        self.fd = None
+        self.module = module
+
+    def __enter__(self):
+        self.fd = open(self.file, self.mode)
+        t = 0
+        while True:
+            t += 1
+
+            if t > 1000:
+                # Raise an error after 100 seconds if we can not open the
+                # file because of an exclusive lock is held by another process.
+                self.module.fail_json(
+                    rc=256,
+                    msg="Unable to obtain an exclusive lock on %s" % self.file
+                )
+
+            try:
+                fcntl.flock(self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return self.fd
+            except IOError as e:
+                # Raise on unrelated IOErrors
+                if e.errno != errno.EAGAIN:
+                    raise
+                else:
+                    time.sleep(0.1)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        fcntl.flock(self.fd, fcntl.LOCK_UN)
+        self.fd.close()
+
+
+def write_changes(module, buffer, dest):
+    # Write buffer content into a temporary file and then make an atomic move
+    tmpfd, tmpfile = tempfile.mkstemp(dir=module.tmpdir)
+    with os.fdopen(tmpfd, 'wb') as f:
+        f.writelines(buffer)
+
+    module.atomic_move(
+        tmpfile,
+        to_native(
+            os.path.realpath(
+                to_bytes(dest, errors='surrogate_or_strict')
+            ),
+            errors='surrogate_or_strict'
+        ),
+        unsafe_writes=False
+    )
+
+
+def check_file_attrs(module, changed, message, diff):
+    file_args = module.load_file_common_arguments(module.params)
+    if module.set_fs_attributes_if_different(file_args, False, diff=diff):
+
+        if changed:
+            message += " and "
+        changed = True
+        message += "ownership, perms or SE linux context changed"
+
+    return message, changed
+
+
+def create_file(module, dest):
+    if os.path.exists(dest):
+        return
+    try:
+        with open(dest, 'w') as f:
+            f.write('')
+    except Exception:
+        module.fail_json(rc=256, msg="Unable to create the file %s" % dest)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            path=dict(type='path', required=True),
+            lines=dict(type='list', required=True),
+            create=dict(type='bool', default=False),
+        ),
+        add_file_common_args=True,
+        supports_check_mode=True,
+    )
+
+    path = module.params['path']
+    create = module.params['create']
+
+    b_path = to_bytes(path, errors='surrogate_or_strict')
+    if os.path.isdir(b_path):
+        module.fail_json(rc=256, msg='Path %s is a directory !' % path)
+
+    changed = False
+    msg = ''
+    diff = {
+        'before': '',
+        'after': '',
+        'before_header': '%s (content)' % path,
+        'after_header': '%s (content)' % path
+    }
+    counters = {
+        'added': 0,
+        'replaced': 0,
+        'removed': 0
+    }
+
+    if create:
+        create_file(module, path)
+
+    # Open the file in read only with an exclusive lock just to be sure no
+    # changes can be made by any other process while we are working on this
+    # file.
+    with lopen(module, b_path, 'r') as f:
+        # Load file content into the buffer as a list of bytes
+        buffer = [to_bytes(cl, errors='surrogate_or_strict')
+                  for cl in f.readlines()]
+
+        if module._diff:
+            diff['before'] = to_native(b''.join(buffer))
+
+        # Loop through each given line
+        for line in module.params['lines']:
+            l_state = line.get('state', 'present')
+            l_regexp = line.get('regexp', None)
+            l_insertafter = line.get('insertafter', 'EOF')
+            l_insertbefore = line.get('insertbefore', None)
+            l_line = line.get('line', None)
+            l_backrefs = line.get('backrefs', False)
+            l_firstmatch = line.get('firstmatch', False)
+
+            if l_state == 'present' and not l_line:
+                module.fail_json(rc=256, msg='line attribute must be set')
+
+            if l_insertafter != 'EOF' and l_insertbefore is not None:
+                module.fail_json(
+                    rc=256,
+                    msg='insertafter and insertbefore are mutually exclusive'
+                )
+
+            l_regexp = re.compile(l_regexp) if l_regexp else None
+
+            l_insertafter_re = None
+            l_insertbefore_re = None
+            if l_insertafter != 'EOF':
+                l_insertafter_re = re.compile(l_insertafter)
+            if l_insertbefore != 'BOF' and l_insertbefore is not None:
+                l_insertbefore_re = re.compile(l_insertbefore)
+
+            if l_line:
+                # Convert it to bytes
+                l_line = to_bytes(l_line, errors='surrogate_or_strict')
+
+            regexp_idxs = []
+            insertafter_idxs = []
+            insertbefore_idxs = []
+            equal_idxs = []
+            content = l_line
+
+            # Line number
+            line_no = -1
+
+            for buffer_line in buffer:
+                line_no += 1
+                buffer_line = buffer_line.rstrip(to_bytes('\r\n'))
+
+                # Let's find if the current line (buffer_line) and the input
+                # line are matching.
+                if l_regexp:
+                    match = l_regexp.search(to_text(buffer_line))
+                    if match:
+                        if l_backrefs:
+                            content = to_bytes(match.expand(to_text(l_line)))
+                        regexp_idxs.append(line_no)
+                        continue
+
+                if l_insertafter_re and l_insertafter_re.match(to_text(buffer_line)):  # noqa
+                    insertafter_idxs.append(line_no)
+                    continue
+
+                if l_insertbefore_re and l_insertbefore_re.match(to_text(buffer_line)):  # noqa
+                    insertbefore_idxs.append(line_no)
+                    continue
+
+                if not l_regexp and buffer_line == l_line:
+                    equal_idxs.append(line_no)
+
+            # Apply the change
+            if l_state == 'absent':
+                if l_regexp:
+                    regexp_idxs.reverse()
+                    for idx in regexp_idxs:
+                        del buffer[idx]
+                        counters['removed'] += 1
+                        changed = True
+                else:
+                    equal_idxs.reverse()
+                    for idx in equal_idxs:
+                        del buffer[idx]
+                        counters['removed'] += 1
+                        changed = True
+
+            if l_state == 'present':
+                # Not found, then append the line to the end. If insertbefore
+                # is set to BOF, then the line is inserted at the beginning of
+                # the file.
+                if len(equal_idxs) == 0 and len(regexp_idxs) == 0 \
+                        and len(insertafter_idxs) == 0 \
+                        and len(insertbefore_idxs) == 0:
+                    if l_insertbefore == 'BOF':
+                        buffer.insert(0, content + to_bytes('\n'))
+                    else:
+                        buffer.append(content + to_bytes('\n'))
+                    counters['added'] += 1
+                    changed = True
+                # Match based on regexp
+                elif len(regexp_idxs) > 0:
+                    buffer[regexp_idxs[-1]] = content + to_bytes('\n')
+                    counters['replaced'] += 1
+                    changed = True
+                # Match based on insertbefore
+                elif len(insertbefore_idxs) > 0:
+                    if l_firstmatch:
+                        p = insertbefore_idxs[0]
+                    else:
+                        p = insertbefore_idxs[-1]
+                    if buffer[p].rstrip(to_bytes('\r\n')) != content:
+                        buffer.insert(p, content + to_bytes('\n'))
+                        counters['added'] += 1
+                        changed = True
+                # Match base on insertfater
+                elif len(insertafter_idxs) > 0:
+                    if l_firstmatch:
+                        p = insertafter_idxs[0] + 1
+                    else:
+                        p = insertafter_idxs[-1] + 1
+                    if p >= len(buffer):
+                        buffer.insert(p, content + to_bytes('\n'))
+                        counters['added'] += 1
+                        changed = True
+                    elif buffer[p].rstrip(to_bytes('\r\n')) != content:
+                        buffer.insert(p, content + to_bytes('\n'))
+                        counters['added'] += 1
+                        changed = True
+
+        if changed and not module.check_mode:
+            write_changes(module, buffer, path)
+
+    if module._diff:
+        diff['after'] = to_native(b''.join(buffer))
+
+    msg = '%s line(s) added' % counters['added']
+    msg += ', %s line(s) removed' % counters['removed']
+    msg += ', %s line(s) replaced' % counters['replaced']
+
+    attr_diff = {}
+    if not module.check_mode:
+        msg, changed = check_file_attrs(module, changed, msg, attr_diff)
+
+    attr_diff['before_header'] = '%s (file attributes)' % path
+    attr_diff['after_header'] = '%s (file attributes)' % path
+
+    difflist = [diff, attr_diff]
+    found = sum([v for k, v in counters.items()])
+
+    module.exit_json(changed=changed, found=found, msg=msg, diff=difflist)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/init_dbserver/tasks/linux_update_etc_hosts.yml
+++ b/roles/init_dbserver/tasks/linux_update_etc_hosts.yml
@@ -1,16 +1,24 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-    regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:

--- a/roles/init_dbserver/tasks/pg_setup_systemd.yml
+++ b/roles/init_dbserver/tasks/pg_setup_systemd.yml
@@ -13,37 +13,31 @@
     - ansible_os_family == 'RedHat'
 
 - name: Update systemd unit file
-  ansible.builtin.lineinfile:
+  edb_devops.edb_postgres.linesinfile:
     path: "/etc/systemd/system/{{ pg_service }}.service"
-    line: "{{ item.line }}"
-    regexp: "{{ item.regexp }}"
-    insertafter: "{{ item.insertafter | default('EOF') }}"
+    lines:
+      - line: "Description=Database server {{ pg_type }} {{ pg_version }} - Instance: {{ pg_instance_name }}"
+        regexp: "^Description=.*"
+      - line: "Environment=PGDATA={{ pg_default_data }}"
+        regexp: "^Environment=PGDATA.*"
+      - line: "PIDFile={{ pg_default_data }}/postmaster.pid"
+        regexp: "^PIDFile=.*"
+        insertafter: "^\\[Service\\]$"
+      - line: "ExecStopPost=+/usr/bin/systemctl daemon-reload"
+        regexp: "^ExecStopPost=.*"
+        insertafter: "^\\[Service\\]$"
   become: true
-  loop:
-    - line: "Description=Database server {{ pg_type }} {{ pg_version }} - Instance: {{ pg_instance_name }}"
-      regexp: "^Description=.*"
-    - line: "Environment=PGDATA={{ pg_default_data }}"
-      regexp: "^Environment=PGDATA.*"
-    - line: "PIDFile={{ pg_default_data }}/postmaster.pid"
-      regexp: "^PIDFile=.*"
-      insertafter: "^\\[Service\\]$"
-    - line: "ExecStopPost=+/usr/bin/systemctl daemon-reload"
-      regexp: "^ExecStopPost=.*"
-      insertafter: "^\\[Service\\]$"
   when:
     - ansible_os_family == 'RedHat'
 
 - name: Add LimitCORE in systemd file
-  ansible.builtin.lineinfile:
+  edb_devops.edb_postgres.linesinfile:
     path: "/etc/systemd/system/{{ pg_service }}.service"
-    line: "{{ item.line }}"
-    regexp: "{{ item.regexp }}"
-    insertafter: "{{ item.insertafter | default('EOF') }}"
+    lines:
+      - line: "LimitCORE=infinity"
+        regexp: "^LimitCORE=.*"
+        insertafter: "^\\[Service\\]$"
   become: true
-  loop:
-    - line: "LimitCORE=infinity"
-      regexp: "^LimitCORE=.*"
-      insertafter: "^\\[Service\\]$"
   when:
     - enable_core_dump|bool
     - ansible_os_family == 'RedHat'

--- a/roles/manage_efm/tasks/efm_cluster_set_params.yml
+++ b/roles/manage_efm/tasks/efm_cluster_set_params.yml
@@ -11,18 +11,28 @@
   ansible.builtin.set_fact:
     efm_listen_host: "{{ hostvars[inventory_hostname].private_ip }}"
 
-- name: Update efm efm.properties file
-  ansible.builtin.lineinfile:
-    path: "{{ efm_properties }}"
-    regexp: "{{ line_item.name + '=' }}"
-    line: "{{ line_item.name + '=' + line_item.value | string }}"
-    state: present
+- name: Build efm_properties_lines
+  ansible.builtin.set_fact:
+    efm_properties_lines: >
+      {{ efm_properties_lines | default([]) + [
+          {
+            'line': item.name + '=' + item.value | string,
+            'regexp': item.name | regex_escape() + '='
+          }
+      ] }}
   with_items: "{{ efm_parameters }}"
-  loop_control:
-    loop_var: line_item
+
+- name: Update efm efm.properties file
+  edb_devops.edb_postgres.linesinfile:
+    path: "{{ efm_properties }}"
+    lines: "{{ efm_properties_lines }}"
   when: efm_parameters|length > 0
   become: true
   register: properties_changes
+
+- name: Reset efm_properties_lines
+  ansible.builtin.set_fact:
+    efm_properties_lines: []
 
 - name: Update pg_service to bind efm_service
   ansible.builtin.lineinfile:

--- a/roles/manage_pgbouncer/tasks/pgbouncer_set_userlist.yml
+++ b/roles/manage_pgbouncer/tasks/pgbouncer_set_userlist.yml
@@ -1,19 +1,30 @@
 ---
+- name: Build pgbouncer_auth_user_lines
+  ansible.builtin.set_fact:
+    pgbouncer_auth_user_lines: >
+      {{ pgbouncer_auth_user_lines | default([]) + [
+        {
+          'line': '"' + item.username + '" "' + item.password + '"',
+          'regexp': '^\"' + item.username | regex_escape() + '\".*',
+          'state': item.state | default('present')
+        }
+      ] }}
+  with_items: "{{ pgbouncer_auth_user_list }}"
+
 - name: Manage PgBouncer auth. file entries in {{ pgbouncer_auth_file }}
-  ansible.builtin.lineinfile:
+  edb_devops.edb_postgres.linesinfile:
     path: "{{ pgbouncer_auth_file }}"
-    line: "\"{{ user_item.username }}\" \"{{ user_item.password }}\""
-    regexp: "^\\\"{{ user_item.username | regex_escape() }}\\\".*"
-    state: "{{ user_item.state | default('present') }}"
+    lines: "{{ pgbouncer_auth_user_lines }}"
     create: true
     mode: 0600
     owner: "{{ pgbouncer_user }}"
     group: "{{ pgbouncer_group }}"
   when: pgbouncer_auth_user_list|length > 0
-  with_items: "{{ pgbouncer_auth_user_list }}"
-  loop_control:
-    loop_var: user_item
   become: true
+
+- name: Reset pgbouncer_auth_user_lines
+  ansible.builtin.set_fact:
+    pgbouncer_auth_user_lines: []
 
 - name: Reload PgBouncer configuration
   ansible.builtin.shell:

--- a/roles/manage_pgpool2/tasks/pcp_manage_users.yml
+++ b/roles/manage_pgpool2/tasks/pcp_manage_users.yml
@@ -20,21 +20,36 @@
   become: true
   become_user: "{{ pg_owner }}"
 
-- name: Remove pcp users
-  ansible.builtin.lineinfile:
-    path: "{{ pcp_configuration_file }}"
-    line: >-
-      {{ user_item.name }}:
-    regexp: "^{{ user_item.name | regex_escape() }}\\:"
-    state: "absent"
+- name: Init pcp_users_lines
+  ansible.builtin.set_fact:
+    pcp_users_lines: []
+
+- name: Build pcp_users_lines
+  ansible.builtin.set_fact:
+    pcp_users_lines: >
+      {{ pcp_users_lines | default([]) + [
+        {
+          'line': item.name,
+          'regexp': '^' + item.name | regex_escape() + '\:',
+          'state': 'absent'
+        }
+      ] }}
   loop: "{{ pcp_users }}"
-  loop_control:
-    loop_var: user_item
   when:
-    - pcp_users|length > 0
-    - user_item.state is defined
-    - user_item.state == 'absent'
+    - item.state is defined
+    - item.state == 'absent'
+
+- name: Remove pcp users
+  edb_devops.edb_postgres.linesinfile:
+    path: "{{ pcp_configuration_file }}"
+    lines: "{{ pcp_users_lines }}"
+  when:
+    - pcp_users_lines|length > 0
   become: true
+
+- name: Reset pcp_users_lines
+  ansible.builtin.set_fact:
+    pcp_users_lines: []
 
 - name: Add pcp users
   ansible.builtin.include_tasks: pcp_add_user.yml

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_configuration.yml
@@ -1,16 +1,26 @@
 ---
+- name: Build _pgpool2_configuration_lines
+  ansible.builtin.set_fact:
+    _pgpool2_configuration_lines: >
+      {{ _pgpool2_configuration_lines | default([]) + [
+        {
+          'line': item.key + ' = ' + (item.value | string if not item.quoted | default(false) else "'" + item.value | string + "'"),
+          'regexp': '^' + item.key | regex_escape() + '\s*=',
+          'state': item.state | default('present')
+        }
+      ] }}
+  with_items: "{{ pgpool2_configuration_lines }}"
+
 - name: Manage pgpool2 configuration file content in {{ pgpool2_configuration_file }}
-  ansible.builtin.lineinfile:
+  edb_devops.edb_postgres.linesinfile:
     path: "{{ pgpool2_configuration_file }}"
-    line: >-
-      {{ conf_item.key }} = {% if conf_item.quoted | default(false) %}'{% endif %}{{ conf_item.value }}{% if conf_item.quoted | default(false) %}'{% endif %}
-    regexp: "^{{ conf_item.key | regex_escape() }}\\s*="
-    state: "{{ conf_item.state | default('present') }}"
+    lines: "{{ _pgpool2_configuration_lines }}"
     create: true
     mode: 0600
     owner: "{{ pgpool2_user }}"
     group: "{{ pgpool2_group }}"
-  with_items: "{{ pgpool2_configuration_lines }}"
-  loop_control:
-    loop_var: conf_item
   become: true
+
+- name: Reset _pgpool2_configuration_lines
+  ansible.builtin.set_fact:
+    _pgpool2_configuration_lines: []

--- a/roles/manage_pgpool2/tasks/pgpool2_manage_users.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_manage_users.yml
@@ -1,19 +1,34 @@
 ---
-- name: Remove users from pool_passwd
-  ansible.builtin.lineinfile:
-    path: "{{ pgpool2_pool_passwd_file }}"
-    line: >-
-      {{ user_item.name }}:
-    regexp: "^{{ user_item.name | regex_escape() }}\\:"
-    state: "absent"
+- name: Init pgpool2_users_lines
+  ansible.builtin.set_fact:
+    pgpool2_users_lines: []
+
+- name: Build pgpool2_users_lines
+  ansible.builtin.set_fact:
+    pgpool2_users_lines: >
+      {{ pgpool2_users_lines | default([]) + [
+        {
+          'line': item.name,
+          'regexp': '^' + item.name | regex_escape() + '\:',
+          'state': 'absent'
+        }
+      ] }}
   loop: "{{ pgpool2_users }}"
-  loop_control:
-    loop_var: user_item
   when:
-    - pgpool2_users|length > 0
-    - user_item.state is defined
-    - user_item.state == 'absent'
+    - item.state is defined
+    - item.state == 'absent'
+
+- name: Remove users from pool_passwd
+  edb_devops.edb_postgres.linesinfile:
+    path: "{{ pgpool2_pool_passwd_file }}"
+    lines: "{{ pgpool2_users_lines }}"
+  when:
+    - pgpool2_users_lines|length > 0
   become: true
+
+- name: Reset pgpool2_users_lines
+  ansible.builtin.set_fact:
+    pgpool2_users_lines: []
 
 - name: Add users with SCRAM authentication
   ansible.builtin.command:

--- a/roles/setup_barman/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_barman/tasks/linux_update_etc_hosts.yml
@@ -1,17 +1,25 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-     regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:
-     name: "{{ inventory_hostname }}"
+    name: "{{ inventory_hostname }}"

--- a/roles/setup_barmanserver/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_barmanserver/tasks/linux_update_etc_hosts.yml
@@ -1,17 +1,25 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-     regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:
-     name: "{{ inventory_hostname }}"
+    name: "{{ inventory_hostname }}"

--- a/roles/setup_dbt2/tasks/dbt2_setup_env.yml
+++ b/roles/setup_dbt2/tasks/dbt2_setup_env.yml
@@ -1,15 +1,11 @@
 ---
 - name: Configure DBT-2 environment variables for {{ pg_owner }}
-  ansible.builtin.lineinfile:
+  edb_devops.edb_postgres.linesinfile:
     path: "{{ pg_user_home }}/.dbt2rc"
-    line: "export {{ item.name }}={{ item.value }}"
+    lines:
+      - line: "export PGDATABASE={{ pg_dbt2_dbname }}"
+      - line: "export PGPORT={{ pg_port }}"
+      - line: "export DBT2DBNAME={{ pg_dbt2_dbname }}"
     create: true
     mode: "0600"
   become_user: "{{ pg_owner }}"
-  loop:
-    - name: PGDATABASE
-      value: "{{ pg_dbt2_dbname }}"
-    - name: PGPORT
-      value: "{{ pg_port }}"
-    - name: DBT2DBNAME
-      value: "{{ pg_dbt2_dbname }}"

--- a/roles/setup_dbt2_client/tasks/main.yml
+++ b/roles/setup_dbt2_client/tasks/main.yml
@@ -31,11 +31,9 @@
     tasks_from: dbt2_configure_pgpass
 
 - name: "Increase nofile limits for user {{ pg_owner }}"
-  ansible.builtin.lineinfile:
+  edb_devops.edb_postgres.linesinfile:
     path: /etc/security/limits.conf
-    line: "{{ item }}"
-    state: present
-  loop:
-    - "{{ pg_owner }}    hard  nofile  10000"
-    - "{{ pg_owner }}    soft  nofile  10000"
+    lines:
+      - line: "{{ pg_owner }}    hard  nofile  10000"
+      - line: "{{ pg_owner }}    soft  nofile  10000"
   become: true

--- a/roles/setup_efm/tasks/efm_configure.yml
+++ b/roles/setup_efm/tasks/efm_configure.yml
@@ -82,30 +82,33 @@
     - efm_eager_failover|bool
     - efm_install_version|int >= 40
 
-- name: Update efm efm.properties file
-  ansible.builtin.lineinfile:
-    path: "{{ efm_properties }}"
-    regexp: "{{ line_item.name + '=' }}"
-    line: "{{ line_item.name + '=' + line_item.value | string }}"
-    state: present
+- name: Build efm_properties_lines
+  ansible.builtin.set_fact:
+    efm_properties_lines: >
+      {{ efm_properties_lines | default([]) + [
+          {
+            'line': item.name + '=' + item.value | string,
+            'regexp': item.name | regex_escape() + '='
+          }
+      ] }}
   with_items: "{{ efm_node_parameters }}"
-  loop_control:
-    loop_var: line_item
+
+- name: Update efm efm.properties file
+  edb_devops.edb_postgres.linesinfile:
+    path: "{{ efm_properties }}"
+    lines: "{{ efm_properties_lines }}"
   become: true
   no_log: "{{ disable_logging }}"
   register: properties_changes
 
 - name: Update pg_service to bind efm_service
-  ansible.builtin.lineinfile:
+  edb_devops.edb_postgres.linesinfile:
     path: "/etc/systemd/system/{{ pg_service }}.service"
-    line: "{{ item.line }}"
-    regexp: "{{ item.regexp }}"
-    insertafter: "{{ item.insertafter | default('EOF') }}"
+    lines:
+      - line: "BindsTo={{ efm_service }}.service"
+        regexp: "^BindsTo=.*"
+        insertafter: "^\\[Unit\\]$"
   become: true
-  loop:
-    - line: "BindsTo={{ efm_service }}.service"
-      regexp: "^BindsTo=.*"
-      insertafter: "^\\[Unit\\]$"
   when:
     - efm_eager_failover|bool
     - ansible_os_family == 'RedHat'
@@ -144,3 +147,7 @@
   when:
     - pg_service_changed is defined
     - pg_service_changed.changed
+
+- name: Reset efm_properties_lines
+  ansible.builtin.set_fact:
+    efm_properties_lines: []

--- a/roles/setup_efm/tasks/efm_pgpool2_integration.yml
+++ b/roles/setup_efm/tasks/efm_pgpool2_integration.yml
@@ -24,12 +24,13 @@
   run_once: true
 
 - name: Save PCP credentials
-  ansible.builtin.lineinfile:
+  edb_devops.edb_postgres.linesinfile:
     path: "{{ pcp_passfile }}"
     owner: "{{ pcp_passfile_owner }}"
     group: "{{ pcp_passfile_group }}"
     mode: "{{ pcp_passfile_mode }}"
-    line: "*:*:{{ pcp_admin_user }}:{{ pcp_admin_user_password }}"
+    lines:
+      - line: "*:*:{{ pcp_admin_user }}:{{ pcp_admin_user_password }}"
     create: true
   become: true
 

--- a/roles/setup_efm/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_efm/tasks/linux_update_etc_hosts.yml
@@ -1,16 +1,24 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-    regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:

--- a/roles/setup_etcd/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_etcd/tasks/linux_update_etc_hosts.yml
@@ -1,16 +1,24 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-    regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:

--- a/roles/setup_patroni/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_patroni/tasks/linux_update_etc_hosts.yml
@@ -1,16 +1,24 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-    regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:

--- a/roles/setup_pemagent/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_pemagent/tasks/linux_update_etc_hosts.yml
@@ -1,20 +1,25 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
-  no_log: "{{ disable_logging }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-    regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
-  no_log: "{{ disable_logging }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:
     name: "{{ inventory_hostname }}"
-  no_log: "{{ disable_logging }}"

--- a/roles/setup_pemserver/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_pemserver/tasks/linux_update_etc_hosts.yml
@@ -1,16 +1,24 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-    regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:

--- a/roles/setup_pgbackrest/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_pgbackrest/tasks/linux_update_etc_hosts.yml
@@ -1,17 +1,25 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-     regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:
-     name: "{{ inventory_hostname }}"
+    name: "{{ inventory_hostname }}"

--- a/roles/setup_pgbackrestserver/tasks/generate_config.yml
+++ b/roles/setup_pgbackrestserver/tasks/generate_config.yml
@@ -124,17 +124,28 @@
     mode: 0600
   become: true
 
+- name: Build pgbackrest_conf_lines
+  ansible.builtin.set_fact:
+    pgbackrest_conf_lines: >
+      {{ pgbackrest_conf_lines | default([]) + [
+        {
+          'line': item.key + '=' + item.value,
+          'insertafter': 'EOF'
+        }
+      ] }}
+  loop: "{{ pgbackrest_standby_configuration }}"
+
 - name: Add standby information to configuration file
   ansible.builtin.lineinfile:
     path: "{{ pgbackrest_configuration_file }}"
     owner: "{{ pgbackrest_user }}"
     group: "{{ pgbackrest_group }}"
     mode: 0600
-    insertafter: "EOF"
-    line: '{{ node.key }}={{ node.value }}'
-  loop: "{{ pgbackrest_standby_configuration }}"
-  loop_control:
-    loop_var: node
+    lines: "{{ pgbackrest_conf_lines }}"
   become: true
   when:
     - standby_present is defined
+
+- name: Reset pgbackrest_conf_lines
+  ansible.builtin.set_fact:
+    pgbackrest_conf_lines: []

--- a/roles/setup_pgbackrestserver/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_pgbackrestserver/tasks/linux_update_etc_hosts.yml
@@ -1,18 +1,25 @@
 ---
-
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-     regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:
-     name: "{{ inventory_hostname }}"
+    name: "{{ inventory_hostname }}"

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 use_hostname: true
+etc_hosts_lists: []
 update_etc_file: true
 # Default configuration values
 pgpool2_port: 9999
@@ -9,6 +10,7 @@ pgpool2_wd_port: 9000
 pgpool2_wd_heartbeat_port: 9694
 use_patroni: false
 
+pg_instance_name: main
 # Default user to login from pgpool
 pg_pgpool_database: "postgres"
 pg_pgpool_user: "pgpool"

--- a/roles/setup_pgpool2/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_pgpool2/tasks/linux_update_etc_hosts.yml
@@ -1,17 +1,25 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-     regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:
-     name: "{{ inventory_hostname }}"
+    name: "{{ inventory_hostname }}"

--- a/roles/setup_replication/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_replication/tasks/linux_update_etc_hosts.yml
@@ -1,16 +1,24 @@
 ---
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item }}"
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-    regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:

--- a/roles/setup_replication/tasks/pg_setup_systemd.yml
+++ b/roles/setup_replication/tasks/pg_setup_systemd.yml
@@ -13,37 +13,31 @@
     - ansible_os_family == "RedHat"
 
 - name: Update systemd unit file
-  ansible.builtin.lineinfile:
+  edb_devops.edb_postgres.linesinfile:
     path: "/etc/systemd/system/{{ pg_service }}.service"
-    line: "{{ item.line }}"
-    regexp: "{{ item.regexp }}"
-    insertafter: "{{ item.insertafter | default('EOF') }}"
+    lines:
+      - line: "Description=Database server {{ pg_type }} {{ pg_version }} - Instance: {{ pg_instance_name }}"
+        regexp: "^Description=.*"
+      - line: "Environment=PGDATA={{ pg_default_data }}"
+        regexp: "^Environment=PGDATA.*"
+      - line: "PIDFile={{ pg_default_data }}/postmaster.pid"
+        regexp: "^PIDFile=.*"
+        insertafter: "^\\[Service\\]$"
+      - line: "ExecStopPost=+/usr/bin/systemctl daemon-reload"
+        regexp: "^ExecStopPost=.*"
+        insertafter: "^\\[Service\\]$"
   become: true
-  loop:
-    - line: "Description=Database server {{ pg_type }} {{ pg_version }} - Instance: {{ pg_instance_name }}"
-      regexp: "^Description=.*"
-    - line: "Environment=PGDATA={{ pg_default_data }}"
-      regexp: "^Environment=PGDATA.*"
-    - line: "PIDFile={{ pg_default_data }}/postmaster.pid"
-      regexp: "^PIDFile=.*"
-      insertafter: "^\\[Service\\]$"
-    - line: "ExecStopPost=+/usr/bin/systemctl daemon-reload"
-      regexp: "^ExecStopPost=.*"
-      insertafter: "^\\[Service\\]$"
   when:
     - ansible_os_family == "RedHat"
 
 - name: Add LimitCORE in systemd file
-  ansible.builtin.lineinfile:
+  edb_devops.edb_postgres.linesinfile:
     path: "/etc/systemd/system/{{ pg_service }}.service"
-    line: "{{ item.line }}"
-    regexp: "{{ item.regexp }}"
-    insertafter: "{{ item.insertafter | default('EOF') }}"
+    lines:
+      - line: "LimitCORE=infinity"
+        regexp: "^LimitCORE=.*"
+        insertafter: "^\\[Service\\]$"
   become: true
-  loop:
-    - line: "LimitCORE=infinity"
-      regexp: "^LimitCORE=.*"
-      insertafter: "^\\[Service\\]$"
   when:
     - enable_core_dump|bool
     - ansible_os_family == 'RedHat'

--- a/roles/setup_repmgr/tasks/linux_update_etc_hosts.yml
+++ b/roles/setup_repmgr/tasks/linux_update_etc_hosts.yml
@@ -1,16 +1,25 @@
-- name: Update /etc/hosts file, based on variable etc_hosts_list
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item }}"
+---
+- name: Build hosts_lines, based on the variable etc_hosts_list
+  ansible.builtin.set_fact:
+    hosts_lines: "{{ hosts_lines | default([]) + [{'line': item}] }}"
   loop: "{{ etc_hosts_lists }}"
 
-- name: Update /etc/hosts file, based on the inventory
-  ansible.builtin.lineinfile:
-     path: "/etc/hosts"
-     line: "{{ item.private_ip }} {{ item.inventory_hostname }}"
-     regexp: ".*\\s{{ item.inventory_hostname | regex_escape() }}$"
+- name: Build hosts_lines, based on the inventory
+  ansible.builtin.set_fact:
+    hosts_lines: >
+      {{ hosts_lines | default([]) + [
+        {
+          'line': item.private_ip + ' ' + item.inventory_hostname,
+          'regexp': '.*\s' + item.inventory_hostname | regex_escape() + '$'
+        }
+      ] }}
   loop: "{{ lookup('edb_devops.edb_postgres.all_nodes', wantlist=True) }}"
+
+- name: Update /etc/hosts file, based on variable hosts_lines
+  edb_devops.edb_postgres.linesinfile:
+    path: "/etc/hosts"
+    lines: "{{ hosts_lines }}"
 
 - name: Update system hostname
   ansible.builtin.hostname:
-     name: "{{ inventory_hostname }}"
+    name: "{{ inventory_hostname }}"


### PR DESCRIPTION
This in-house Ansible module is intended to provide better performance than lineinfile when multiple lines must be managed.

Instead of using a loop, with linesinfile, we can pass an array of lines. This way, the module is executed only once, whatever the number of managed lines is.

Most of lineinfile's attributes are supported: line, regexp, insertafter, insertbefore, state, backrefs, firstmatch, create, owner, group, mode.

A few attributes are not supported: backup and search_string