### PR TITLE
fix: convert `pg_version` to string in template

### DIFF
--- a/roles/install_dbserver/tasks/validate_install_dbserver.yml
+++ b/roles/install_dbserver/tasks/validate_install_dbserver.yml
@@ -4,7 +4,7 @@
     package_list: >-
       {{ package_list | default([]) + [
         'glibc-common', 'ca-certificates', 'postgresql' + pg_version | string,
-        'postgresql' + pg_version + '-server' | string, 'postgresql' + pg_version + '-contrib' | string,
+        'postgresql' + pg_version | string + '-server', 'postgresql' + pg_version | string + '-contrib',
         'sslutils_' + pg_version | string
       ] }}
   when:
@@ -36,11 +36,11 @@
   ansible.builtin.set_fact:
     package_list: >-
       {{ package_list | default([]) + [
-        'edb-as' + pg_version + '-server' | string, 'edb-as' + pg_version + '-server-core' | string,
-        'edb-as' + pg_version + '-server-contrib' | string, 'edb-as' + pg_version + '-server-libs' | string,
-        'edb-as' + pg_version + '-server-client' | string, 'edb-as' + pg_version + '-server-sslutils' | string,
-        'edb-as' + pg_version + '-server-indexadvisor' | string, 'edb-as' + pg_version + '-server-sqlprofiler' | string,
-        'edb-as' + pg_version + '-server-sqlprotect' | string
+        'edb-as' + pg_version | string + '-server', 'edb-as' + pg_version | string + '-server-core',
+        'edb-as' + pg_version | string + '-server-contrib', 'edb-as' + pg_version | string + '-server-libs',
+        'edb-as' + pg_version | string + '-server-client', 'edb-as' + pg_version | string + '-server-sslutils',
+        'edb-as' + pg_version | string + '-server-indexadvisor', 'edb-as' + pg_version | string + '-server-sqlprofiler',
+        'edb-as' + pg_version | string + '-server-sqlprotect'
       ] }}
   when:
     - ansible_os_family == 'RedHat'
@@ -71,7 +71,7 @@
 - name: Add pg_version > 10 packages to EPAS RedHat package_list
   ansible.builtin.set_fact:
     package_list: >-
-      {{ package_list | default([]) + ['edb-as' + pg_version + '-server-llvmjit' | string] }}
+      {{ package_list | default([]) + ['edb-as' + pg_version | string + '-server-llvmjit'] }}
   when:
     - pg_type == 'EPAS'
     - ansible_os_family == 'RedHat'
@@ -80,7 +80,7 @@
 - name: Add 10 < pg_version < 14 packages to EPAS RedHat package_list
   ansible.builtin.set_fact:
     package_list: >-
-      {{ package_list | default([]) + ['edb-as' + pg_version + '-server-edb-modules' | string] }}
+      {{ package_list | default([]) + ['edb-as' + pg_version | string + '-server-edb-modules'] }}
   when:
     - pg_type == 'EPAS'
     - ansible_os_family == 'RedHat'
@@ -90,7 +90,7 @@
 - name: Add pg_version >= 14 packages to EPAS RedHat package_list
   ansible.builtin.set_fact:
     package_list: >-
-      {{ package_list | default([]) + ['edb-as' + pg_version + '-server-edb_wait_states' | string] }}
+      {{ package_list | default([]) + ['edb-as' + pg_version | string + '-server-edb_wait_states'] }}
   when:
     - pg_type == 'EPAS'
     - ansible_os_family == 'RedHat'
@@ -108,7 +108,7 @@
     package_list: >-
       {{ package_list | default([]) + [
         'ca-certificates', 'python3-pycurl', 'python3-psycopg2', 'postgresql-' + pg_version | string,
-        'postgresql-server-dev-' + pg_version | string, 'postgresql-' + pg_version + '-sslutils' | string
+        'postgresql-server-dev-' + pg_version | string, 'postgresql-' + pg_version | string + '-sslutils'
       ] }}
   when:
     - ansible_os_family == 'Debian'
@@ -126,10 +126,10 @@
   ansible.builtin.set_fact:
     package_list: >-
       {{ package_list | default([]) + [
-        'python3-pip', 'python3-psycopg2', 'edb-as' + pg_version + '-server' | string,
-        'edb-as' + pg_version + '-server-core' | string, 'edb-as' + pg_version + '-server-client' | string,
-        'edb-as' + pg_version + '-server-sslutils' | string, 'edb-as' + pg_version + '-server-indexadvisor' | string,
-        'edb-as' + pg_version + '-server-sqlprofiler' | string, 'edb-as' + pg_version + '-server-sqlprotect' | string
+        'python3-pip', 'python3-psycopg2', 'edb-as' + pg_version | string + '-server',
+        'edb-as' + pg_version | string + '-server-core', 'edb-as' + pg_version | string + '-server-client',
+        'edb-as' + pg_version | string + '-server-sslutils', 'edb-as' + pg_version | string + '-server-indexadvisor',
+        'edb-as' + pg_version | string + '-server-sqlprofiler', 'edb-as' + pg_version | string + '-server-sqlprotect'
       ] }}
   when:
     - ansible_os_family == 'Debian'
@@ -146,7 +146,7 @@
 - name: Add pg_version < 14 packages to EPAS Debian package_list
   ansible.builtin.set_fact:
     package_list: >-
-      {{ package_list | default([]) + ['edb-as' + pg_version + '-server-edb-modules' | string] }}
+      {{ package_list | default([]) + ['edb-as' + pg_version | string + '-server-edb-modules'] }}
   when:
     - pg_type == 'EPAS'
     - ansible_os_family == 'Debian'
@@ -155,7 +155,7 @@
 - name: Add pg_version >= 14 packages to EPAS Debian package_list
   ansible.builtin.set_fact:
     package_list: >-
-      {{ package_list | default([]) + ['edb-as' + pg_version + '-server-edb-wait-states' | string] }}
+      {{ package_list | default([]) + ['edb-as' + pg_version | string + '-server-edb-wait-states'] }}
   when:
     - pg_type == 'EPAS'
     - ansible_os_family == 'Debian'


### PR DESCRIPTION
`install_dbserver` role error while testing https://github.com/EnterpriseDB/edb-benchmarks/pull/64:
```yaml
TASK [edb_devops.edb_postgres.install_dbserver : Set package list for EPAS RedHat] ***
fatal: [postgres1]: FAILED! => {"msg": "Unexpected templating type error occurred on ({{ package_list | default([]) + [\n  'edb-as' + pg_version + '-server' | string, 'edb-as' + pg_version + '-server-core' | string,\n  'edb-as' + pg_version + '-server-contrib' | string, 'edb-as' + pg_version + '-server-libs' | string,\n  'edb-as' + pg_version + '-server-client' | string, 'edb-as' + pg_version + '-server-sslutils' | string,\n  'edb-as' + pg_version + '-server-indexadvisor' | string, 'edb-as' + pg_version + '-server-sqlprofiler' | string,\n  'edb-as' + pg_version + '-server-sqlprotect' | string\n] }}): can only concatenate str (not \"int\") to str. can only concatenate str (not \"int\") to str"}
```