### PR TITLE
fix barman_no_configuration logic

### DIFF
--- a/roles/setup_barman/tasks/setup_barman.yml
+++ b/roles/setup_barman/tasks/setup_barman.yml
@@ -79,16 +79,16 @@
   ansible.builtin.include_tasks: configure_barman.yml
   when: >
     hostvars[inventory_hostname].barman_no_configuration is not defined
-    or hostvars[inventory_hostname].barman_no_configuration|bool
+    or not hostvars[inventory_hostname].barman_no_configuration|bool
 
 - name: Include the Postgres configuration tasks for backup
   ansible.builtin.include_tasks: configure_pg_backup.yml
   when: >
     hostvars[inventory_hostname].barman_no_configuration is not defined
-    or hostvars[inventory_hostname].barman_no_configuration|bool
+    or not hostvars[inventory_hostname].barman_no_configuration|bool
 
 - name: Include the barman post configuration tasks
   ansible.builtin.include_tasks: post_configure_barman.yml
   when: >
     hostvars[inventory_hostname].barman_no_configuration is not defined
-    or hostvars[inventory_hostname].barman_no_configuration|bool
+    or not hostvars[inventory_hostname].barman_no_configuration|bool


### PR DESCRIPTION
When setting `barman_no_configuration: true` to skip configuration on non-primary nodes, the conditional to skip these tasks was incorrect. The following evaluates true when `barman_no_configuration: true` is set and we need to it evaluate false.
```
hostvars[inventory_hostname].barman_no_configuration is not defined
or hostvars[inventory_hostname].barman_no_configuration|bool
``` 
To have the conditional evaluate correctly, it has been changed to 
```
hostvars[inventory_hostname].barman_no_configuration is not defined
or not hostvars[inventory_hostname].barman_no_configuration|bool
```