### PR TITLE
Update manage_dbpatches - supported EFM versions WIP

### DIFF
--- a/roles/manage_dbpatches/defaults/main.yml
+++ b/roles/manage_dbpatches/defaults/main.yml
@@ -79,6 +79,7 @@ supported_pg_version:
   - 15
 
 supported_efm_version:
+  - "4.6"
   - "4.5"
   - "4.4"
   - "4.3"

--- a/roles/setup_efm/tasks/validate_setup_efm.yml
+++ b/roles/setup_efm/tasks/validate_setup_efm.yml
@@ -29,7 +29,7 @@
 - name: Run command to check efm cluster status
   ansible.builtin.shell: |
     set -o pipefail
-    /usr/edb/efm-4.5/bin/efm cluster-status {{ efm_cluster_name }} | grep UP
+    {{ efm_bin_path }}/efm cluster-status {{ efm_cluster_name }} | grep UP
   args:
     executable: /bin/bash
   become: true

--- a/tests/cases/manage_dbpatches/playbook.yml
+++ b/tests/cases/manage_dbpatches/playbook.yml
@@ -11,12 +11,12 @@
     - name: Initialize the user defined variables
       set_fact:
         disable_logging: false
-        efm_version: 4.5
+        efm_version: 4.6
         pg_package_list:
           - edb-as14-server*
-          - edb-efm45*
+          - edb-efm46*
         user_package_list:
-          - edb-efm45*
+          - edb-efm46*
 
   roles:
     - role: setup_repo

--- a/tests/tests/test_manage_dbpatches.py
+++ b/tests/tests/test_manage_dbpatches.py
@@ -13,13 +13,14 @@ from conftest import (
     os_family,
 )
 
+
 def test_manage_dbpatches_user():
     pg_user = 'postgres'
 
     if get_pg_type() == 'EPAS':
         pg_user = 'enterprisedb'
 
-    host= get_primary()
+    host = get_primary()
     socket_dir = get_pg_unix_socket_dir()
     
     with host.sudo(pg_user):
@@ -30,21 +31,23 @@ def test_manage_dbpatches_user():
     assert len(result) > 0, \
         "efm user was not succesfully created"
 
+
 def test_manage_dbpatches_service():
     pg_user = 'postgres'
 
     if get_pg_type() == 'EPAS':
         pg_user = 'enterprisedb'
 
-    host= get_primary()
+    host = get_primary()
     nodes = [node for node in get_pg_cluster_nodes()]
     
     with host.sudo(pg_user):
-        cmd = host.run('/usr/edb/efm-4.5/bin/efm cluster-status main | grep UP')
+        cmd = host.run('/usr/edb/efm-4.6/bin/efm cluster-status main | grep UP')
         result = cmd.stdout.strip().split('\n')
 
     assert len(result) == len(nodes), \
         "EFM service has not started on all the nodes"
+
 
 def test_manage_dbpatches_pg_read_all_settings():
     pg_user = 'postgres'
@@ -52,7 +55,7 @@ def test_manage_dbpatches_pg_read_all_settings():
     if get_pg_type() == 'EPAS':
         pg_user = 'enterprisedb'
 
-    host= get_primary()
+    host = get_primary()
     socket_dir = get_pg_unix_socket_dir()
     
     with host.sudo(pg_user):
@@ -64,6 +67,7 @@ def test_manage_dbpatches_pg_read_all_settings():
     assert 'pg_read_all_settings' in result[efm_index], \
         "EFM role is not a pg_read_all_settings"
 
+
 def test_manage_dbpatches_redhat():
     if os_family() != 'RedHat':
         pytest.skip()
@@ -72,12 +76,13 @@ def test_manage_dbpatches_redhat():
     packages = [
         'java-1.8.0-openjdk',
         'mailx',
-        'edb-efm45'
+        'edb-efm46'
     ]
 
     for package in packages:
         assert host.package(package).is_installed, \
             "Package %s not installed" % packages
+
 
 def test_manage_dbpatches_debian():
     if os_family() != 'Debian':


### PR DESCRIPTION
Adds EFM version 4.6 to `supported_efm_version` list. Also updates `validate_setup_efm.yml` to use the variable `efm_bin_path` instead of hardcoding the EFM version into the bin path as is done in the test script. 

At the task `Execute efm cluster status` in `efm_cluster_primary.yml`, the primary node is failing with the message "One or more standby databases are not in sync with the primary database." with both standby's having status "UP" but not having the correct WAL LSN. It seems that the primary is looking for `/5009080` and the standby's have `/5000000` (case with EPAS 14 and EFM 4.6).  