### PR TITLE
update pgbackrest documentation

### DIFF
--- a/roles/setup_pgbackrest/README.md
+++ b/roles/setup_pgbackrest/README.md
@@ -184,6 +184,10 @@ Below is an example of how to include the `setup_pgbackrest` role:
         pg_type: "PG"
         
   roles:
+    - role: setup_repo
+      when: "'setup_repo' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: setup_pgbackrestserver
+      when: "'setup_pgbackrestserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: setup_pgbackrest
       when: "'setup_pgbackrest' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
 ```

--- a/roles/setup_pgbackrestserver/README.md
+++ b/roles/setup_pgbackrestserver/README.md
@@ -224,6 +224,8 @@ Below is an example of how to include the `setup_pgbackrestserver` role:
       when: "'setup_repo' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
     - role: setup_pgbackrestserver
       when: "'setup_pgbackrestserver' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
+    - role: setup_pgbackrest
+      when: "'setup_pgbackrest' in lookup('edb_devops.edb_postgres.supported_roles', wantlist=True)"
 ```
 
 Defining and adding variables is done in the `set_fact` of the `pre_tasks`.


### PR DESCRIPTION
Update pgbackrest documentation to only include playbook examples where both the `setup_pgbackrest` and `setup_pgbackrestserver` roles are included. 