### PR TITLE
fix: `pg_wal` configuration check

### DIFF
--- a/roles/init_dbserver/tasks/validate_init_dbserver.yml
+++ b/roles/init_dbserver/tasks/validate_init_dbserver.yml
@@ -16,6 +16,7 @@
     path: "{{ pg_wal }}"
   register: wal_check
   become: true
+  when: pg_wal|length > 0 and pg_data not in pg_wal
 
 - name: Check that pg_data was configured correctly
   ansible.builtin.assert:
@@ -35,6 +36,7 @@
       - data_wal_check.stat['lnk_source'] == pg_wal
     fail_msg: "The directory {{ pg_wal }} is not configured correctly."
     success_msg: "The directory {{ pg_wal }} is configured correctly."
+  when: pg_wal|length > 0 and pg_data not in pg_wal
 
 # check if service pg_service is running
 - name: Gather service facts


### PR DESCRIPTION
pg_wal configuration check fails as `pg_wal` is empty and [we skip creating the directory](https://github.com/EnterpriseDB/edb-ansible/blob/master/roles/init_dbserver/tasks/create_directories.yml#L30-L38)

wal directory task skipped:
```yaml
TASK [edb_devops.edb_postgres.init_dbserver : Ensure postgres wal directory exists] ***
skipping: [postgres1]
```

Failing task:
```yaml
TASK [edb_devops.edb_postgres.init_dbserver : Check that pg_wal was configured correctly] ***
fatal: [postgres1]: FAILED! => {"msg": "The conditional check 'wal_check.stat['pw_name'] == pg_owner' failed. The error was: error while evaluating conditional (wal_check.stat['pw_name'] == pg_owner): 'dict object' has no attribute 'pw_name'"}
```

Ref: https://github.com/EnterpriseDB/edb-benchmarks/pull/64
