### PR TITLE
add manage_touchstone_tools

### DIFF
--- a/roles/manage_touchstone_tools/README.md
+++ b/roles/manage_touchstone_tools/README.md
@@ -104,25 +104,13 @@ Database server host or docker directory. Same as `-h` in `psql` commands.
 
 Database server port. Same as `-p` in `psql` commands.
 
-#### `pg_owner`
-
-The database connection username. Same as `-U` in `psql` commands.
  
 #### How to include `start_db_stats` in your playbook
 
 Below is an example of how to put `start_db_stats` in your playbook.
 
 ```yaml
-# if libpq environment vars are set on the machine, only ts_output_dir is required
-- name: Include start_db_stats tasks to start pgsql stats data collection
-  ansible.builtin.include_role:
-    name: manage_touchstone_tools
-    tasks_from: start_db_stats
-  vars:
-    ts_output_dir: "/var/log/touchstone/db_run_1"
-    sec_bw_sample: 60
-
-# if libpq environment vars are not set or you wish to explicitly define them
+# if vars pg_database, pg_port are already set by ansible, they are not required to be passed in
 - name: Include start_db_stats tasks to start pgsql stats data collection
   ansible.builtin.include_role:
     name: manage_touchstone_tools
@@ -133,7 +121,6 @@ Below is an example of how to put `start_db_stats` in your playbook.
     pg_database: "postgres"
     pg_server_hostname: "primary1"
     pg_port: 5432
-    pg_owner: "postgres"
 ```
 
 ### `stop_db_stats`

--- a/roles/manage_touchstone_tools/README.md
+++ b/roles/manage_touchstone_tools/README.md
@@ -92,19 +92,19 @@ The output directory for the touchstone-tools database data collection.
 
 The number of seconds between samples, default 60.
 
-#### `db_name`
+#### `pg_database`
 
 The database name to connect to.
 
-#### `db_server_name`
+#### `pg_server_name`
 
 Database server host or docker directory. Same as `-h` in `psql` commands.
 
-#### `db_port`
+#### `pg_port`
 
 Database server port. Same as `-p` in `psql` commands.
 
-#### `db_user`
+#### `pg_owner`
 
 The database connection username. Same as `-U` in `psql` commands.
  
@@ -113,6 +113,16 @@ The database connection username. Same as `-U` in `psql` commands.
 Below is an example of how to put `start_db_stats` in your playbook.
 
 ```yaml
+# if libpq environment vars are set on the machine, only ts_output_dir is required
+- name: Include start_db_stats tasks to start pgsql stats data collection
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: start_db_stats
+  vars:
+    ts_output_dir: "/var/log/touchstone/db_run_1"
+    sec_bw_sample: 60
+
+# if libpq environment vars are not set or you wish to explicitly define them
 - name: Include start_db_stats tasks to start pgsql stats data collection
   ansible.builtin.include_role:
     name: manage_touchstone_tools
@@ -120,10 +130,10 @@ Below is an example of how to put `start_db_stats` in your playbook.
   vars:
     ts_output_dir: "/var/log/touchstone/db_stats"
     sec_bw_sample: 15
-    db_name: "postgres"
-    db_server_hostname: "primary1"
-    db_server_port: 5432
-    db_user: "postgres"
+    pg_database: "postgres"
+    pg_server_hostname: "primary1"
+    pg_port: 5432
+    pg_owner: "postgres"
 ```
 
 ### `stop_db_stats`
@@ -133,22 +143,6 @@ This task stops the collection of database statistics.
 #### `ts_output_dir`
 
 The output directory for the touchstone-tools database data collection.
-
-#### `db_name`
-
-The database name to connect to.
-
-#### `db_server_name`
-
-Database server host or docker directory. Same as `-h` in `psql` commands.
-
-#### `db_port`
-
-Database server port. Same as `-p` in `psql` commands.
-
-#### `db_user`
-
-The database connection username. Same as `-U` in `psql` commands.
  
 #### How to include `stop_db_stats` in your playbook
 
@@ -161,11 +155,6 @@ Below is an example of how to put `stop_db_stats` in your playbook.
     tasks_from: stop_db_stats
   vars:
     ts_output_dir: "/var/log/touchstone/db_stats"
-    sec_bw_sample: 15
-    db_name: "postgres"
-    db_server_hostname: "primary1"
-    db_server_port: 5432
-    db_user: "postgres"
 ```
 
 ### `process_pidstat_data`
@@ -260,7 +249,7 @@ Below is an example of how to put `plot_pidstat_data` in your playbook.
 
 This task plots the generated database stats.
 
-#### `db_name`
+#### `pg_databse`
 
 The database name to plot the stats from.
 
@@ -288,7 +277,7 @@ Below is an example of how to put `plot_db_data` in your playbook.
     name: manage_touchstone_tools
     tasks_from: plot_db_data
   vars:
-    db_name: "postgres"
+    pg_database: "postgres"
     ts_output_dir: "/var/log/touchstone/db_stats"
     ts_plot_output_dir: "/var/log/touchstone/db_stats/pgsql_plots"
     plot_size: "800,500"

--- a/roles/manage_touchstone_tools/README.md
+++ b/roles/manage_touchstone_tools/README.md
@@ -1,0 +1,307 @@
+# manage_touchstone_tools
+
+`manage_touchstone_tools` role is for managing the use of the touchstone system performance 
+tools. For more information on the touchstone-tools, visit the project homepage:
+https://gitlab.com/touchstone/touchstone-tools.
+
+There are eight tasks that this role can perform:
+  1. [Start collecting system stats](#startsystemstats)
+  2. [Stop collecting system stats](#stopsystemstats)
+  3. [Start collecting database stats](#startdbstats)
+  4. [Stop collecting database stats](#stopdbstats)
+  5. [Process pidstat data](#processpidstatdata)
+  6. [Plot sar data](#plotsardata)
+  7. [Plot pidstat data](#plotpidstatdata)
+  8. [Plot database data](#plotdbdata)
+
+## Requirements
+
+Following are the requirements of this role.
+  1. Ansible
+  2. `edb_devops.edb_postgres` -> `setup_repo` role for setting the repository on
+     the systems.
+  3. `edb_devops.edb_postgres` -> `setup_touchstone_tools` role for installing the touchstone appimage.
+
+## Role Variables
+
+The variables that can be configured and are available in the:
+
+  * [roles/manage_touchstone_tools/defaults/main.yml](./defaults/main.yml)
+
+Each task within this role has a different set of required variables. 
+Below is the documentation for each of those tasks and their variables'.
+
+### `start_system_stats`
+
+This task starts the collection of system statistics.
+
+#### `ts_output_dir`
+
+The output directory for the touchstone-tools data collection. This must be a 
+directory that does not already exist.
+
+#### `sec_bw_sample`
+
+The number of seconds between samples, default 60.
+ 
+#### How to include `start_system_stats` in your playbook
+
+Below is an example of how to put `start_system_stats` in your playbook.
+
+```yaml
+- name: Include start_system_stats tasks to start sysstat data collection
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: start_system_stats
+  vars:
+    ts_output_dir: "/var/log/touchstone/system_stats"
+    sec_bw_sample: 30
+```
+
+### `stop_system_stats`
+
+This task stops the collection of system statistics.
+
+#### `ts_output_dir`
+
+The output directory for the touchstone-tools data collection. This must be a 
+directory that does not already exist.
+ 
+#### How to include `stop_system_stats` in your playbook
+
+Below is an example of how to put `stop_system_stats` in your playbook.
+
+```yaml
+- name: Include stop_system_stats tasks to stop sysstat data collection
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: stop_system_stats
+  vars:
+    ts_output_dir: "/var/log/touchstone/system_stats"
+```
+
+### `start_db_stats`
+
+This task starts the collection of database statistics.
+
+#### `ts_output_dir`
+
+The output directory for the touchstone-tools database data collection.
+
+#### `sec_bw_sample`
+
+The number of seconds between samples, default 60.
+
+#### `db_name`
+
+The database name to connect to.
+
+#### `db_server_name`
+
+Database server host or docker directory. Same as `-h` in `psql` commands.
+
+#### `db_port`
+
+Database server port. Same as `-p` in `psql` commands.
+
+#### `db_user`
+
+The database connection username. Same as `-U` in `psql` commands.
+ 
+#### How to include `start_db_stats` in your playbook
+
+Below is an example of how to put `start_db_stats` in your playbook.
+
+```yaml
+- name: Include start_db_stats tasks to start pgsql stats data collection
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: start_db_stats
+  vars:
+    ts_output_dir: "/var/log/touchstone/db_stats"
+    sec_bw_sample: 15
+    db_name: "postgres"
+    db_server_hostname: "primary1"
+    db_server_port: 5432
+    db_user: "postgres"
+```
+
+### `stop_db_stats`
+
+This task stops the collection of database statistics.
+
+#### `ts_output_dir`
+
+The output directory for the touchstone-tools database data collection.
+
+#### `db_name`
+
+The database name to connect to.
+
+#### `db_server_name`
+
+Database server host or docker directory. Same as `-h` in `psql` commands.
+
+#### `db_port`
+
+Database server port. Same as `-p` in `psql` commands.
+
+#### `db_user`
+
+The database connection username. Same as `-U` in `psql` commands.
+ 
+#### How to include `stop_db_stats` in your playbook
+
+Below is an example of how to put `stop_db_stats` in your playbook.
+
+```yaml
+- name: Include stop_db_stats tasks to stop pgsql stats data collection
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: stop_db_stats
+  vars:
+    ts_output_dir: "/var/log/touchstone/db_stats"
+    sec_bw_sample: 15
+    db_name: "postgres"
+    db_server_hostname: "primary1"
+    db_server_port: 5432
+    db_user: "postgres"
+```
+
+### `process_pidstat_data`
+
+This task processes the `pidstat.txt` file generated during system stat collection.
+This task generates the `pidstat.csv` file and places in the same directory as the `pidstat.txt`.
+
+#### `pidstat_txt_file`
+
+The file location of the `pidstat.txt`. This file is generated during sysstat collection.
+Usually placed within the `ts_output_file` directory used during `stop_system_stats`.
+If not specified, it will use the `ts_output_file` directory to generate, but this may not be an accurate location. 
+ 
+#### How to include `process_pidstat_data` in your playbook
+
+Below is an example of how to put `process_pidstat_data` in your playbook.
+
+```yaml
+- name: Include process_pidstat_data tasks to start sysstat data collection
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: process_pidstat_data
+  vars:
+    pidstat_txt_file: "/var/log/touchstone/system_stats/pidstat.txt"
+```
+
+### `plot_sar_data`
+
+This task plots the generated sar data.
+
+#### `ts_output_dir`
+
+The directory of the ts-sysstat processed sar data. This location is the 
+output directory (`ts_output_dir`) from the `stop_system_stats` tasks. 
+
+#### `ts_plot_output_dir`
+
+The directory for the generated plots to be placed. Plotting the sar data will generate 
+new directories within this directory. Defaults to `ts_output_dir` if not value specified.
+
+#### `plot_size`
+
+The dimensions of the generated plots. Default `1600,1000`.
+
+#### How to include `plot_sar_data` in your playbook
+
+Below is an example of how to put `plot_sar_data` in your playbook.
+
+```yaml
+- name: Include plot_sar_data tasks to plot sar data
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: plot_sar_data
+  vars:
+    ts_output_dir: "/var/log/touchstone/system_stats"
+    ts_plot_output_dir: "/var/log/touchstone/system_stats"
+    plot_size: "800,500"
+```
+
+### `plot_pidstat_data`
+
+This task plots the generated and processed pidstat data in `pidstat.csv`.
+
+#### `pidstat_csv_file`
+
+The location of the processed `pidstat.csv` file.
+
+#### `ts_plot_output_dir`
+
+The directory for the generated plots to be placed. 
+
+#### `plot_size`
+
+The dimensions of the generated plots. Default `1600,1000`.
+
+#### How to include `plot_pidstat_data` in your playbook
+
+Below is an example of how to put `plot_pidstat_data` in your playbook.
+
+```yaml
+- name: Include plot_pidstat_data tasks to plot pidstat data
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: plot_pidstat_data
+  vars:
+    pidstat_csv_file: "/var/log/touchstone/system_stats/pidstat.csv"
+    ts_plot_output_dir: "/var/log/touchstone/system_stats/pidstat_plots"
+    plot_size: "1600,1000"
+```
+
+### `plot_db_data`
+
+This task plots the generated database stats.
+
+#### `db_name`
+
+The database name to plot the stats from.
+
+#### `ts_output_dir`
+
+The directory of the ts-pgsql-stat collected data. This location is the 
+output directory (`ts_output_dir`) from the `stop_db_stats` tasks. 
+
+#### `ts_plot_output_dir`
+
+The directory for the generated plots to be placed. 
+Defaults to `ts_output_dir` if not value specified.
+
+#### `plot_size`
+
+The dimensions of the generated plots. Default `1600,1000`.
+
+#### How to include `plot_db_data` in your playbook
+
+Below is an example of how to put `plot_db_data` in your playbook.
+
+```yaml
+- name: Include plot_db_data tasks to plot pgsql data
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: plot_db_data
+  vars:
+    db_name: "postgres"
+    ts_output_dir: "/var/log/touchstone/db_stats"
+    ts_plot_output_dir: "/var/log/touchstone/db_stats/pgsql_plots"
+    plot_size: "800,500"
+```
+
+## License
+
+BSD
+
+## Author information
+
+Author:
+  * Hannah Stoik
+  * Mark Wong
+  * EDB Postgres
+  * edb-devops@enterprisedb.com www.enterprisedb.com

--- a/roles/manage_touchstone_tools/README.md
+++ b/roles/manage_touchstone_tools/README.md
@@ -96,7 +96,7 @@ The number of seconds between samples, default 60.
 
 The database name to connect to.
 
-#### `pg_server_name`
+#### `pg_server_hostname`
 
 Database server host or docker directory. Same as `-h` in `psql` commands.
 

--- a/roles/manage_touchstone_tools/README.md
+++ b/roles/manage_touchstone_tools/README.md
@@ -102,15 +102,18 @@ Database server host or docker directory. Same as `-h` in `psql` commands.
 
 #### `pg_port`
 
-Database server port. Same as `-p` in `psql` commands.
+The database server port. Same as `-p` in `psql` commands.
 
+#### `pg_owner`
+
+Database connections username. Same as `-U` in `psql` commands.
  
 #### How to include `start_db_stats` in your playbook
 
 Below is an example of how to put `start_db_stats` in your playbook.
 
 ```yaml
-# if vars pg_database, pg_port are already set by ansible, they are not required to be passed in
+# if vars pg_database, pg_port, pg_owner are already set by ansible, they are not required to be passed in
 - name: Include start_db_stats tasks to start pgsql stats data collection
   ansible.builtin.include_role:
     name: manage_touchstone_tools
@@ -121,6 +124,7 @@ Below is an example of how to put `start_db_stats` in your playbook.
     pg_database: "postgres"
     pg_server_hostname: "primary1"
     pg_port: 5432
+    pg_owner: "postgres"
 ```
 
 ### `stop_db_stats`

--- a/roles/manage_touchstone_tools/defaults/main.yml
+++ b/roles/manage_touchstone_tools/defaults/main.yml
@@ -3,10 +3,10 @@ touchstone_tools_version: 0.6.1
 touchstone_tools_appimage: https://touchstone.gitlab.io/download/ts-tools-{{ touchstone_tools_version }}-x86_64.AppImage
 
 # database informations for ts-pgsql commands
-db_name: ""   # database name to connect to
-db_server_hostname: ""    # database server host or docker directory (-h)
-db_server_port: ""    # database server PORT (-p)
-db_user: ""   # database USERNAME (-U)
+pg_database: ""   # database name to connect to
+pg_server_hostname: ""    # database server host or docker directory (-h)
+pg_port: ""    # database server PORT (-p)
+pg_owner: ""   # database USERNAME (-U)
 
 # size of plots output from ts-plot-sar, ts-plot-pidstat and ts-plot-pgsql
 plot_size: '1600,1000'

--- a/roles/manage_touchstone_tools/defaults/main.yml
+++ b/roles/manage_touchstone_tools/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-touchstone_tools_version: 0.6.1
+touchstone_tools_version: 0.6.2
 touchstone_tools_appimage: https://touchstone.gitlab.io/download/ts-tools-{{ touchstone_tools_version }}-x86_64.AppImage
 
 # database informations for ts-pgsql commands

--- a/roles/manage_touchstone_tools/defaults/main.yml
+++ b/roles/manage_touchstone_tools/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-touchstone_tools_version: 0.6.2
+touchstone_tools_version: 0.7.0
 touchstone_tools_appimage: https://touchstone.gitlab.io/download/ts-tools-{{ touchstone_tools_version }}-x86_64.AppImage
 
 # database informations for ts-pgsql commands

--- a/roles/manage_touchstone_tools/defaults/main.yml
+++ b/roles/manage_touchstone_tools/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+touchstone_tools_version: 0.6.1
+touchstone_tools_appimage: https://touchstone.gitlab.io/download/ts-tools-{{ touchstone_tools_version }}-x86_64.AppImage
+
+# database informations for ts-pgsql commands
+db_name: ""   # database name to connect to
+db_server_hostname: ""    # database server host or docker directory (-h)
+db_server_port: ""    # database server PORT (-p)
+db_user: ""   # database USERNAME (-U)
+
+# size of plots output from ts-plot-sar, ts-plot-pidstat and ts-plot-pgsql
+plot_size: '1600,1000'
+
+# default number of seconds in between samples
+sec_bw_sample: 60
+
+supported_os:
+  - CentOS8
+  - RHEL8
+  - Rocky8
+  - AlmaLinux8

--- a/roles/manage_touchstone_tools/meta/main.yml
+++ b/roles/manage_touchstone_tools/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  author: EDB
+  description: Manage Touchstone Tools
+  company: "EnterpriseDB"
+
+  license: BSD
+
+  min_ansible_version: "2.8"
+
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+
+  galaxy_tags:
+    - database
+
+dependencies: []

--- a/roles/manage_touchstone_tools/tasks/main.yml
+++ b/roles/manage_touchstone_tools/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+# Entry point of the manage_touchstone_tools role
+- name: Include the manage_touchstone_tools.yml
+  ansible.builtin.include_tasks: manage_touchstone_tools.yml

--- a/roles/manage_touchstone_tools/tasks/manage_touchstone_tools.yml
+++ b/roles/manage_touchstone_tools/tasks/manage_touchstone_tools.yml
@@ -14,10 +14,10 @@
   vars:
     ts_output_dir: "/var/log/touchstone/db_run_1"
     sec_bw_sample: 60
-    db_name: "postgres"
-    db_server_hostname: "primary1"
-    db_server_port: 5432
-    db_user: "postgres"
+    pg_database: "postgres"
+    pg_server_hostname: "primary1"
+    pg_port: 5432
+    pg_owner: "postgres"
 
 - name: Include stop_system_stats tasks to stop sysstat data collection
   ansible.builtin.include_role:
@@ -32,10 +32,6 @@
     tasks_from: stop_db_stats
   vars:
     ts_output_dir: "/var/log/touchstone/db_run_1"
-    db_name: "postgres"
-    db_server_hostname: "primary1"
-    db_server_port: 5432
-    db_user: "postgres"
 
 - name: Include process_pidstat tasks
   ansible.builtin.include_role:
@@ -66,6 +62,6 @@
     name: manage_touchstone_tools
     tasks_from: plot_db_data
   vars:
-    db_name: "postgres"
+    pg_database: "postgres"
     ts_output_dir: "/var/log/touchstone/db_run_1"
     ts_plot_output_dir: "/var/log/touchstone/db_run_1/pgsql_plots"

--- a/roles/manage_touchstone_tools/tasks/manage_touchstone_tools.yml
+++ b/roles/manage_touchstone_tools/tasks/manage_touchstone_tools.yml
@@ -1,0 +1,71 @@
+---
+- name: Include start_system_stats tasks to start sysstat data collection
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: start_system_stats
+  vars:
+    ts_output_dir: "/var/log/touchstone/sys_run_1"
+    sec_bw_sample: 60
+
+- name: Include start_db_stats tasks to start pgsql stats data collection
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: start_db_stats
+  vars:
+    ts_output_dir: "/var/log/touchstone/db_run_1"
+    sec_bw_sample: 60
+    db_name: "postgres"
+    db_server_hostname: "primary1"
+    db_server_port: 5432
+    db_user: "postgres"
+
+- name: Include stop_system_stats tasks to stop sysstat data collection
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: stop_system_stats
+  vars:
+    ts_output_dir: "/var/log/touchstone/sys_run_1"
+
+- name: Include stop_db_stats tasks to stop pgsql stats data collection
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: stop_db_stats
+  vars:
+    ts_output_dir: "/var/log/touchstone/db_run_1"
+    db_name: "postgres"
+    db_server_hostname: "primary1"
+    db_server_port: 5432
+    db_user: "postgres"
+
+- name: Include process_pidstat tasks
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: process_pidstat
+  vars:
+    pidstat_txt_file: "/var/log/touchstone/sys_run_1/pidstat.txt"
+
+- name: Include plot_sar_data tasks to plot sar data
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: plot_sar_data
+  vars:
+    ts_output_dir: "/var/log/touchstone/sys_run_1"
+    ts_plot_output_dir: "/var/log/touchstone/sys_run_1"
+
+- name: Include plot_pidstat_data tasks to plot pidstat data
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: plot_pidstat_data
+  vars:
+    pidstat_csv_file: "/var/log/touchstone/sys_run_1/pidstat.csv"
+    ts_output_dir: "/var/log/touchstone/sys_run_1"
+    ts_plot_output_dir: "/var/log/touchstone/sys_run_1/pidstat_plots"
+
+- name: Include plot_db_data tasks to plot pgsql data
+  ansible.builtin.include_role:
+    name: manage_touchstone_tools
+    tasks_from: plot_db_data
+  vars:
+    db_name: "postgres"
+    ts_output_dir: "/var/log/touchstone/db_run_1"
+    ts_plot_output_dir: "/var/log/touchstone/db_run_1/pgsql_plots"

--- a/roles/manage_touchstone_tools/tasks/manage_touchstone_tools.yml
+++ b/roles/manage_touchstone_tools/tasks/manage_touchstone_tools.yml
@@ -17,7 +17,6 @@
     pg_database: "postgres"
     pg_server_hostname: "primary1"
     pg_port: 5432
-    pg_owner: "postgres"
 
 - name: Include stop_system_stats tasks to stop sysstat data collection
   ansible.builtin.include_role:

--- a/roles/manage_touchstone_tools/tasks/manage_touchstone_tools.yml
+++ b/roles/manage_touchstone_tools/tasks/manage_touchstone_tools.yml
@@ -17,6 +17,7 @@
     pg_database: "postgres"
     pg_server_hostname: "primary1"
     pg_port: 5432
+    pg_owner: "postgres"
 
 - name: Include stop_system_stats tasks to stop sysstat data collection
   ansible.builtin.include_role:

--- a/roles/manage_touchstone_tools/tasks/plot_db_data.yml
+++ b/roles/manage_touchstone_tools/tasks/plot_db_data.yml
@@ -8,7 +8,7 @@
   ansible.builtin.shell: |
     set -o pipefail
     ts plot-pgsql \
-      -d {{ db_name }} \
+      -d {{ pg_database }} \
       -i {{ ts_output_dir }} \
       -o {{ ts_plot_output_dir }} \
       -s {{ plot_size }}

--- a/roles/manage_touchstone_tools/tasks/plot_db_data.yml
+++ b/roles/manage_touchstone_tools/tasks/plot_db_data.yml
@@ -1,0 +1,21 @@
+---
+- name: Set ts_plot_output_dir if not defined
+  ansible.builtin.set_fact:
+    ts_plot_output_dir: "{{ ts_output_dir }}"
+  when: ts_plot_output_dir is not defined
+
+- name: Run ts plot-pidstat
+  ansible.builtin.shell: |
+    set -o pipefail
+    ts plot-pgsql \
+      -d {{ db_name }} \
+      -i {{ ts_output_dir }} \
+      -o {{ ts_plot_output_dir }} \
+      -s {{ plot_size }}
+  args:
+    chdir: /usr/bin/
+  become: true
+
+- name: Reset ts_plot_output_dir
+  ansible.builtin.set_fact:
+    ts_plot_output_dir: Null

--- a/roles/manage_touchstone_tools/tasks/plot_pidstat_data.yml
+++ b/roles/manage_touchstone_tools/tasks/plot_pidstat_data.yml
@@ -1,0 +1,25 @@
+---
+- name: Set pidstat_csv_file if not defined
+  ansible.builtin.set_fact:
+    pidstat_csv_file: "{{ ts_output_dir }}/pidstat.csv"
+  when: pidstat_csv_file is not defined
+
+- name: Set ts_plot_output_dir if not defined
+  ansible.builtin.set_fact:
+    ts_plot_output_dir: "{{ ts_output_dir }}"
+  when: ts_plot_output_dir is not defined
+
+- name: Run ts plot-pidstat
+  ansible.builtin.shell: |
+    set -o pipefail
+    ts plot-pidstat \
+      -i {{ pidstat_csv_file }} \
+      -o {{ ts_plot_output_dir }} \
+      -s {{ plot_size }}
+  args:
+    chdir: /usr/bin/
+  become: true
+
+- name: Reset ts_plot_output_dir
+  ansible.builtin.set_fact:
+    ts_plot_output_dir: Null

--- a/roles/manage_touchstone_tools/tasks/plot_sar_data.yml
+++ b/roles/manage_touchstone_tools/tasks/plot_sar_data.yml
@@ -1,0 +1,20 @@
+---
+- name: Set ts_plot_output_dir if not defined
+  ansible.builtin.set_fact:
+    ts_plot_output_dir: "{{ ts_output_dir }}"
+  when: ts_plot_output_dir is not defined
+
+- name: Run ts plot-sar
+  ansible.builtin.shell: |
+    set -o pipefail
+    ts plot-sar \
+      -i {{ ts_output_dir }} \
+      -o {{ ts_plot_output_dir }} \
+      -s {{ plot_size }}
+  args:
+    chdir: /usr/bin/
+  become: true
+
+- name: Reset ts_plot_output_dir
+  ansible.builtin.set_fact:
+    ts_plot_output_dir: Null

--- a/roles/manage_touchstone_tools/tasks/process_pidstat.yml
+++ b/roles/manage_touchstone_tools/tasks/process_pidstat.yml
@@ -1,0 +1,13 @@
+---
+- name: Set pidstat_txt_file if not defined
+  ansible.builtin.set_fact:
+    pidstat_txt_file: "{{ ts_output_dir }}/pidstat.txt"
+  when: pidstat_txt_file is not defined
+
+- name: Run ts process-pidstat
+  ansible.builtin.shell: |
+    set -o pipefail
+    ts process-pidstat -i {{ pidstat_txt_file }}
+  args:
+    chdir: /usr/bin/
+  become: true

--- a/roles/manage_touchstone_tools/tasks/start_db_stats.yml
+++ b/roles/manage_touchstone_tools/tasks/start_db_stats.yml
@@ -1,14 +1,35 @@
 ---
-- name: Start ts pgsql-stat
+- name: Start ts pgsql-stat with no explicit libpq vars
+  ansible.builtin.shell: |
+    set -o pipefail
+    ts pgsql-stat \
+      -o {{ ts_output_dir }} \
+      -i {{ sec_bw_sample }}
+  args:
+    chdir: /usr/bin/
+  become: true
+  when:
+    - pg_database|length < 1
+    - pg_server_hostname|length < 1
+    - pg_port|length < 1
+    - pg_owner|length < 1
+
+# if libpq environment vars are not set or explicitly defined
+- name: Start ts pgsql-stat with explicitly set libpq vars
   ansible.builtin.shell: |
     set -o pipefail
     ts pgsql-stat \
       -o {{ ts_output_dir }} \
       -i {{ sec_bw_sample }} \
-      -d {{ db_name }} \
-      -h {{ db_server_hostname }} \
-      -p {{ db_server_port }} \
-      -U {{ db_user }}
+      -d {{ pg_database }} \
+      -h {{ pg_server_hostname }} \
+      -p {{ pg_port }} \
+      -U {{ pg_owner }}
   args:
     chdir: /usr/bin/
   become: true
+  when:
+    - pg_database|length > 0
+    - pg_server_hostname|length > 0
+    - pg_port|length > 0
+    - pg_owner|length > 0

--- a/roles/manage_touchstone_tools/tasks/start_db_stats.yml
+++ b/roles/manage_touchstone_tools/tasks/start_db_stats.yml
@@ -8,7 +8,8 @@
       -i {{ sec_bw_sample }} \
       -d {{ pg_database }} \
       -h {{ pg_server_hostname }} \
-      -p {{ pg_port }}
+      -p {{ pg_port }} \
+      -U {{ pg_owner }}
   args:
     chdir: /usr/bin/
   become: true

--- a/roles/manage_touchstone_tools/tasks/start_db_stats.yml
+++ b/roles/manage_touchstone_tools/tasks/start_db_stats.yml
@@ -1,21 +1,6 @@
 ---
-- name: Start ts pgsql-stat with no explicit libpq vars
-  ansible.builtin.shell: |
-    set -o pipefail
-    ts pgsql-stat \
-      -o {{ ts_output_dir }} \
-      -i {{ sec_bw_sample }}
-  args:
-    chdir: /usr/bin/
-  become: true
-  when:
-    - pg_database|length < 1
-    - pg_server_hostname|length < 1
-    - pg_port|length < 1
-    - pg_owner|length < 1
-
-# if libpq environment vars are not set or explicitly defined
-- name: Start ts pgsql-stat with explicitly set libpq vars
+# Start collection of pgsql-stat
+- name: Start ts pgsql-stat
   ansible.builtin.shell: |
     set -o pipefail
     ts pgsql-stat \
@@ -23,13 +8,8 @@
       -i {{ sec_bw_sample }} \
       -d {{ pg_database }} \
       -h {{ pg_server_hostname }} \
-      -p {{ pg_port }} \
-      -U {{ pg_owner }}
+      -p {{ pg_port }}
   args:
     chdir: /usr/bin/
   become: true
-  when:
-    - pg_database|length > 0
-    - pg_server_hostname|length > 0
-    - pg_port|length > 0
-    - pg_owner|length > 0
+

--- a/roles/manage_touchstone_tools/tasks/start_db_stats.yml
+++ b/roles/manage_touchstone_tools/tasks/start_db_stats.yml
@@ -1,0 +1,14 @@
+---
+- name: Start ts pgsql-stat
+  ansible.builtin.shell: |
+    set -o pipefail
+    ts pgsql-stat \
+      -o {{ ts_output_dir }} \
+      -i {{ sec_bw_sample }} \
+      -d {{ db_name }} \
+      -h {{ db_server_hostname }} \
+      -p {{ db_server_port }} \
+      -U {{ db_user }}
+  args:
+    chdir: /usr/bin/
+  become: true

--- a/roles/manage_touchstone_tools/tasks/start_system_stats.yml
+++ b/roles/manage_touchstone_tools/tasks/start_system_stats.yml
@@ -1,0 +1,14 @@
+---
+- name: Set ts_output_dir
+  ansible.builtin.set_fact:
+    ts_output_dir: "/var/log/touchstone/{{ now() }}"
+  when:
+    - ts_output_dir is not defined
+
+- name: Start ts sysstat
+  ansible.builtin.shell: |
+    set -o pipefail
+    ts sysstat -o {{ ts_output_dir }} -i {{ sec_bw_sample }}
+  args:
+    chdir: /usr/bin/
+  become: true

--- a/roles/manage_touchstone_tools/tasks/stop_db_stats.yml
+++ b/roles/manage_touchstone_tools/tasks/stop_db_stats.yml
@@ -2,13 +2,7 @@
 - name: Stop ts pgsql-stat
   ansible.builtin.shell: |
     set -o pipefail
-    ts pgsql-stat \
-      -o {{ ts_output_dir }} \
-      -d {{ db_name }} \
-      -h {{ db_server_hostname }} \
-      -p {{ db_server_port }} \
-      -U {{ db_user }} \
-      -s
+    ts pgsql-stat -o {{ ts_output_dir }} -s
   args:
     chdir: /usr/bin/
   become: true

--- a/roles/manage_touchstone_tools/tasks/stop_db_stats.yml
+++ b/roles/manage_touchstone_tools/tasks/stop_db_stats.yml
@@ -1,0 +1,14 @@
+---
+- name: Stop ts pgsql-stat
+  ansible.builtin.shell: |
+    set -o pipefail
+    ts pgsql-stat \
+      -o {{ ts_output_dir }} \
+      -d {{ db_name }} \
+      -h {{ db_server_hostname }} \
+      -p {{ db_server_port }} \
+      -U {{ db_user }} \
+      -s
+  args:
+    chdir: /usr/bin/
+  become: true

--- a/roles/manage_touchstone_tools/tasks/stop_system_stats.yml
+++ b/roles/manage_touchstone_tools/tasks/stop_system_stats.yml
@@ -1,0 +1,8 @@
+---
+- name: Stop ts sysstat
+  ansible.builtin.shell: |
+    set -o pipefail
+    ts sysstat -o {{ ts_output_dir }} -s
+  args:
+    chdir: /usr/bin/
+  become: true

--- a/roles/setup_touchstone_tools/defaults/main.yml
+++ b/roles/setup_touchstone_tools/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-touchstone_tools_version: 0.6.2
+touchstone_tools_version: 0.7.0
 touchstone_tools_appimage: https://touchstone.gitlab.io/download/ts-tools-{{ touchstone_tools_version }}-x86_64.AppImage
 supported_os:
   - CentOS8

--- a/roles/setup_touchstone_tools/defaults/main.yml
+++ b/roles/setup_touchstone_tools/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-touchstone_tools_version: 0.6.1
+touchstone_tools_version: 0.6.2
 touchstone_tools_appimage: https://touchstone.gitlab.io/download/ts-tools-{{ touchstone_tools_version }}-x86_64.AppImage
 supported_os:
   - CentOS8

--- a/roles/setup_touchstone_tools/tasks/main.yml
+++ b/roles/setup_touchstone_tools/tasks/main.yml
@@ -9,11 +9,11 @@
     state: present
   become: true
 
-# if CentOS or RHEL, fuse-sshfs package is needed as per example https://github.com/AppImage/AppImageKit/wiki/FUSE
+# if CentOS or RHEL, fuse-libs package is needed as per example https://github.com/AppImage/AppImageKit/wiki/FUSE
 - name: Install packages to use AppImage if RHEL
   ansible.builtin.package:
     name:
-      - fuse-sshfs
+      - fuse-libs
     state: present
   become: true
   when: ansible_os_family == 'RedHat'

--- a/roles/setup_touchstone_tools/tasks/main.yml
+++ b/roles/setup_touchstone_tools/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install packages for Touchstone
   ansible.builtin.package:
     name:
@@ -9,6 +8,15 @@
       - util-linux
     state: present
   become: true
+
+# if CentOS or RHEL, fuse-sshfs package is needed as per example https://github.com/AppImage/AppImageKit/wiki/FUSE
+- name: Install packages to use AppImage if RHEL
+  ansible.builtin.package:
+    name:
+      - fuse-sshfs
+    state: present
+  become: true
+  when: ansible_os_family == 'RedHat'
 
 - name: Download Touchstone Tools AppImage
   ansible.builtin.get_url:

--- a/tests/cases/manage_touchstone_tools/Makefile
+++ b/tests/cases/manage_touchstone_tools/Makefile
@@ -1,0 +1,9 @@
+include ../../Makefile.mk
+
+build-rocky8:
+	docker compose up primary1-rocky8 -d
+	docker compose up dbt2_driver1-rocky8 -d
+
+build-almalinux8:
+	docker compose up primary1-almalinux8 -d
+	docker compose up dbt2_driver1-almalinux8 -d

--- a/tests/cases/manage_touchstone_tools/Makefile
+++ b/tests/cases/manage_touchstone_tools/Makefile
@@ -3,7 +3,9 @@ include ../../Makefile.mk
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up dbt2_driver1-rocky8 -d
+	docker compose up dbt2_client1-rocky8 -d
 
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up dbt2_driver1-almalinux8 -d
+	docker compose up dbt2_client1-almalinux8 -d

--- a/tests/cases/manage_touchstone_tools/docker-compose.yml
+++ b/tests/cases/manage_touchstone_tools/docker-compose.yml
@@ -1,0 +1,65 @@
+version: '3'
+
+services:
+  ansible-tester:
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ansible-tester
+      args:
+        ansible_core_version: "${ANSIBLE_CORE_VERSION}"
+    environment:
+    - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
+    - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
+    - EDB_PG_TYPE
+    - EDB_PG_VERSION
+    - CASE_NAME=manage_touchstone_tools
+    - EDB_OS
+    - ANSIBLE_CORE_VERSION="${ANSIBLE_CORE_VERSION:-2.13}"
+    volumes:
+    - ../../..:/workspace
+    command: "/workspace/tests/docker/exec-tests.sh"
+  primary1-rocky8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  dbt2_driver1-rocky8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  primary1-almalinux8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.almalinux8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  dbt2_driver1-almalinux8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.almalinux8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init

--- a/tests/cases/manage_touchstone_tools/docker-compose.yml
+++ b/tests/cases/manage_touchstone_tools/docker-compose.yml
@@ -41,6 +41,17 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  dbt2_client1-rocky8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:
@@ -53,6 +64,17 @@ services:
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
   dbt2_driver1-almalinux8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.almalinux8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  dbt2_client1-almalinux8:
     privileged: true
     build:
       context: ../../docker

--- a/tests/cases/manage_touchstone_tools/inventory.yml.j2
+++ b/tests/cases/manage_touchstone_tools/inventory.yml.j2
@@ -1,0 +1,14 @@
+---
+all:
+  children:
+    primary:
+      hosts:
+        primary1:
+          dbt2: true
+          ansible_host: {{ inventory_vars['primary1_ip'] }}
+          private_ip: {{ inventory_vars['primary1_ip'] }}
+    dbt2_driver:
+      hosts:
+        dbt2_driver1:
+          ansible_host: {{ inventory_vars['dbt2_driver1_ip'] }}
+          private_ip: {{ inventory_vars['dbt2_driver1_ip'] }}

--- a/tests/cases/manage_touchstone_tools/inventory.yml.j2
+++ b/tests/cases/manage_touchstone_tools/inventory.yml.j2
@@ -12,3 +12,8 @@ all:
         dbt2_driver1:
           ansible_host: {{ inventory_vars['dbt2_driver1_ip'] }}
           private_ip: {{ inventory_vars['dbt2_driver1_ip'] }}
+    dbt2_client:
+      hosts:
+        dbt2_client1:
+          ansible_host: {{ inventory_vars['dbt2_client1_ip'] }}
+          private_ip: {{ inventory_vars['dbt2_client1_ip'] }}

--- a/tests/cases/manage_touchstone_tools/playbook.yml
+++ b/tests/cases/manage_touchstone_tools/playbook.yml
@@ -21,6 +21,8 @@
       when: "'init_dbserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: setup_dbt2_driver
       when: "'setup_dbt2_driver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: setup_dbt2_client
+      when: "'setup_dbt2_client' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: setup_dbt2
       when: "'setup_dbt2' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: setup_touchstone_tools

--- a/tests/cases/manage_touchstone_tools/playbook.yml
+++ b/tests/cases/manage_touchstone_tools/playbook.yml
@@ -1,0 +1,27 @@
+---
+- hosts: all
+  name: Postgres deployment playbook
+  become: true
+  gather_facts: true
+
+  collections:
+    - edb_devops.edb_postgres
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      set_fact:
+        disable_logging: false
+
+  roles:
+    - role: setup_repo
+      when: "'setup_repo' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: install_dbserver
+      when: "'install_dbserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: init_dbserver
+      when: "'init_dbserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: setup_dbt2_driver
+      when: "'setup_dbt2_driver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: setup_dbt2
+      when: "'setup_dbt2' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: setup_touchstone_tools
+    - role: manage_touchstone_tools

--- a/tests/cases/manage_touchstone_tools/vars.json
+++ b/tests/cases/manage_touchstone_tools/vars.json
@@ -1,0 +1,5 @@
+{
+  "use_hostname": false,
+  "pg_data": "/opt/pgdata",
+  "pg_wal": "/opt/pgwal"
+}

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -491,3 +491,14 @@ cases:
     - debian10
     - ubuntu20
     - oraclelinux7
+  manage_touchstone_tools:
+    pg_version:
+    - 13
+    - 14
+    - 15
+    pg_type:
+    - PG
+    - EPAS
+    os:
+    - rocky8
+    - almalinux8

--- a/tests/tests/test_manage_touchstone_tools.py
+++ b/tests/tests/test_manage_touchstone_tools.py
@@ -27,7 +27,7 @@ def test_touchstone_packages():
     ]
 
     if os_family() == 'RedHat':
-        packages.append('fuse-sshfs')
+        packages.append('fuse-libs')
 
     for package in packages:
         assert host.package(package).is_installed, \

--- a/tests/tests/test_manage_touchstone_tools.py
+++ b/tests/tests/test_manage_touchstone_tools.py
@@ -1,0 +1,34 @@
+import pytest
+
+from conftest import (
+    load_ansible_vars,
+    get_pg_type,
+    get_pg_version,
+    get_primary,
+    os_family
+)
+
+
+def test_touchstone_appimage():
+    host = get_primary()
+    appimage_bin_location = "/usr/bin/ts"
+
+    assert host.file(appimage_bin_location).exists, \
+        "touchstone appimage not installed correctly."
+
+
+def test_touchstone_packages():
+    host = get_primary()
+    packages = [
+        'fuse',
+        'perf',
+        'sysstat',
+        'util-linux'
+    ]
+
+    if os_family() == 'RedHat':
+        packages.append('fuse-sshfs')
+
+    for package in packages:
+        assert host.package(package).is_installed, \
+            "Package %s not installed" % package


### PR DESCRIPTION
Manage touchstone tools role to perform eight actions, each now contained within their own yaml file in the `manage_touchstone_tools` tasks. Each task has required variables to run, which are all specified in the README. The `manage_touchstone_tools.yml` is designed to be able to copy and paste the `import_role` block into a benchmark playbook. Examples of how to use these tasks is also documented in the README.

Within the `setup_touchstone_tools` role, I added the installation of the `fuse-sshfs` package, as that is a requirement to run the appimage in RHEL distros. 

