### PR TITLE
fix pgbackrest validation and configuration

### DIFF
--- a/roles/setup_pgbackrest/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_pgbackrest/tasks/exchange_ssh_keys.yml
@@ -74,7 +74,6 @@
   delegate_to: "{{ _pgbackrest_server_inventory_hostname }}"
   become: true
   changed_when: false
-  # delegate_facts: true
 
 - name: Add pg_owner SSH public key into pgbackrest_server known hosts
   ansible.builtin.known_hosts:

--- a/roles/setup_pgbackrest/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_pgbackrest/tasks/exchange_ssh_keys.yml
@@ -72,9 +72,9 @@
   ansible.builtin.command: ssh-keyscan {{ _pg_host }}
   register: _pgbackrest_ssh_keyscan_output
   delegate_to: "{{ _pgbackrest_server_inventory_hostname }}"
-  delegate_facts: true
   become: true
   changed_when: false
+  # delegate_facts: true
 
 - name: Add pg_owner SSH public key into pgbackrest_server known hosts
   ansible.builtin.known_hosts:

--- a/roles/setup_pgbackrest/tasks/validate_setup_pgbackrest.yml
+++ b/roles/setup_pgbackrest/tasks/validate_setup_pgbackrest.yml
@@ -14,10 +14,14 @@
   register: pgbackrest_config_check_res
   changed_when: pgbackrest_config_check_res.rc == '0'
 
+- name: Debug
+  ansible.builtin.debug:
+    var: "{{ pgbackrest_config_check_res.stdout_lines }}"
+
 - name: Check if pgbackrest server has been configured correctly.
   ansible.builtin.assert:
     that:
-      - pgbackrest_config_check_res.stdout_lines is search('Completed successfully')
+      - pgbackrest_config_check_res.stdout_lines is search('completed successfully')
     fail_msg: "Configuration for pgBackRest server node is not properly done."
     success_msg: "Configuration for pgBackRest server node is properly done."
   run_once: true
@@ -28,6 +32,7 @@
     cmd: pgbackrest --stanza={{ pg_instance_name }} info
   become: true
   become_user: "{{ pgbackrest_user }}"
+  delegate_to: "{{ pgbackrest_server_node_info[0].inventory_hostname }}"
   run_once: true
   register: pgbackrest_config_info_res
   changed_when: pgbackrest_config_info_res.rc == '0'
@@ -46,6 +51,7 @@
     cmd: pgbackrest repo-ls
   become: true
   become_user: "{{ pgbackrest_user }}"
+  delegate_to: "{{ pgbackrest_server_node_info[0].inventory_hostname }}"
   run_once: true
   register: pgbackrest_config_repo_res
   changed_when: pgbackrest_config_repo_res.rc == '0'

--- a/roles/setup_pgbackrest/tasks/validate_setup_pgbackrest.yml
+++ b/roles/setup_pgbackrest/tasks/validate_setup_pgbackrest.yml
@@ -14,10 +14,6 @@
   register: pgbackrest_config_check_res
   changed_when: pgbackrest_config_check_res.rc == '0'
 
-- name: Debug
-  ansible.builtin.debug:
-    var: "{{ pgbackrest_config_check_res.stdout_lines }}"
-
 - name: Check if pgbackrest server has been configured correctly.
   ansible.builtin.assert:
     that:

--- a/roles/setup_pgbackrestserver/tasks/define_node_variables.yml
+++ b/roles/setup_pgbackrestserver/tasks/define_node_variables.yml
@@ -3,35 +3,35 @@
   ansible.builtin.set_fact:
     pgbackrest_node_info: "{{ lookup('edb_devops.edb_postgres.pgbackrest_nodes', wantlist=True) }}"
 
-- name: Determine if standby
+- name: Gather standby_node_info if any
   ansible.builtin.set_fact:
     standby_node_info: "{{ pgbackrest_node_info | selectattr('node_type', 'equalto', 'standby') | default([]) }}"
 
-- name: Determine if backup_standby
+- name: Determine if standby_present using standby_node_info
   ansible.builtin.set_fact:
     standby_present: 'y'
   when: standby_node_info|length > 0
 
-- name: Get primary node informations
+- name: Get primary node informations if use_hostname
   ansible.builtin.set_fact:
     primary_node_hostname: "{{ pgbackrest_node_info | selectattr('node_type', 'equalto', 'primary') | map(attribute='inventory_hostname') }}"
   when:
     - use_hostname|bool
 
-- name: Get primary node informations
+- name: Get primary node informations if not use_hostname
   ansible.builtin.set_fact:
     primary_node_hostname: "{{ pgbackrest_node_info | selectattr('node_type', 'equalto', 'primary') | map(attribute='ansible_host') }}"
   when:
     - "not use_hostname|bool"
 
-- name: Get standby node informations
+- name: Get standby node informations if any, if use_hostname
   ansible.builtin.set_fact:
     standby_node_hostname: "{{ pgbackrest_node_info | selectattr('node_type', 'equalto', 'standby') | map(attribute='inventory_hostname') }}"
   when:
     - use_hostname|bool
     - standby_present is defined
 
-- name: Get standby node informations
+- name: Get standby node informations if any, if not use_hostname
   ansible.builtin.set_fact:
     standby_node_hostname: "{{ pgbackrest_node_info | selectattr('node_type', 'equalto', 'standby') | map(attribute='ansible_host') }}"
   when:
@@ -48,7 +48,7 @@
     primary_host_user: "enterprisedb"
   when: pg_type == 'EPAS'
 
-- name: Define EPAS DB information
+- name: Define EPAS DB information if RedHat
   ansible.builtin.set_fact:
     pg_unix_socket_epas: "/var/run/edb/as{{ pg_version }}"
     pg_port_epas: "5444"
@@ -57,7 +57,7 @@
     - pg_type == 'EPAS'
     - ansible_os_family == 'RedHat'
 
-- name: Define EPAS DB information
+- name: Define EPAS DB information if Debian
   ansible.builtin.set_fact:
     pg_unix_socket_epas: "/var/run/edb-as"
     pg_port_epas: "5444"

--- a/roles/setup_pgbackrestserver/tasks/generate_config.yml
+++ b/roles/setup_pgbackrestserver/tasks/generate_config.yml
@@ -124,7 +124,7 @@
     mode: "0600"
   become: true
 
-- name: Build pgbackrest_conf_lines
+- name: Build pgbackrest_conf_lines when standby_present is defined
   ansible.builtin.set_fact:
     pgbackrest_conf_lines: >
       {{ pgbackrest_conf_lines | default([]) + [
@@ -134,6 +134,8 @@
         }
       ] }}
   loop: "{{ pgbackrest_standby_configuration }}"
+  when:
+    - standby_present is defined
 
 - name: Add standby information to configuration file
   edb_devops.edb_postgres.linesinfile:


### PR DESCRIPTION
Fixes error incurred in issue #537 where the variable `pgbackrest_standby_configuration` is undefined when called to loop in building the `pgbackrest_conf_lines` variable. The condition of `standby_present` was added to not build these lines when no standby is present, as the lines are only added to the configuration file if a standby is present. 

In addition this fix, the `validate_setup_pgbackrest` tasks were not working as expected. The SSH setup previously configured did not connect the pgbackrestserver to the standby in the test case. This was because of a `delegate_tasks` that had been thrown into the `exchange_ssh_keys` tasks. This line was removed. 

More commenting was added to the `define_node_variables` tasks to make each task have a unique name. 