### PR TITLE
Allow EDB credentials update

### DIFF
--- a/roles/setup_repo/tasks/PG_RedHat_rm_repos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_rm_repos.yml
@@ -1,13 +1,4 @@
 ---
-- name: Remove PG/EDB repos and epel-release packages
-  ansible.builtin.package:
-    name:
-      - pgdg-redhat-repo
-      - epel-release
-      - edb-repo
-    state: removed
-  become: true
-
 - name: Remove repo file
   ansible.builtin.file:
     path: "{{ item_file }}"
@@ -19,6 +10,15 @@
     - "/etc/yum.repos.d/enterprisedb-enterprise.repo"
   loop_control:
     loop_var: item_file
+  become: true
+
+- name: Remove PG/EDB repos and epel-release packages
+  ansible.builtin.package:
+    name:
+      - pgdg-redhat-repo
+      - epel-release
+      - edb-repo
+    state: removed
   become: true
 
 - name: Remove additional Redhat repositories


### PR DESCRIPTION
In case of using wrong credentials, if we want to replace them, we first need to remove the .repo file, and then, remove the corresponding package.

If the .repo file is not removed prior to package deletion, then, package deletion is not possible due to wrong creds.

The variable force_repo must be set to true.