### PR TITLE
Now when pg_ssl=false don't check the package.

### DIFF
--- a/roles/install_dbserver/tasks/validate_install_dbserver.yml
+++ b/roles/install_dbserver/tasks/validate_install_dbserver.yml
@@ -108,7 +108,7 @@
     package_list: >-
       {{ package_list | default([]) + [
         'ca-certificates', 'python3-pycurl', 'python3-psycopg2', 'postgresql-' + pg_version | string,
-        'postgresql-server-dev-' + pg_version | string, 'postgresql-' + pg_version | string + '-sslutils'
+        'postgresql-server-dev-' + pg_version | string, 'postgresql-' + pg_version | string + ('-sslutils' if pg_ssl else '')
       ] }}
   when:
     - ansible_os_family == 'Debian'


### PR DESCRIPTION
Hi,

Small contribution, when running the playbook with `pg_ssl` we don't install postgres-sslutils. But the check is still done.
I removed added a conditional, so now it works as expected. 