### PR TITLE
Add enable_epel_repo and enable_pgdg_repo flags

### DIFF
--- a/roles/setup_repo/README.md
+++ b/roles/setup_repo/README.md
@@ -54,6 +54,14 @@ When executing the role via Ansible these are the required variables:
   EDB repository token used to access EDB package repository.
   Required when **enable_edb_repo** is set to `true` and **repo_username** and **repo_password** aren't used.
 
+  * **enable_pgdg_repo** 
+
+  Configure access to the PGDG package repository. Default: `true`. Only set to `false` when using local repositories. 
+
+  * **enable_epel_repo**
+
+  Configure access to EPEL package repository on EL8 distributions. Default: `true`. Only set to `false` when using local repositories.
+
   * **yum_additional_repos**
 
   List of additional YUM repositories. List items are dictionnaries:

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -13,6 +13,11 @@ repo_password: ""
 tpa_subscription_token: ""
 install_bdr_packages: false
 
+# set to false only if you are using local repositories and do not need the PGDG and/or EPEL repositories.
+# setting to false will result in failure to download required packages if access to local repos is not available
+enable_pgdg_repo: true
+enable_epel_repo: true
+
 # EDB RPM Repo
 edb_rpm_repo: "http://yum.enterprisedb.com/edbrepos/edb-repo-latest.noarch.rpm"
 edb_gpg_key_8: "https://yum.enterprisedb.com/ENTERPRISEDB-GPG-KEY"
@@ -72,3 +77,4 @@ supported_pg_version:
   - 12
   - 13
   - 14
+  - 15

--- a/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
@@ -56,6 +56,7 @@
     update_cache: true
     state: present
   become: true
+  when: enable_edb_repo|bool or enable_pgdg_repo|bool
 
 - name: Add EDB Debian 9 repo
   ansible.builtin.apt_repository:
@@ -70,7 +71,9 @@
   ansible.builtin.apt_key:
     url: "{{ pg_deb_keys }}"
     state: present
-  when: pg_type == 'PG'
+  when:
+    - pg_type == 'PG'
+    - enable_pgdg_repo|bool
   become: true
 
 - name: Add PG Debian repo
@@ -78,7 +81,9 @@
     repo: "{{ pg_deb_repo_url }}"
     state: present
     filename: "pgdg"
-  when: pg_type == 'PG'
+  when:
+    - pg_type == 'PG'
+    - enable_pgdg_repo|bool
   become: true
 
 - name: Add additional Debian repositories

--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -21,6 +21,7 @@
   when:
     - ansible_distribution_major_version == '8'
     - pg_type == 'PG'
+    - enable_pgdg_repo|bool
   become: true
 
 - name: Download EPEL GPG key for EL8
@@ -29,13 +30,16 @@
     state: present
   when:
     - ansible_distribution_major_version == '8'
+    - enable_epel_repo|bool
   become: true
 
 - name: Install EPEL repo for EL7
   ansible.builtin.package:
     name: "{{ epel_repo_7 }}"
     state: present
-  when: ansible_distribution_major_version == '7'
+  when:
+    - ansible_distribution_major_version == '7'
+    - enable_epel_repo|bool
   become: true
 
 - name: Install PG repo for EL7
@@ -46,25 +50,32 @@
   when:
     - ansible_distribution_major_version == '7'
     - pg_type == 'PG'
+    - enable_pgdg_repo|bool
 
 - name: Install dnf-plugins-core for EL8
   ansible.builtin.package:
     name: dnf-plugins-core
     state: present
   become: true
-  when: ansible_distribution_major_version == '8'
+  when:
+    - ansible_distribution_major_version == '8'
+    - enable_epel_repo|bool
 
 - name: Enable powertools for EL8
   ansible.builtin.command: >
     dnf config-manager --set-enabled powertools
   become: true
-  when: ansible_distribution_major_version == '8'
+  when:
+    - ansible_distribution_major_version == '8'
+    - enable_epel_repo|bool
 
 - name: Install EPEL repo for EL8
   ansible.builtin.package:
     name: "{{ epel_repo_8 }}"
     state: present
-  when: ansible_distribution_major_version == '8'
+  when:
+    - ansible_distribution_major_version == '8'
+    - enable_epel_repo|bool
   become: true
 
 - name: Install PG repo for EL8
@@ -75,6 +86,7 @@
   when:
     - ansible_distribution_major_version == '8'
     - pg_type == 'PG'
+    - enable_pgdg_repo|bool
 
 - name: Install EPAS repo for RedHat
   ansible.builtin.package:


### PR DESCRIPTION
In cases when users have configured access to local repositories and do not require configuration of the EPEL and/or PGDG repos, the flags `enable_pgdg_repo` and `enable_epel_repo` have been added to the `setup_repo` role. When set to `false` the flags enable skipping tasks not required for configuration of the respective repo(s).