### PR TITLE
update manage_dbserver validation tasks with new lookup function

### DIFF
--- a/plugins/lookup/pg_conf_params_boolean.py
+++ b/plugins/lookup/pg_conf_params_boolean.py
@@ -1,0 +1,77 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: pg_conf_params_boolean
+    author: Hannah Stoik
+    short_description: Returns pg_postgres_conf_params value(s) as on/off if boolean
+    description:
+      - "Returns pg_postgres_conf_params value(s) as on/off if boolean"
+    options:
+      _terms:
+        description: pg_postgres_conf_params, a list of postgres parameters and values.
+        required: True
+      default:
+        description: pg_postgres_conf_params
+"""
+
+EXAMPLES = """
+- name: Show postgresql.conf values of parameters in pg_postgres_conf_params if they are boolean
+  debug: msg="{{ lookup('pg_conf_params_boolean', pg_postgres_conf_params) }}"
+"""
+
+RETURN = """
+_value:
+  description:
+    - List of postgres params 
+  type: list
+  elements:
+    - dict: name, value, original_value (if boolean)
+"""
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+def get_pg_on_off(value):
+    if value.lower() in ['on', 'true', 'yes']:
+        return 'on'
+    elif value.lower() in ['off', 'false', 'no']:
+        return 'off'
+
+
+def is_pg_bool(param_dict):
+    if str(param_dict["value"]).lower() in ['on', 'off', 'true', 'false', 'yes', 'no']:
+        return True
+    else:
+        return False
+
+
+def get_dict_vals(parameter):
+    if is_pg_bool(parameter):
+        new_parameter = dict(
+            name=str(parameter["name"]),
+            value=get_pg_on_off(str(parameter["value"])),
+            original_value=str(parameter["value"])
+        )
+        return new_parameter
+    else:
+        return parameter
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+        if len(terms) == 0:
+            return []
+        elif len(terms) > 1:
+            raise AnsibleError(
+                "Must input list of postgres configuration parameters."
+                "Check lookup function input values."
+            )
+
+        if isinstance(terms[0], list):
+            bool_conf_params = list(map(get_dict_vals, terms[0]))
+            return bool_conf_params
+        else:
+            raise AnsibleError(
+                "TypeError: Must input a list."
+            )

--- a/roles/manage_dbserver/README.md
+++ b/roles/manage_dbserver/README.md
@@ -21,11 +21,12 @@ day tasks:
 ### `pg_postgres_conf_params`
 
 Using this parameters user can set the database parameters.
+*Note*: To ensure the playbook runs successfully, input parameter names and values as strings.
 
 Example:
 ```yaml
 pg_postgres_conf_params:
-  - name: listen_addresses
+  - name: "listen_addresses"
     value: "*"
 ```
 

--- a/roles/manage_dbserver/tasks/validate_manage_dbserver.yml
+++ b/roles/manage_dbserver/tasks/validate_manage_dbserver.yml
@@ -157,6 +157,11 @@
   when:
     - pg_postgres_conf_params|length > 0
 
+- name: Determine parameter boolean values
+  ansible.builtin.set_fact:
+    _pg_postgres_conf_params: "{{ lookup('edb_devops.edb_postgres.pg_conf_params_boolean', pg_postgres_conf_params, wantlist=True) }}"
+  when: pg_postgres_conf_params|length > 0
+
 - name: Check if pg_postgres_conf_params were updated correctly
   ansible.builtin.assert:
     that:
@@ -164,7 +169,7 @@
     fail_msg: "Configuration parameter {{ parameter.name }} was not updated correctly."
     success_msg: "Configuration parameter {{ parameter.name }} was updated correctly."
   when: pg_postgres_conf_params|length > 0
-  loop: "{{ pg_postgres_conf_params }}"
+  loop: "{{ _pg_postgres_conf_params }}"
   loop_control:
     loop_var: parameter
     extended: true
@@ -331,6 +336,7 @@
     hba_query_result: null
     conf_query: null
     conf_query_res: null
+    _pg_postgres_conf_params: null
     slot_query: null
     pg_slots_names: null
     pg_slots_query_names: null


### PR DESCRIPTION
To ensure that boolean values are validated correctly within `pg_postgres_conf_params`, the lookup function `pg_conf_params_boolean` has been added to take boolean parameter values and return them as `on` for `true, on, yes` and `off` for `false, off, no`. The README has been updated to add comments about inputing parameter names and values as strings to make sure python parses the value correctly.  