### PR TITLE
A couple of HammerDB playbook updates

### DIFF
--- a/roles/setup_hammerdb/README.md
+++ b/roles/setup_hammerdb/README.md
@@ -7,6 +7,15 @@ This role is for installing HammerDB.
 Following are the requirements of this role.
   1. Ansible
 
+## Role variables
+
+When executing the role via ansible these are the required variables:
+
+  * ***hammerdb_user***
+
+  The operating system user that will be created.  HammerDB is intalled into
+  this user's home directory.
+
 ## License
 
 BSD

--- a/roles/setup_hammerdb/defaults/main.yml
+++ b/roles/setup_hammerdb/defaults/main.yml
@@ -10,6 +10,18 @@ hammerdb_user: "hammerdb"
 hammerdb_group: "hammerdb"
 oracle_instant_client_repo_pkg: "oracle-instantclient-release-el\
                            {{ ansible_facts[\"distribution_major_version\"] }}"
+oracle_instant_client_rpm: "https://download.oracle.com/otn_software/linux/\
+                            instantclient/219000/\
+                            oracle-instantclient-basic-21.9.0.0.0-1.\
+                            el8.x86_64.rpm"
+oracle_instant_client_sqlplus_rpm: "https://download.oracle.com/otn_software/\
+                                    linux/instantclient/219000/\
+                                    oracle-instantclient-sqlplus-21.9.0.0.0-1.\
+                                    el8.x86_64.rpm"
+oracle_instant_client_tools_rpm: "https://download.oracle.com/otn_software/\
+                                  linux/instantclient/219000/\
+                                  oracle-instantclient-tools-21.9.0.0.0-1.\
+                                  el8.x86_64.rpm"
 supported_os:
   - CentOS8
   - RHEL8

--- a/roles/setup_hammerdb/defaults/main.yml
+++ b/roles/setup_hammerdb/defaults/main.yml
@@ -28,5 +28,6 @@ supported_os:
   - Rocky8
   - AlmaLinux8
   - Debian10
+  - OracleLinux8
   - Ubuntu20
 use_patroni: false

--- a/roles/setup_hammerdb/defaults/main.yml
+++ b/roles/setup_hammerdb/defaults/main.yml
@@ -6,6 +6,8 @@ hammerdb_filename: "HammerDB-{{ hammerdb_version }}-\
                     {{ ansible_distribution_major_version if \
                     ansible_os_family == 'RedHat'}}.tar.gz"
 hammerdb_url: "https://github.com/TPC-Council/HammerDB/releases/download/"
+hammerdb_user: "hammerdb"
+hammerdb_group: "hammerdb"
 oracle_instant_client_repo_pkg: "oracle-instantclient-release-el\
                            {{ ansible_facts[\"distribution_major_version\"] }}"
 supported_os:

--- a/roles/setup_hammerdb/tasks/main.yml
+++ b/roles/setup_hammerdb/tasks/main.yml
@@ -10,7 +10,7 @@
   ansible.builtin.user:
     name: "{{ hammerdb_user }}"
     system: true
-    group: "{{ hammerdb_user }}"
+    group: "{{ hammerdb_group }}"
     state: present
     create_home: true
   become: true

--- a/roles/setup_hammerdb/tasks/main.yml
+++ b/roles/setup_hammerdb/tasks/main.yml
@@ -44,10 +44,21 @@
       - "{{ oracle_instant_client_repo_pkg }}"
   when: ansible_facts["distribution"] == "OracleLinux"
 
-- name: Install Oracle Instant Client Packages
+- name: Install Oracle Instant Client Packages (repo)
   ansible.builtin.package:
     name:
       - oracle-instantclient-basic
       - oracle-instantclient-sqlplus
       - oracle-instantclient-tools
   when: ansible_facts["distribution"] == "OracleLinux"
+
+- name: Install Oracle Instant Client Packages (url)
+  ansible.builtin.package:
+    name:
+      - "{{ oracle_instant_client_rpm }}"
+      - "{{ oracle_instant_client_sqlplus_rpm }} "
+      - "{{ oracle_instant_client_tools_rpm }} "
+    disable_gpg_check: true
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == "8"

--- a/roles/setup_hammerdb/tasks/main.yml
+++ b/roles/setup_hammerdb/tasks/main.yml
@@ -1,5 +1,20 @@
 ---
 
+- name: Create hammerdb system group {{ hammerdb_group }}
+  ansible.builtin.group:
+    name: "{{ hammerdb_group }}"
+    state: present
+  become: true
+
+- name: Create hammerdb system user {{ hammerdb_user }}
+  ansible.builtin.user:
+    name: "{{ hammerdb_user }}"
+    system: true
+    group: "{{ hammerdb_user }}"
+    state: present
+    create_home: true
+  become: true
+
 - name: Install packages required for installing HammerDB
   ansible.builtin.package:
     name:
@@ -10,14 +25,18 @@
 - name: Download HammerDB
   ansible.builtin.get_url:
     url: "{{ hammerdb_url }}/v{{ hammerdb_version }}/{{ hammerdb_filename }}"
-    dest: "{{ ansible_user_dir }}/{{ hammerdb_filename }}"
+    dest: "/home/{{ hammerdb_user }}/{{ hammerdb_filename }}"
     mode: '0644'
+  become: true
+  become_user: "{{ hammerdb_user }}"
 
 - name: Install HammerDB
   ansible.builtin.unarchive:
-    src: "{{ ansible_user_dir }}/{{ hammerdb_filename }}"
-    dest: "{{ ansible_user_dir }}"
+    src: "/home/{{ hammerdb_user }}/{{ hammerdb_filename }}"
+    dest: "/home/{{ hammerdb_user }}"
     remote_src: true
+  become: true
+  become_user: "{{ hammerdb_user }}"
 
 - name: Install Oracle Instant Client Repository
   ansible.builtin.package:

--- a/tests/cases/setup_hammerdb/vars.json
+++ b/tests/cases/setup_hammerdb/vars.json
@@ -1,5 +1,5 @@
 {
   "use_hostname": false,
-  "hammerdb": "/root/HammerDB-4.6",
+  "hammerdb": "/home/hammerdb/HammerDB-4.6",
   "hammerdb_version": "4.6"
 }


### PR DESCRIPTION
* Use a dedicated user for hammerdb installations as a reliable alternative to ansible_user_dir
* Add installation rules for RHEL8 and Oracle Instant Client