### PR TITLE
Add remove_only flag and update rm_setup_repo

### DIFF
--- a/roles/init_dbserver/tasks/init_dbserver.yml
+++ b/roles/init_dbserver/tasks/init_dbserver.yml
@@ -38,9 +38,9 @@
 
 - name: Force cleanup based on force_initdb
   ansible.builtin.include_tasks: rm_initdb.yml
-  when:
-    - force_initdb is defined
-    - force_initdb
+  when: >
+    ((force_initdb is defined and force_initdb) or
+     (remove_only is defined and remove_only))
 
 - name: Update /etc/hosts based on use_hostname
   ansible.builtin.import_tasks: linux_update_etc_hosts.yml

--- a/roles/install_dbserver/tasks/install_dbserver.yml
+++ b/roles/install_dbserver/tasks/install_dbserver.yml
@@ -27,9 +27,9 @@
 
 - name: Remove Postgres packages
   ansible.builtin.include_tasks: "{{ pg_type }}_{{ ansible_os_family }}_rm_install.yml"
-  when:
-    - force_install is defined
-    - force_install
+  when: >
+    ((force_install is defined and force_install) or
+     (remove_only is defined and remove_only))
 
 - name: Install and Configure Postgres on RedHat
   ansible.builtin.include_tasks: "{{ pg_type }}_{{ ansible_os_family }}_install.yml"

--- a/roles/setup_barman/tasks/setup_barman.yml
+++ b/roles/setup_barman/tasks/setup_barman.yml
@@ -40,7 +40,8 @@
       ((force_barman is defined and force_barman)
        or (force_initdb is defined and force_initdb)
         or (force_replication is defined and force_replication)
-         or (force_pemserver is defined and force_pemserver))
+         or (force_pemserver is defined and force_pemserver)
+          or (remove_only is defined and remove_only))
 
 - name: Update /etc/hosts based on use_hostname
   when:

--- a/roles/setup_barmanserver/tasks/setup_barmanserver.yml
+++ b/roles/setup_barmanserver/tasks/setup_barmanserver.yml
@@ -10,9 +10,9 @@
 
 - name: Remove the barmanserver install/config based on force_barmanserver
   ansible.builtin.include_tasks: rm_barmanserver_install_config.yml
-  when:
-    - force_barmanserver is defined
-    - force_barmanserver
+  when: >
+    ((force_barmanserver is defined and force_barmanserver) or
+     (remove_only is defined and remove_only))
 
 - name: Include the package installation tasks
   ansible.builtin.include_tasks: install_packages.yml

--- a/roles/setup_dbt2/tasks/main.yml
+++ b/roles/setup_dbt2/tasks/main.yml
@@ -6,7 +6,8 @@
   ansible.builtin.include_tasks: rm_dbt2_install_config.yml
   when: >
     ((force_initdb is defined and force_initdb) or
-     (force_dbt2 is defined and force_dbt2))
+     (force_dbt2 is defined and force_dbt2) or
+     (remove_only is defined and remove_only))
 
 - name: Include DBT-2 client systems into pg_hba
   ansible.builtin.include_tasks: dbt2_update_pg_hba.yml

--- a/roles/setup_dbt2_client/tasks/main.yml
+++ b/roles/setup_dbt2_client/tasks/main.yml
@@ -9,7 +9,8 @@
   ansible.builtin.include_tasks: rm_dbt2_client_install_config.yml
   when: >
     ((force_dbt2 is defined and force_dbt2) or
-     (force_dbt2_client is defined and force_dbt2_client))
+     (force_dbt2_client is defined and force_dbt2_client) or
+     (remove_only is defined and remove_only))
 
 - name: Include DBT-2 kit client installation
   ansible.builtin.include_role:

--- a/roles/setup_dbt2_driver/tasks/main.yml
+++ b/roles/setup_dbt2_driver/tasks/main.yml
@@ -6,7 +6,8 @@
   ansible.builtin.include_tasks: rm_dbt2_driver_install_config.yml
   when: >
     ((force_dbt2 is defined and force_dbt2) or
-    (force_dbt2_driver is defined and force_dbt2_driver))
+    (force_dbt2_driver is defined and force_dbt2_driver) or
+    (remove_only is defined and remove_only))
 
 - name: Include DBT-2 kit driver installation
   ansible.builtin.include_role:

--- a/roles/setup_efm/tasks/setup_efm.yml
+++ b/roles/setup_efm/tasks/setup_efm.yml
@@ -86,6 +86,7 @@
     (force_efm is defined and force_efm)
     or (force_initdb is defined and force_initdb)
     or (force_replication is defined and force_replication)
+    or (remove_only is defined and remove_only)
 
 - name: Prepare efm_nodes_list based on use_hostname
   ansible.builtin.set_fact:

--- a/roles/setup_hammerdb/tasks/main.yml
+++ b/roles/setup_hammerdb/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Remove hammerdb install/config based on force_hammerdb
   ansible.builtin.include_tasks: rm_hammerdb_install_config.yml
-  when:
-    - force_hammerdb is defined
-    - force_hammerdb
+  when: >
+    ((force_hammerdb is defined and force_hammerdb) or
+     (remove_only is defined and remove_only))
 
 - name: Create hammerdb system group {{ hammerdb_group }}
   ansible.builtin.group:

--- a/roles/setup_pemagent/tasks/setup_pemagent.yml
+++ b/roles/setup_pemagent/tasks/setup_pemagent.yml
@@ -75,7 +75,8 @@
   when: >
       ((force_pemserver is defined and force_pemserver)
        or (force_initdb is defined and force_initdb)
-       or (force_pemagent is defined and force_pemagent))
+       or (force_pemagent is defined and force_pemagent)
+       or (remove_only is defined and remove_only))
        and not pem_agent_remote
   become: true
   no_log: "{{ disable_logging }}"

--- a/roles/setup_pemserver/tasks/setup_pemserver.yml
+++ b/roles/setup_pemserver/tasks/setup_pemserver.yml
@@ -48,7 +48,8 @@
   ansible.builtin.import_tasks: rm_pem_server_install.yml
   when: >
       ((force_pemserver is defined and force_pemserver)
-       or (force_initdb is defined and force_initdb))
+       or (force_initdb is defined and force_initdb)
+        or (remove_only is defined and remove_only))
   become: true
 
 - name: Install and configure pemserver

--- a/roles/setup_pgbackrest/tasks/setup_pgbackrest.yml
+++ b/roles/setup_pgbackrest/tasks/setup_pgbackrest.yml
@@ -38,7 +38,8 @@
   when: >
     ((force_pgbackrest is defined and force_pgbackrest)
      or (force_initdb is defined and force_initdb)
-      or (force_replication is defined and force_replication))
+      or (force_replication is defined and force_replication)
+       or (remove_only is defined and remove_only))
 
 - name: Incluse pgBackRest install
   ansible.builtin.include_tasks: pgbackrest_install_PG.yml

--- a/roles/setup_pgbackrestserver/tasks/setup_pgbackrestserver.yml
+++ b/roles/setup_pgbackrestserver/tasks/setup_pgbackrestserver.yml
@@ -38,9 +38,9 @@
 
 - name: Remove pgbackrest install/config based on force_pgbackrestserver
   ansible.builtin.include_tasks: rm_pgbackrestserver_install_config.yml
-  when:
-    - force_pgbackrestserver is defined
-    - force_pgbackrestserver
+  when: >
+    ((force_pgbackrestserver is defined and force_pgbackrestserver) or 
+     (remove_only is defined and remove_only))
 
 - name: Update /etc/hosts based on use_hostname
   become: true

--- a/roles/setup_pgbouncer/tasks/setup_pgbouncer.yml
+++ b/roles/setup_pgbouncer/tasks/setup_pgbouncer.yml
@@ -28,8 +28,9 @@
   ansible.builtin.include_tasks: rm_pgbouncer_install_config.yml
   when: >
     ((force_pgbouncer is defined and force_pgbouncer) or
-    (force_initdb is defined and force_initdb) or
-    (force_replication is defined and force_replication))
+     (force_initdb is defined and force_initdb) or
+     (force_replication is defined and force_replication) or
+     (remove_only is defined and remove_only))
 
 - name: Include the pgbouncer_install
   ansible.builtin.include_tasks: pgbouncer_install.yml

--- a/roles/setup_pgpool2/tasks/setup_pgpool2.yml
+++ b/roles/setup_pgpool2/tasks/setup_pgpool2.yml
@@ -128,9 +128,9 @@
 
 - name: Remove pgpool2 install and configuration based on force_pgpool2
   ansible.builtin.include_tasks: rm_pgpool2_install_config.yml
-  when:
-    - force_pgpool2 is defined
-    - force_pgpool2
+  when: >
+    ((force_pgpool2 is defined and force_pgpool2) or
+     (remove_only is defined and remove_only))
 
 - name: Include the pgpool2_install
   ansible.builtin.include_tasks: pgpool2_install.yml

--- a/roles/setup_replication/tasks/setup_replication.yml
+++ b/roles/setup_replication/tasks/setup_replication.yml
@@ -34,8 +34,10 @@
 
 - name: Force cleanup based on force_initdb/replication
   ansible.builtin.include_tasks: rm_replication.yml
-  when: (force_initdb is defined and force_initdb)
-      or (force_replication is defined and force_replication)
+  when: >
+    ((force_initdb is defined and force_initdb) or
+     (force_replication is defined and force_replication) or
+     (remove_only is defined and remove_only))
 
 - name: Gather the cluster_nodes information
   ansible.builtin.set_fact:

--- a/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
@@ -14,7 +14,7 @@
       {{ edb_auth_conf_url }} login {{ repo_username }} password {{ repo_password }}
     owner: root
     group: root
-    mode: 0600
+    mode: "0600"
   when:
     - os != 'Debian9'
     - enable_edb_repo|bool and repo_token|length < 1

--- a/roles/setup_repo/tasks/PG_RedHat_rm_repos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_rm_repos.yml
@@ -1,4 +1,29 @@
 ---
+- name: Remove EDB GPG key for EL8
+  ansible.builtin.rpm_key:
+    key: "{{ edb_gpg_key_8 }}"
+    state: absent
+  when:
+    - ansible_distribution_major_version == '8'
+  become: true
+
+- name: Remove PGDG GPG key for EL8
+  ansible.builtin.rpm_key:
+    key: "{{ pg_gpg_key_8 }}"
+    state: absent
+  when:
+    - ansible_distribution_major_version == '8'
+    - pg_type == 'PG'
+  become: true
+
+- name: Remove EPEL GPG key for EL8
+  ansible.builtin.rpm_key:
+    key: "{{ epel_gpg_key_8 }}"
+    state: absent
+  when:
+    - ansible_distribution_major_version == '8'
+  become: true
+
 - name: Remove repo file
   ansible.builtin.file:
     path: "{{ item_file }}"
@@ -18,8 +43,16 @@
       - pgdg-redhat-repo
       - epel-release
       - edb-repo
-    state: removed
+    state: absent
   become: true
+
+- name: Remove dnf-plugins-core for EL8
+  ansible.builtin.package:
+    name: dnf-plugins-core
+    state: absent
+  become: true
+  when:
+    - ansible_distribution_major_version == '8'
 
 - name: Remove additional Redhat repositories
   ansible.builtin.yum_repository:

--- a/roles/setup_repo/tasks/setup_repo.yml
+++ b/roles/setup_repo/tasks/setup_repo.yml
@@ -45,9 +45,9 @@
 
 - name: Cleanup the repos based on force_repo
   ansible.builtin.include_tasks: "PG_{{ ansible_os_family }}_rm_repos.yml"
-  when:
-    - force_repo is defined
-    - force_repo
+  when: >
+     ((force_repo is defined and force_repo) or
+      (remove_only is defined and remove_only))
 
 - name: Install Postgres repositories
   ansible.builtin.include_tasks: "PG_{{ ansible_os_family }}_setuprepos.yml"


### PR DESCRIPTION
Adds a `remove_only` flag to all removal tasks to make allow users to run the playbook to only remove a previous attempt at or successful installation and configuration. 
Updates `rm_setup_repo` tasks to be consistent with what is currently in the respective OS family's `PG_setup_repo` installation and configuration. 