### PR TITLE
Fix registerdb with EFM for pemagent version 9.0

### DIFF
--- a/roles/setup_pemagent/tasks/pem_agent_register_db.yml
+++ b/roles/setup_pemagent/tasks/pem_agent_register_db.yml
@@ -44,7 +44,9 @@
         --asb-host-user {{ pg_pem_agent_user }} \
         --asb-ssl-mode prefer \
         --remote-monitoring no \
-    && touch {{ pem_agent_bin_path }}/../etc/.{{ inventory_hostname }}-{{ pg_port }}-registered
+    && touch {{ pem_agent_bin_path }}/../etc/.{{ inventory_hostname }}-{{ pg_port }}-registered \
+    && systemctl stop {{ pem_agent_service }} \
+    && systemctl start {{ pem_agent_service }}
   args:
     executable: /bin/bash
     creates: "{{ pem_agent_bin_path }}/../etc/.{{ inventory_hostname }}-{{ pg_port }}-registered"


### PR DESCRIPTION
This commit ensures the pemagent service restart after EFM and DB registration