### PR TITLE
Update init_dbserver, install_dbserver, and manage_dbserver rolls to …

### DIFF
--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -47,7 +47,11 @@ pg_unix_socket_directories:
 # pg_init_conf_params:
 # - name: "edb_filter_log.redact_password_commands"
 #   value: "true"
-pg_init_conf_params: []
+
+# For ease of configuration, we can always add edb_pg_tuner.autotune whether
+# the extension is installed or not, because these types or settings will be
+# simply ignored if it doesn't apply to anything.
+pg_init_conf_params: [{"name": "edb_pg_tuner.autotune", "value": "true"}]
 # postgres port
 pg_port: 5432
 

--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -48,10 +48,7 @@ pg_unix_socket_directories:
 # - name: "edb_filter_log.redact_password_commands"
 #   value: "true"
 
-# For ease of configuration, we can always add edb_pg_tuner.autotune whether
-# the extension is installed or not, because these types or settings will be
-# simply ignored if it doesn't apply to anything.
-pg_init_conf_params: [{"name": "edb_pg_tuner.autotune", "value": "true"}]
+pg_init_conf_params: []
 # postgres port
 pg_port: 5432
 

--- a/roles/init_dbserver/tasks/pg_initdb.yml
+++ b/roles/init_dbserver/tasks/pg_initdb.yml
@@ -32,6 +32,15 @@
   when: ansible_os_family == 'Debian'
   become: true
 
+- name: Add EDB Postgres Tuner to shared_preload_libraries
+  ansible.builtin.set_fact:
+    pg_shared_libraries_list: "{{ pg_shared_libraries_list + \
+                               ['$libdir/edb_pg_tuner'] }}"
+  when: >-
+    enable_edb_repo|bool
+    and install_edb_postgres_tuner|bool
+    and pg_version|int >= 11
+
 - name: Copy the postgresql.conf.template to the server
   ansible.builtin.template:
     src: postgresql.conf.template

--- a/roles/init_dbserver/tasks/pg_initdb.yml
+++ b/roles/init_dbserver/tasks/pg_initdb.yml
@@ -32,15 +32,6 @@
   when: ansible_os_family == 'Debian'
   become: true
 
-- name: Add EDB Postgres Tuner to shared_preload_libraries
-  ansible.builtin.set_fact:
-    pg_shared_libraries_list: "{{ pg_shared_libraries_list + \
-                               ['$libdir/edb_pg_tuner'] }}"
-  when: >-
-    enable_edb_repo|bool
-    and install_edb_postgres_tuner|bool
-    and pg_version|int >= 11
-
 - name: Copy the postgresql.conf.template to the server
   ansible.builtin.template:
     src: postgresql.conf.template

--- a/roles/init_dbserver/templates/postgresql.conf.template
+++ b/roles/init_dbserver/templates/postgresql.conf.template
@@ -31,8 +31,15 @@ log_autovacuum_min_duration = 0
 autovacuum_max_workers = 5
 autovacuum_vacuum_cost_limit = 3000
 idle_in_transaction_session_timeout = 10min
+{% if enable_edb_repo|bool and install_edb_postgres_tuner|bool and pg_version|int >= 11 %}
+{{ pg_shared_libraries_list.append('$libdir/edb_pg_tuner') }}
+{% endif %}
 shared_preload_libraries = '{{ pg_shared_libraries_list | join(",") }}'
 cluster_name = '{{ pg_instance_name }}'
+# For ease of configuration, we can always add edb_pg_tuner.autotune whether
+# the extension is installed or not, because these types or settings will be
+# simply ignored if it doesn't apply to anything.
+edb_pg_tuner.autotune = on
 {% if pg_init_conf_params|length > 0 %}
 {% for item in pg_init_conf_params %}
 {{ item.name }} = '{{ item.value }}'

--- a/roles/install_dbserver/defaults/main.yml
+++ b/roles/install_dbserver/defaults/main.yml
@@ -4,10 +4,12 @@ os: ""
 pg_type: "PG"
 pg_version: 14
 bdr_version: 4
+pg_tuner_version: 1
 pg_owner: "{{ 'enterprisedb' if pg_type == 'EPAS' else 'postgres' }}"
 enable_core_dump: false
 core_dump_directory: "/var/coredumps"
 
+install_edb_postgres_tuner: true
 install_bdr_packages: false
 epas_deb_drop_cluster: "/usr/bin/epas_dropcluster"
 epas_service: "edb-as@{{ pg_version }}-main"

--- a/roles/install_dbserver/defaults/main.yml
+++ b/roles/install_dbserver/defaults/main.yml
@@ -10,6 +10,8 @@ enable_core_dump: false
 core_dump_directory: "/var/coredumps"
 
 install_edb_postgres_tuner: true
+edb_tuner_package: "edb-{{ 'as' if pg_type == 'EPAS' else 'pg' }}\
+                   {{ pg_version }}-postgres-tuner{{ pg_tuner_version }}"
 install_bdr_packages: false
 epas_deb_drop_cluster: "/usr/bin/epas_dropcluster"
 epas_service: "edb-as@{{ pg_version }}-main"

--- a/roles/install_dbserver/tasks/main.yml
+++ b/roles/install_dbserver/tasks/main.yml
@@ -2,3 +2,33 @@
 # Entry point of the install_dbserver role
 - name: Include the install_dbserver.yml
   ansible.builtin.include_tasks: install_dbserver.yml
+
+- name: Set Postgres Tuner package prefix (PG)
+  ansible.builtin.set_fact:
+    pg_tuner_prefix: "{{ pg_type | lower }}"
+  when: >-
+    pg_type == "PG"
+    and enable_edb_repo|bool
+    and install_edb_postgres_tuner|bool
+    and pg_version|int >= 11
+
+- name: Set Postgres Tuner package prefix (EPAS)
+  ansible.builtin.set_fact:
+    pg_tuner_prefix: "as"
+  when: >-
+    pg_type == "EPAS"
+    and enable_edb_repo|bool
+    and install_edb_postgres_tuner|bool
+    and pg_version|int >= 11
+
+- name: Install EDB Postgres Tuner
+  ansible.builtin.package:
+    name:
+      - "edb-{{ pg_type | lower }}{{ pg_version }}-\
+        postgres-tuner{{ pg_tuner_version }}"
+    state: present
+  become: true
+  when: >-
+    enable_edb_repo|bool
+    and install_edb_postgres_tuner|bool
+    and pg_version|int >= 11

--- a/roles/install_dbserver/tasks/main.yml
+++ b/roles/install_dbserver/tasks/main.yml
@@ -3,29 +3,9 @@
 - name: Include the install_dbserver.yml
   ansible.builtin.include_tasks: install_dbserver.yml
 
-- name: Set Postgres Tuner package prefix (PG)
-  ansible.builtin.set_fact:
-    pg_tuner_prefix: "{{ pg_type | lower }}"
-  when: >-
-    pg_type == "PG"
-    and enable_edb_repo|bool
-    and install_edb_postgres_tuner|bool
-    and pg_version|int >= 11
-
-- name: Set Postgres Tuner package prefix (EPAS)
-  ansible.builtin.set_fact:
-    pg_tuner_prefix: "as"
-  when: >-
-    pg_type == "EPAS"
-    and enable_edb_repo|bool
-    and install_edb_postgres_tuner|bool
-    and pg_version|int >= 11
-
 - name: Install EDB Postgres Tuner
   ansible.builtin.package:
-    name:
-      - "edb-{{ pg_type | lower }}{{ pg_version }}-\
-        postgres-tuner{{ pg_tuner_version }}"
+    name: "{{ edb_tuner_package }}"
     state: present
   become: true
   when: >-

--- a/roles/manage_dbserver/tasks/manage_extensions.yml
+++ b/roles/manage_dbserver/tasks/manage_extensions.yml
@@ -11,6 +11,16 @@
   become_user: "{{ pg_owner }}"
   register: db_status
 
+- name: Add EDB Postgres Tuner to managed extensions
+  ansible.builtin.set_fact:
+    pg_extensions: "{{ pg_extensions + [{\"name\": \"edb_pg_tuner\", \
+                                         \"database\": \"{{ pg_database }}\", \
+                                         \"state\": \"present\"}] }}"
+  when: >-
+    enable_edb_repo|bool
+    and install_edb_postgres_tuner|bool
+    and pg_version|int >= 11
+
 - name: Manage postgres extensions
   community.postgresql.postgresql_ext:
     name: "{{ line_item.name }}"

--- a/roles/manage_dbserver/tasks/manage_extensions.yml
+++ b/roles/manage_dbserver/tasks/manage_extensions.yml
@@ -11,11 +11,12 @@
   become_user: "{{ pg_owner }}"
   register: db_status
 
+- name: Load list of additional PostgreSQL extensions to potentially manage
+  ansible.builtin.include_vars: "extensions.yml"
+
 - name: Add EDB Postgres Tuner to managed extensions
   ansible.builtin.set_fact:
-    pg_extensions: "{{ pg_extensions + [{\"name\": \"edb_pg_tuner\", \
-                                         \"database\": \"{{ pg_database }}\", \
-                                         \"state\": \"present\"}] }}"
+    pg_extensions: "{{ pg_extensions + [edb_tuner_extension] }}"
   when: >-
     enable_edb_repo|bool
     and install_edb_postgres_tuner|bool

--- a/roles/manage_dbserver/vars/extensions.yml
+++ b/roles/manage_dbserver/vars/extensions.yml
@@ -1,0 +1,5 @@
+---
+edb_tuner_extension:
+  name: edb_pg_tuner
+  database: "{{ pg_database }}"
+  state: present


### PR DESCRIPTION
…handle EDB Postgres Tuner

https://www.enterprisedb.com/docs/pg_extensions/pg_tuner/

If the EDB repository is enabled, include the installation and enabling of EDB Postgres Tuner on all platforms that it is supported on.

The installation and setup of the Postgres Tuner can be individually disabled by setting install_edb_postgres_tuner to false.