### PR TITLE
convert `hammerdb_version` to string during check

### DIFF
--- a/roles/setup_hammerdb/tasks/main.yml
+++ b/roles/setup_hammerdb/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Check support for HammerDB version
   ansible.builtin.fail:
     msg: "HammerDB version = {{ hammerdb_version }} not supported."
-  when: hammerdb_version not in supported_hammerdb_versions
+  when: hammerdb_version|string not in supported_hammerdb_versions
 
 - name: Remove hammerdb install/config based on force_hammerdb
   ansible.builtin.include_tasks: rm_hammerdb_install_config.yml


### PR DESCRIPTION
Fix: Convert `hammerdb_version` variable to string during task.

HammerDB install is failing with supported version 4.6 when passed as a float:
```
TASK [edb_devops.edb_postgres.setup_hammerdb : Check support for HammerDB version] ***
fatal: [hammerdb-driver]: FAILED! => {"changed": false, "msg": "HammerDB version = 4.6 not supported."}
```

https://github.com/EnterpriseDB/edb-benchmarks/blob/main/aws-hammerdb-tproc-c-bignimal/vars.yml#L2
```yaml
---
hammerdb_version: 4.6
```

Ref: https://github.com/EnterpriseDB/edb-ansible/pull/522/files#diff-f9a5ea296862f641fc832f5d37fdb04f69d2e6d4acf41a77e6a00b2cc048f796R2-R6