### PR TITLE
addition hba appending error

### DIFF
--- a/roles/setup_barman/tasks/update_pg_hba.yml
+++ b/roles/setup_barman/tasks/update_pg_hba.yml
@@ -7,13 +7,13 @@
           'users': 'barman',
           'databases': 'postgres',
           'contype': 'hostssl',
-          'source': '{{ hostvars[inventory_hostname].barman_server_private_ip | default("127.0.0.1") }}/32'
+          'source': hostvars[inventory_hostname].barman_server_private_ip | default("127.0.0.1") + '/32' | string
         },
         {
           'users': 'barman',
           'databases': 'postgres',
           'contype': 'host',
-          'source': '{{ hostvars[inventory_hostname].barman_server_private_ip | default("127.0.0.1") }}/32'
+          'source': hostvars[inventory_hostname].barman_server_private_ip | default("127.0.0.1") + '/32' | string
         }
       ] }}
 

--- a/roles/setup_barman/tasks/update_pg_hba.yml
+++ b/roles/setup_barman/tasks/update_pg_hba.yml
@@ -2,7 +2,7 @@
 - name: Initialize the hba_entries variable
   ansible.builtin.set_fact:
     hba_entries: >-
-      [
+      {{ hba_entries | default([]) + [
         {
           'users': 'barman',
           'databases': 'postgres',
@@ -15,12 +15,12 @@
           'contype': 'host',
           'source': '{{ hostvars[inventory_hostname].barman_server_private_ip | default("127.0.0.1") }}/32'
         }
-      ]
+      ] }}
 
 - name: Add HBA rule for barman replication
   ansible.builtin.set_fact:
     hba_entries: >-
-      {{ hba_entries + [
+      {{ hba_entries | default([]) + [
         {
           'users': 'barman',
           'databases': 'replication',


### PR DESCRIPTION
In addition to @hannahms  also the fix for the default situation in task:
- name: I**nitialize the hba_entries variable** in update_pg_hba.yml

Now resulting in :

`ok: [xxxxx] => {
    "msg": "[{'users': 'barman', 'databases': 'postgres', 'contype': 'hostssl', 'source': 'xxxxxx}, {'users': 'barman', 'databases': 'postgres', 'contype': 'host', 'source': 'xxxxxx'}] + [\n  {\n    'users': 'barman',\n    'databases': 'replication',\n    'contype': 'hostssl',\n    'address': '10.110.0.4/32'\n  },\n  {\n    'users': 'barman',\n    'databases': 'replication',\n    'contype': 'host',\n    'source': 'xxxxxx'\n  }\n]"
}`

Which is not correct!

Strange that the replication role has this more neat in a prepare_hba_value.yml ! Would advice to make this uninform.

