### PR TITLE
Update Barman and PG Tuner versions

### DIFF
--- a/roles/init_dbserver/templates/postgresql.conf.template
+++ b/roles/init_dbserver/templates/postgresql.conf.template
@@ -31,7 +31,7 @@ log_autovacuum_min_duration = 0
 autovacuum_max_workers = 5
 autovacuum_vacuum_cost_limit = 3000
 idle_in_transaction_session_timeout = 10min
-{% if enable_edb_repo|bool and install_edb_postgres_tuner|bool and pg_version|int >= 11 and ansible_os_family == 'RedHat' %}
+{% if enable_edb_repo|bool and install_edb_postgres_tuner|bool and pg_version|int >= 11 %}
 {{ pg_shared_libraries_list.append('$libdir/edb_pg_tuner') }}
 {% endif %}
 shared_preload_libraries = '{{ pg_shared_libraries_list | join(",") }}'

--- a/roles/install_dbserver/defaults/main.yml
+++ b/roles/install_dbserver/defaults/main.yml
@@ -11,7 +11,7 @@ core_dump_directory: "/var/coredumps"
 
 install_edb_postgres_tuner: true
 edb_tuner_package: "edb-{{ 'as' if pg_type == 'EPAS' else 'pg' }}\
-                   {{ pg_version }}-postgres-tuner{{ pg_tuner_version }}"
+                   {{ pg_version }}-postgres-tuner{{ '-' if ansible_os_family == 'Debian' }}{{ pg_tuner_version }}"
 install_bdr_packages: false
 epas_deb_drop_cluster: "/usr/bin/epas_dropcluster"
 epas_service: "edb-as@{{ pg_version }}-main"

--- a/roles/install_dbserver/tasks/main.yml
+++ b/roles/install_dbserver/tasks/main.yml
@@ -12,4 +12,3 @@
     enable_edb_repo|bool
     and install_edb_postgres_tuner|bool
     and pg_version|int >= 11
-    and ansible_os_family == 'RedHat'

--- a/roles/manage_dbserver/tasks/manage_extensions.yml
+++ b/roles/manage_dbserver/tasks/manage_extensions.yml
@@ -21,7 +21,6 @@
     enable_edb_repo|bool
     and install_edb_postgres_tuner|bool
     and pg_version|int >= 11
-    and ansible_os_family == 'RedHat'
 
 - name: Manage postgres extensions
   community.postgresql.postgresql_ext:

--- a/roles/setup_barman/defaults/main.yml
+++ b/roles/setup_barman/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 pg_version: 15
 pg_instance_name: main
-barman_cli_package: "{{ 'barman-cli-3.3.0-1' if pg_type == 'PG' else 'barman-cli-3.0.1-1' }}"
+barman_cli_package: "{{ 'barman-cli-3.3.0-1' if pg_type == 'PG' else 'barman-cli-3.2.0-1' }}"
 use_hostname: true
 use_patroni: false
 

--- a/roles/setup_barman/defaults/main.yml
+++ b/roles/setup_barman/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 pg_version: 15
 pg_instance_name: main
-barman_cli_package: "{{ 'barman-cli-3.3.0-1' if pg_type == 'PG' else 'barman-cli-3.2.0-1' }}"
+barman_cli_package: "barman-cli-3.3.0-1"
 use_hostname: true
 use_patroni: false
 

--- a/roles/setup_barmanserver/defaults/main.yml
+++ b/roles/setup_barmanserver/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # version 3.3.0-1 is only available on PGDG repo - 3.0.1-1 is available on EPEL
-barman_package: "{{ 'barman-3.3.0-1' if pg_type == 'PG' else 'barman-3.0.1-1' }}"
-barman_cli_package: "{{ 'barman-cli-3.3.0-1' if pg_type == 'PG' else 'barman-cli-3.0.1-1' }}"
+barman_package: "{{ 'barman-3.3.0-1' if pg_type == 'PG' else 'barman-3.2.0-1' }}"
+barman_cli_package: "{{ 'barman-cli-3.3.0-1' if pg_type == 'PG' else 'barman-cli-3.2.0-1' }}"
 
 barman_user: "barman"
 barman_group: "barman"

--- a/roles/setup_barmanserver/defaults/main.yml
+++ b/roles/setup_barmanserver/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
-# version 3.3.0-1 is only available on PGDG repo - 3.0.1-1 is available on EPEL
-barman_package: "{{ 'barman-3.3.0-1' if pg_type == 'PG' else 'barman-3.2.0-1' }}"
-barman_cli_package: "{{ 'barman-cli-3.3.0-1' if pg_type == 'PG' else 'barman-cli-3.2.0-1' }}"
+barman_package: "barman-3.3.0-1"
+barman_cli_package: "barman-cli-3.3.0-1"
 
 barman_user: "barman"
 barman_group: "barman"


### PR DESCRIPTION
Updates barman and barman-cli package version to 3.2.0-1 for EPAS to reflect the package versions offered in EDB repo. The pg-tuner package name was also updated to include Debian OS's consistent with the EDB repos. Tasks where the pg-tuner is directly called had `and ansible_os_distribution == 'RedHat'` removed from the conditional statement. Tested with EPAS and PG on Rocky8 and Debian10. 