### PR TITLE
Fix repmgr packages

### DIFF
--- a/roles/setup_repmgr/vars/PG_Debian.yml
+++ b/roles/setup_repmgr/vars/PG_Debian.yml
@@ -1,5 +1,5 @@
 ---
-repmgr_package_name: "postgresql-14-repmgr"
+repmgr_package_name: "postgresql-{{ pg_version }}-repmgr"
 repmgrd_service: repmgrd
 repmgr_configuration_file: "/etc/repmgr.conf"
 

--- a/tests/docker/Dockerfile.debian10
+++ b/tests/docker/Dockerfile.debian10
@@ -14,7 +14,7 @@ RUN apt install acl -y
 RUN apt install apt-transport-https -y
 RUN apt-get update -y
 RUN apt-get install software-properties-common -y
-RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' -y
+RUN apt-add-repository 'deb http://archive.debian.org/debian-security stretch/updates main' -y
 RUN apt-get update -y
 RUN apt-get install openjdk-8-jdk -y
 RUN systemctl disable ssh


### PR DESCRIPTION
Update the `PG_Debian` variable `repmgr_package_name` to not have the `pg_version` hardcoded. While fixing, the `Dockerfile.debian10` needed updating with the stretch security-updates repo. This has been archived and instead of being available at security.debian.org, it is available at archive.debian.org. This repo is required for installing the `openjdk-8-jdk` package.