### PR TITLE
[setup_repo] update ca-certificates to latest

### DIFF
--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -2,7 +2,7 @@
 - name: Update the ca-certificates package
   ansible.builtin.package:
     name: ca-certificates
-    state: present
+    state: latest
   become: true
 
 - name: Download EDB GPG key for EL8


### PR DESCRIPTION
Hi,

On CentOS7 default docker images, the ca-certificates package isn't updated preventing to install the pgdg package.
With the ansible role updating it to its latest version, the problem is fixed.

Kind Regards,
Stefan