### PR TITLE
Manage efm support for version 4.6

### DIFF
--- a/roles/manage_efm/defaults/main.yml
+++ b/roles/manage_efm/defaults/main.yml
@@ -64,6 +64,7 @@ supported_pg_version:
   - 15
 
 supported_efm_version:
+  - "4.6"
   - "4.5"
   - "4.4"
   - "4.3"


### PR DESCRIPTION
In the `manage_efm` role, version 4.6 is missing from the `supported_efm_version` list. Now, users can go through both the `setup_efm` and `manage_efm` roles using efm v4.6.