### PR TITLE
update hammerdb version variable setup

### DIFF
--- a/roles/setup_hammerdb/defaults/main.yml
+++ b/roles/setup_hammerdb/defaults/main.yml
@@ -38,11 +38,5 @@ supported_os:
 use_patroni: false
 
 supported_hammerdb_versions:
+  - "4.7"
   - "4.6"
-  - "4.5"
-  - "4.4"
-  - "4.3"
-  - "4.2"
-  - "4.1"
-  - "4.0"
-  - "3.3"

--- a/roles/setup_hammerdb/defaults/main.yml
+++ b/roles/setup_hammerdb/defaults/main.yml
@@ -4,7 +4,7 @@
 validate_only: false
 use_validation: true
 
-hammerdb_version: 4.6
+hammerdb_version: 4.7
 hammerdb_filename: "HammerDB-{{ hammerdb_version }}-\
                     {{ 'RHEL' if ansible_os_family == 'RedHat' else 'Linux' }}\
                     {{ ansible_distribution_major_version if \

--- a/roles/setup_hammerdb/defaults/main.yml
+++ b/roles/setup_hammerdb/defaults/main.yml
@@ -4,7 +4,7 @@
 validate_only: false
 use_validation: true
 
-hammerdb_version: 4.7
+hammerdb_version: 4.6
 hammerdb_filename: "HammerDB-{{ hammerdb_version }}-\
                     {{ 'RHEL' if ansible_os_family == 'RedHat' else 'Linux' }}\
                     {{ ansible_distribution_major_version if \
@@ -34,4 +34,15 @@ supported_os:
   - Debian10
   - OracleLinux8
   - Ubuntu20
+
 use_patroni: false
+
+supported_hammerdb_versions:
+  - "4.6"
+  - "4.5"
+  - "4.4"
+  - "4.3"
+  - "4.2"
+  - "4.1"
+  - "4.0"
+  - "3.3"

--- a/roles/setup_hammerdb/tasks/main.yml
+++ b/roles/setup_hammerdb/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check support for HammerDB version
+  ansible.builtin.fail:
+    msg: "HammerDB version = {{ hammerdb_version }} not supported."
+  when: hammerdb_version not in supported_hammerdb_versions
+
 - name: Remove hammerdb install/config based on force_hammerdb
   ansible.builtin.include_tasks: rm_hammerdb_install_config.yml
   when: >

--- a/tests/cases/setup_hammerdb/vars.json
+++ b/tests/cases/setup_hammerdb/vars.json
@@ -1,5 +1,4 @@
 {
   "use_hostname": false,
-  "hammerdb": "/home/hammerdb/HammerDB-4.7",
-  "hammerdb_version": "4.7"
+  "hammerdb_version": "4.6"
 }

--- a/tests/cases/setup_hammerdb/vars.json
+++ b/tests/cases/setup_hammerdb/vars.json
@@ -1,5 +1,5 @@
 {
   "use_hostname": false,
-  "hammerdb": "/home/hammerdb/HammerDB-4.6",
-  "hammerdb_version": "4.6"
+  "hammerdb": "/home/hammerdb/HammerDB-4.7",
+  "hammerdb_version": "4.7"
 }

--- a/tests/tests/test_setup_hammerdb.py
+++ b/tests/tests/test_setup_hammerdb.py
@@ -10,10 +10,11 @@ from conftest import (
 
 def test_setup_hammerdb_dir():
     ansible_vars = load_ansible_vars()
-    hammerdb = ansible_vars['hammerdb']
+    hammerdb_version = ansible_vars['hammerdb_version']
+    hammerdb_file = '/home/hammerdb/HammerDB-%s' % hammerdb_version
     host = get_hammerdb()[0]
     
-    assert host.file(hammerdb).exists, \
+    assert host.file(hammerdb_file).exists, \
         "HammerDB wasn't sucessfully installed"
 
 def test_setup_hammerdb_install_file():


### PR DESCRIPTION
Update HammerDB variables to support a list of versions and allow version to change without having to hardcode certain variables in the testing setup.