### PR TITLE
Update DBT docker-compose files

### DIFF
--- a/roles/setup_dbt2/tasks/dbt2_install_packages_client.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_client.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install packages for DBT-2 Client
+- name: Install packages for DBT-2 Client for EL8
   ansible.builtin.dnf:
     name:
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-client-{{ dbt2_version }}-1.el8.x86_64.rpm'
@@ -8,7 +8,23 @@
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-pgsql-plpgsql-{{ dbt2_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: true
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
+  become: true
+
+- name: Download dbt2 packages for EL7
+  ansible.builtin.get_url:
+    url: "https://github.com/osdldbt/dbt2-packaging/archive/refs/tags/v{{ dbt2_version }}.tar.gz"
+    dest: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    mode: '0644'
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+  become: true
+
+- name: Install dbt2 packages for EL7
+  ansible.builtin.unarchive:
+    src: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    dest: "/usr/local/bin"
+    remote_src: true
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
   become: true
 
 - name: Install additional supporting packages

--- a/roles/setup_dbt2/tasks/dbt2_install_packages_client.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_client.yml
@@ -11,17 +11,17 @@
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
   become: true
 
-- name: Download dbt2 packages for EL7
+- name: Download packages for DBT-2 Database for EL7
   ansible.builtin.get_url:
-    url: "https://github.com/osdldbt/dbt2-packaging/archive/refs/tags/v{{ dbt2_version }}.tar.gz"
-    dest: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    url: "https://github.com/osdldbt/dbt2/archive/refs/tags/v{{ dbt2_version }}.tar.gz"
+    dest: "/usr/local/share/dbt2-v{{ dbt2_version }}.tar.gz"
     mode: '0644'
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
   become: true
 
-- name: Install dbt2 packages for EL7
+- name: Install packages for DBT-2 Database for EL7
   ansible.builtin.unarchive:
-    src: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    src: "/usr/local/share/dbt2-v{{ dbt2_version }}.tar.gz"
     dest: "/usr/local/bin"
     remote_src: true
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'

--- a/roles/setup_dbt2/tasks/dbt2_install_packages_db.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_db.yml
@@ -11,17 +11,17 @@
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
   become: true
 
-- name: Download dbt2 packages for EL7
+- name: Download packages for DBT-2 Database for EL7
   ansible.builtin.get_url:
-    url: "https://github.com/osdldbt/dbt2-packaging/archive/refs/tags/v{{ dbt2_version }}.tar.gz"
-    dest: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    url: "https://github.com/osdldbt/dbt2/archive/refs/tags/v{{ dbt2_version }}.tar.gz"
+    dest: "/usr/local/share/dbt2-v{{ dbt2_version }}.tar.gz"
     mode: '0644'
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
   become: true
 
-- name: Install dbt2 packages for EL7
+- name: Install packages for DBT-2 Database for EL7
   ansible.builtin.unarchive:
-    src: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    src: "/usr/local/share/dbt2-v{{ dbt2_version }}.tar.gz"
     dest: "/usr/local/bin"
     remote_src: true
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'

--- a/roles/setup_dbt2/tasks/dbt2_install_packages_db.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_db.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install packages for DBT-2 Database
+- name: Install packages for DBT-2 Database for EL8
   ansible.builtin.dnf:
     name:
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-pgsql-c_{{ pg_version }}-{{ dbt2_version }}-1.el8.x86_64.rpm'
@@ -8,7 +8,23 @@
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-scripts-{{ dbt2_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: true
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
+  become: true
+
+- name: Download dbt2 packages for EL7
+  ansible.builtin.get_url:
+    url: "https://github.com/osdldbt/dbt2-packaging/archive/refs/tags/v{{ dbt2_version }}.tar.gz"
+    dest: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    mode: '0644'
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+  become: true
+
+- name: Install dbt2 packages for EL7
+  ansible.builtin.unarchive:
+    src: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    dest: "/usr/local/bin"
+    remote_src: true
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
   become: true
 
 - name: Install additional supporting packages

--- a/roles/setup_dbt2/tasks/dbt2_install_packages_driver.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_driver.yml
@@ -14,17 +14,17 @@
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
   become: true
 
-- name: Download DBT-2 packages for EL7
+- name: Download packages for DBT-2 Database for EL7
   ansible.builtin.get_url:
-    url: "https://github.com/osdldbt/dbt2-packaging/archive/refs/tags/v{{ dbt2_version }}.tar.gz"
-    dest: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    url: "https://github.com/osdldbt/dbt2/archive/refs/tags/v{{ dbt2_version }}.tar.gz"
+    dest: "/usr/local/share/dbt2-v{{ dbt2_version }}.tar.gz"
     mode: '0644'
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
   become: true
 
-- name: Install DBT-2 packages for EL7
+- name: Install packages for DBT-2 Database for EL7
   ansible.builtin.unarchive:
-    src: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    src: "/usr/local/share/dbt2-v{{ dbt2_version }}.tar.gz"
     dest: "/usr/local/bin"
     remote_src: true
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'

--- a/roles/setup_dbt2/tasks/dbt2_install_packages_driver.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_driver.yml
@@ -1,5 +1,6 @@
 ---
-- name: Install packages for DBT-2 Driver
+# centos7 does not have dnf enabled
+- name: Install packages for DBT-2 Driver for EL8
   ansible.builtin.dnf:
     name:
       - 'https://github.com/osdldbt/dbttools-packaging/releases/download/v{{ dbttools_version }}/dbttools-{{ dbttools_version }}-1.el8.x86_64.rpm'
@@ -10,7 +11,39 @@
       - 'https://github.com/osdldbt/dbt2-packaging/releases/download/v{{ dbt2_version }}/dbt2-pgsql-plpgsql-{{ dbt2_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: true
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
+  become: true
+
+- name: Download DBT-2 packages for EL7
+  ansible.builtin.get_url:
+    url: "https://github.com/osdldbt/dbt2-packaging/archive/refs/tags/v{{ dbt2_version }}.tar.gz"
+    dest: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    mode: '0644'
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+  become: true
+
+- name: Install DBT-2 packages for EL7
+  ansible.builtin.unarchive:
+    src: "/usr/local/share/dbt2-packaging-v{{ dbt2_version }}.tar.gz"
+    dest: "/usr/local/bin"
+    remote_src: true
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+  become: true
+
+- name: Download DBTtools packages for EL7
+  ansible.builtin.get_url:
+    url: "https://github.com/osdldbt/dbttools/archive/refs/tags/v{{ dbttools_version }}.tar.gz"
+    dest: "/usr/local/share/dbttools-v{{ dbttools_version }}.tar.gz"
+    mode: '0644'
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+  become: true
+
+- name: Install DBTtools packages for EL7
+  ansible.builtin.unarchive:
+    src: "/usr/local/share/dbttools-v{{ dbttools_version }}.tar.gz"
+    dest: "/usr/local/bin"
+    remote_src: true
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
   become: true
 
 - name: Download stackcollapse-perf.pl
@@ -27,7 +60,7 @@
     mode: '0755'
   become: true
 
-- name: Install additional supporting packages
+- name: Install additional supporting packages for EL8
   ansible.builtin.package:
     name:
       - perf
@@ -36,5 +69,18 @@
       - rsync
       - tmux
     state: present
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
+  become: true
+
+# centos7 does not have python3-docutils pacakge
+- name: Install additional supporting packages for EL7
+  ansible.builtin.package:
+    name:
+      - perf
+      - postgresql
+      - python-docutils
+      - rsync
+      - tmux
+    state: present
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
   become: true

--- a/roles/setup_dbt3/tasks/dbt3_install_packages.yml
+++ b/roles/setup_dbt3/tasks/dbt3_install_packages.yml
@@ -7,7 +7,6 @@
       - patch
       - perf
       - psmisc
-      - python3-docutils
       - R-core
       - sysstat
       - tmux
@@ -15,11 +14,41 @@
   when: ansible_os_family == "RedHat"
   become: true
 
-- name: Install packages for DBT-3 Database
+- name: Install python3-docutils package for EL8
+  ansible.builtin.package:
+    name:
+      - python3-docutils
+    state: present
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
+
+- name: Install python-docutils package for EL7
+  ansible.builtin.package:
+    name:
+      - python-docutils
+    state: present
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+
+- name: Install packages for DBT-3 Database for EL8
   ansible.builtin.dnf:
     name:
       - 'https://github.com/osdldbt/dbt3-packaging/releases/download/v{{ dbt3_version }}/dbt3-{{ dbt3_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: true
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
+  become: true
+
+- name: Download package for DBT-3 Database for EL7
+  ansible.builtin.get_url:
+    url: "https://github.com/osdldbt/dbt3/archive/refs/tags/v{{ dbt3_version }}.tar.gz"
+    dest: "/usr/local/share/dbt3-v{{ dbt3_version }}.tar.gz"
+    mode: '0644'
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+  become: true
+
+- name: Install package for DBT-3 Database for EL7
+  ansible.builtin.unarchive:
+    src: "/usr/local/share/dbt3-v{{ dbt3_version }}.tar.gz"
+    dest: "/usr/local/bin"
+    remote_src: true
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
   become: true

--- a/roles/setup_dbt7/tasks/dbt7_install_packages.yml
+++ b/roles/setup_dbt7/tasks/dbt7_install_packages.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install additional supporting packages
   ansible.builtin.package:
     name:
@@ -9,7 +8,6 @@
       - patch
       - perf
       - psmisc
-      - python3-docutils
       - R-core
       - sysstat
       - tmux
@@ -17,11 +15,41 @@
   when: ansible_os_family == "RedHat"
   become: true
 
-- name: Install packages for DBT-7 Database
+- name: Install python3-docutils package for EL8
+  ansible.builtin.package:
+    name:
+      - python3-docutils
+    state: present
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
+
+- name: Install python-docutils package for EL7
+  ansible.builtin.package:
+    name:
+      - python-docutils
+    state: present
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+
+- name: Install packages for DBT-7 Database for EL8
   ansible.builtin.dnf:
     name:
       - 'https://github.com/osdldbt/dbt7-packaging/releases/download/v{{ dbt7_version }}/dbt7-{{ dbt7_version }}-1.el8.x86_64.rpm'
     state: present
     disable_gpg_check: true
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
+  become: true
+
+- name: Download package for DBT-7 Database for EL7
+  ansible.builtin.get_url:
+    url: "https://github.com/osdldbt/dbt7/archive/refs/tags/v{{ dbt7_version }}.tar.gz"
+    dest: "/usr/local/share/dbt7-v{{ dbt7_version }}.tar.gz"
+    mode: '0644'
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+  become: true
+
+- name: Install package for DBT-7 Database for EL7
+  ansible.builtin.unarchive:
+    src: "/usr/local/share/dbt7-v{{ dbt7_version }}.tar.gz"
+    dest: "/usr/local/bin"
+    remote_src: true
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
   become: true

--- a/tests/cases/setup_dbt2/docker-compose.yml
+++ b/tests/cases/setup_dbt2/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     privileged: true
     build:
       context: ../../docker
-      dockerfile: Dockerfile.rocky8
+      dockerfile: Dockerfile.centos7
     cap_add:
     - SYS_ADMIN
     volumes:
@@ -67,7 +67,7 @@ services:
     privileged: true
     build:
       context: ../../docker
-      dockerfile: Dockerfile.rocky8
+      dockerfile: Dockerfile.centos7
     cap_add:
     - SYS_ADMIN
     volumes:
@@ -78,7 +78,7 @@ services:
     privileged: true
     build:
       context: ../../docker
-      dockerfile: Dockerfile.rocky8
+      dockerfile: Dockerfile.centos7
     cap_add:
     - SYS_ADMIN
     volumes:

--- a/tests/cases/setup_dbt2_client/docker-compose.yml
+++ b/tests/cases/setup_dbt2_client/docker-compose.yml
@@ -89,7 +89,7 @@ services:
     privileged: true
     build:
       context: ../../docker
-      dockerfile: Dockerfile.rocky8
+      dockerfile: Dockerfile.centos7
     cap_add:
     - SYS_ADMIN
     volumes:
@@ -100,7 +100,7 @@ services:
     privileged: true
     build:
       context: ../../docker
-      dockerfile: Dockerfile.rocky8
+      dockerfile: Dockerfile.centos7
     cap_add:
     - SYS_ADMIN
     volumes:
@@ -111,7 +111,7 @@ services:
     privileged: true
     build:
       context: ../../docker
-      dockerfile: Dockerfile.rocky8
+      dockerfile: Dockerfile.centos7
     cap_add:
     - SYS_ADMIN
     volumes:

--- a/tests/cases/setup_dbt2_driver/docker-compose.yml
+++ b/tests/cases/setup_dbt2_driver/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     privileged: true
     build:
       context: ../../docker
-      dockerfile: Dockerfile.rocky8
+      dockerfile: Dockerfile.centos7
     cap_add:
     - SYS_ADMIN
     volumes:
@@ -78,7 +78,7 @@ services:
     privileged: true
     build:
       context: ../../docker
-      dockerfile: Dockerfile.rocky8
+      dockerfile: Dockerfile.centos7
     cap_add:
     - SYS_ADMIN
     volumes:

--- a/tests/cases/setup_dbt3/docker-compose.yml
+++ b/tests/cases/setup_dbt3/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     privileged: true
     build:
       context: ../../docker
-      dockerfile: Dockerfile.rocky8
+      dockerfile: Dockerfile.centos7
     cap_add:
     - SYS_ADMIN
     volumes:

--- a/tests/cases/setup_dbt7/docker-compose.yml
+++ b/tests/cases/setup_dbt7/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     privileged: true
     build:
       context: ../../docker
-      dockerfile: Dockerfile.rocky8
+      dockerfile: Dockerfile.centos7
     cap_add:
     - SYS_ADMIN
     volumes:

--- a/tests/cases/setup_hammerdb/Makefile
+++ b/tests/cases/setup_hammerdb/Makefile
@@ -4,7 +4,6 @@ build-rocky8:
 	docker compose up hammerdb1-rocky8 -d
 
 build-almalinux8:
-	docker compose up primary1-almalinux8 -d
 	docker compose up hammerdb1-almalinux8 -d
 
 build-debian10:

--- a/tests/cases/setup_hammerdb/docker-compose.yml
+++ b/tests/cases/setup_hammerdb/docker-compose.yml
@@ -19,33 +19,11 @@ services:
     volumes:
     - ../../..:/workspace
     command: "/workspace/tests/docker/exec-tests.sh"
-  primary1-rocky8:
-    privileged: true
-    build:
-      context: ../../docker
-      dockerfile: Dockerfile.rocky8
-    cap_add:
-    - SYS_ADMIN
-    volumes:
-    - .:/workspace
-    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
-    command: /usr/sbin/init
   hammerdb1-rocky8:
     privileged: true
     build:
       context: ../../docker
       dockerfile: Dockerfile.rocky8
-    cap_add:
-    - SYS_ADMIN
-    volumes:
-    - .:/workspace
-    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
-    command: /usr/sbin/init
-  primary1-almalinux8:
-    privileged: true
-    build:
-      context: ../../docker
-      dockerfile: Dockerfile.almalinux8
     cap_add:
     - SYS_ADMIN
     volumes:
@@ -63,41 +41,11 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
-  primary1-debian10:
-    privileged: true
-    build:
-      context: ../../docker
-      dockerfile: Dockerfile.debian10
-    cap_add:
-    - SYS_ADMIN
-    volumes:
-    - .:/workspace
-    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
-    tmpfs:
-    - /run
-    - /tmp
-    - /run/sshd
-    - /run/lock
   hammerdb1-debian10:
     privileged: true
     build:
       context: ../../docker
       dockerfile: Dockerfile.debian10
-    cap_add:
-    - SYS_ADMIN
-    volumes:
-    - .:/workspace
-    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
-    tmpfs:
-    - /run
-    - /tmp
-    - /run/sshd
-    - /run/lock
-  primary1-ubuntu20:
-    privileged: true
-    build:
-      context: ../../docker
-      dockerfile: Dockerfile.ubuntu20
     cap_add:
     - SYS_ADMIN
     volumes:


### PR DESCRIPTION
Updates the `docker-compose.yml` files for `setup_dbt2`, `setup_dbt2_driver`, `setup_dbt2_client`, `setup_dbt3` and `setup_dbt7`. To ensure these roles are compatible with Centos7, the install files for the respective roles were updated for EL7 compatibility. The `setup_hammerdb` `docker-compose.yml` and Makefile were updated to reflect the tests only having a `hammerdb1` node and no longer a `primary1` node as well. 
The tests for roles `setup_dbt2`, `setup_dbt2_driver`, `setup_dbt2_client`, `setup_dbt3` and `setup_dbt7` use the RPM package feature and thus are failing on Centos7, however, the RPM package presence is the only failing test.