### PR TITLE
add new OS dockerfiles

### DIFF
--- a/tests/Makefile.mk
+++ b/tests/Makefile.mk
@@ -9,20 +9,36 @@ post-build:
 	python3 ../../scripts/ssh-build-ssh-config.py --ssh-dir .ssh
 
 centos7: export EDB_OS=centos7
+centos8: export EDB_OS=centos8
 rocky8: export EDB_OS=rocky8
+rocky9: export EDB_OS=rocky9
+rhel8: export EDB_OS=rhel8
 almalinux8: export EDB_OS=almalinux8
 debian9: export EDB_OS=debian9
 debian10: export EDB_OS=debian10
+debian11: export EDB_OS=debian11
 ubuntu20: export EDB_OS=ubuntu20
+ubuntu22: export EDB_OS=ubuntu22
+suse15: export EDB_OS=suse15
 oraclelinux7: export EDB_OS=oraclelinux7
+oraclelinux8: export EDB_OS=oraclelinux8
+oraclelinux9: export EDB_OS=oraclelinux9
 
 centos7: build-centos7 post-build ansible-tester-up
+centos8: build-centos8 post-build ansible-tester-up
 rocky8: build-rocky8 post-build ansible-tester-up
+rocky9: build-rocky9 post-build ansible-tester-up
+rhel8: build-rhel8 post-build ansible-tester-up
 almalinux8: build-almalinux8 post-build ansible-tester-up
 debian9: build-debian9 post-build ansible-tester-up
 debian10: build-debian10 post-build ansible-tester-up
+debian11: build-debian11 post-build ansible-tester-up
 ubuntu20: build-ubuntu20 post-build ansible-tester-up
+ubuntu22: build-ubuntu22 post-build ansible-tester-up
+suse15: build-suse15 post-build ansible-tester-up
 oraclelinux7: build-oraclelinux7 post-build ansible-tester-up
+oraclelinux8: build-oraclelinux8 post-build ansible-tester-up
+oraclelinux9: build-oraclelinux9 post-build ansible-tester-up
 
 clean:
 	rm -rf ./.ssh

--- a/tests/cases/setup_repo/Makefile
+++ b/tests/cases/setup_repo/Makefile
@@ -3,8 +3,17 @@ include ../../Makefile.mk
 build-centos7:
 	docker compose up primary1-centos7 -d
 
+build-centos8:
+	docker compose up primary1-centos8 -d
+
 build-rocky8:
 	docker compose up primary1-rocky8 -d
+
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+
+build-rhel8:
+	docker compose up primary1-rhel8 -d
 
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
@@ -15,8 +24,23 @@ build-debian9:
 build-debian10:
 	docker compose up primary1-debian10 -d
 
+build-debian11:
+	docker compose up primary1-debian11 -d
+
 build-ubuntu20:
 	docker compose up primary1-ubuntu20 -d
 
+build-ubuntu22:
+	docker compose up primary1-ubuntu22 -d
+
+build-suse15:
+	docker compose up primary1-suse15 -d
+
 build-oraclelinux7:
 	docker compose up primary1-oraclelinux7 -d
+
+build-oraclelinux8:
+	docker compose up primary1-oraclelinux8 -d
+
+build-oraclelinux9:
+	docker compose up primary1-oraclelinux9 -d

--- a/tests/cases/setup_repo/docker-compose.yml
+++ b/tests/cases/setup_repo/docker-compose.yml
@@ -30,6 +30,28 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  primary1-rhel8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rhel8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:
@@ -52,6 +74,21 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-centos8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.centos8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
   primary1-debian9:
     privileged: true
     build:
@@ -82,6 +119,21 @@ services:
     - /tmp
     - /run/sshd
     - /run/lock
+  primary1-debian11:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.debian11
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
   primary1-ubuntu20:
     privileged: true
     build:
@@ -97,11 +149,64 @@ services:
     - /tmp
     - /run/sshd
     - /run/lock
+  primary1-ubuntu22:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.ubuntu22
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+  primary1-suse15:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.suse15
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    tmpfs:
+    - /run
+    - /tmp
+    - /run/sshd
+    - /run/lock
+    command: /usr/lib/systemd/systemd --system
   primary1-oraclelinux7:
     privileged: true
     build:
       context: ../../docker
       dockerfile: Dockerfile.oraclelinux7
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  primary1-oraclelinux8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.oraclelinux8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  primary1-oraclelinux9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.oraclelinux9
     cap_add:
     - SYS_ADMIN
     volumes:

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -12,12 +12,20 @@ cases:
     - EPAS
     os:
     - centos7
+    - centos8
     - oraclelinux7
+    - oraclelinux8
+    - oraclelinux9
     - rocky8
+    - rocky9
+    - rhel8
     - almalinux8
     - debian9
     - debian10
+    - debian11
     - ubuntu20
+    - ubuntu22
+    - suse15
   install_dbserver:
     pg_version:
     - 10

--- a/tests/docker/Dockerfile.centos8
+++ b/tests/docker/Dockerfile.centos8
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+FROM jrei/systemd-centos:8
+
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-*
+RUN sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+
+RUN yum install iproute -y
+RUN yum install sudo -y
+RUN yum install python3 -y
+RUN yum install ca-certificates -y
+RUN yum install openssh-clients -y
+RUN yum install openssl -y
+RUN yum install openssh-server -y
+RUN yum install which -y

--- a/tests/docker/Dockerfile.debian11
+++ b/tests/docker/Dockerfile.debian11
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM jrei/systemd-debian:11
+
+RUN apt update
+RUN apt install sudo -y
+RUN apt install python3 -y
+RUN apt install ca-certificates -y
+RUN apt install openssh-client -y
+RUN apt install openssh-server -y
+RUN apt install python3-apt -y
+RUN apt install gpg -y
+RUN apt install acl -y
+RUN apt install apt-transport-https -y
+RUN apt-get update -y
+RUN apt-get install iproute2 -y
+RUN apt-get install software-properties-common -y
+RUN apt-add-repository 'deb http://archive.debian.org/debian-security stretch/updates main' -y
+RUN apt-get update -y
+RUN apt-get install openjdk-8-jdk -y
+RUN systemctl disable ssh

--- a/tests/docker/Dockerfile.oraclelinux8
+++ b/tests/docker/Dockerfile.oraclelinux8
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+FROM oraclelinux:8
+
+RUN dnf -y reinstall systemd
+RUN (cd /etc/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+RUN yum update -y
+RUN yum install iproute -y
+RUN yum install sudo -y
+RUN yum install python3 -y
+RUN yum reinstall ca-certificates -y
+RUN yum install openssh-clients -y
+RUN yum install openssl -y
+RUN yum install openssh-server -y
+RUN yum install which -y

--- a/tests/docker/Dockerfile.oraclelinux9
+++ b/tests/docker/Dockerfile.oraclelinux9
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+FROM oraclelinux:9
+
+RUN dnf -y reinstall systemd
+RUN (cd /etc/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+RUN yum update -y
+RUN yum install iproute -y
+RUN yum install sudo -y
+RUN yum install python3 -y
+RUN yum reinstall ca-certificates -y
+RUN yum install openssh-clients -y
+RUN yum install openssl -y
+RUN yum install openssh-server -y
+RUN yum install which -y

--- a/tests/docker/Dockerfile.rhel8
+++ b/tests/docker/Dockerfile.rhel8
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+FROM registry.access.redhat.com/ubi8/ubi
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+RUN dnf install glibc-langpack-en -y
+RUN dnf update -y
+RUN dnf install sudo -y
+RUN dnf install python3 -y
+RUN dnf install ca-certificates -y
+RUN dnf install openssh-clients -y
+RUN dnf install openssh-server -y
+RUN dnf install which -y
+RUN dnf install iproute -y

--- a/tests/docker/Dockerfile.rocky9
+++ b/tests/docker/Dockerfile.rocky9
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+FROM rockylinux/rockylinux:9
+
+RUN [ ! -f /usr/sbin/init ] && dnf -y install systemd;
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+RUN dnf install glibc-langpack-en -y
+RUN dnf -qy module disable postgresql -y
+RUN dnf update -y
+RUN dnf install sudo -y
+RUN dnf install iproute -y
+RUN dnf install python3 -y
+RUN dnf install ca-certificates -y
+RUN dnf install openssh-clients -y
+RUN dnf install openssh-server -y
+RUN dnf install which -y

--- a/tests/docker/Dockerfile.suse15
+++ b/tests/docker/Dockerfile.suse15
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+FROM opensuse/leap:latest
+
+RUN zypper -n install systemd
+RUN zypper clean
+RUN zypper update
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+RUN zypper install --no-confirm openssh
+RUN zypper install --no-confirm sudo
+RUN zypper install --no-confirm iproute2
+RUN zypper install --no-confirm python3

--- a/tests/docker/Dockerfile.ubuntu22
+++ b/tests/docker/Dockerfile.ubuntu22
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM jrei/systemd-ubuntu:22.04
+
+RUN apt update
+RUN apt install iproute2 -y
+RUN apt install sudo -y
+RUN apt install python3 -y
+RUN apt install ca-certificates -y
+RUN apt install openssh-client -y
+RUN apt install openssh-server -y
+RUN apt install python3-apt -y
+RUN apt install gpg -y
+RUN apt install acl -y
+RUN apt install apt-transport-https -y
+RUN apt install iputils-ping -y
+RUN systemctl disable ssh

--- a/tests/scripts/lib/docker.py
+++ b/tests/scripts/lib/docker.py
@@ -86,13 +86,35 @@ class DockerCentos7Container(DockerCentosContainer):
     pass
 
 
+class DockerCentos8Container(DockerCentosContainer):
+    pass
+
+
 class DockerRocky8Container(DockerCentosContainer):
     pass
+
+
+class DockerRocky9Container(DockerCentosContainer):
+    pass
+
+
+class DockerRHEL8Container(DockerCentosContainer):
+    pass
+
 
 class DockerAlmalinux8Container(DockerCentosContainer):
     pass
 
+
 class DockerOraclelinux7Container(DockerCentosContainer):
+    pass
+
+
+class DockerOraclelinux8Container(DockerCentosContainer):
+    pass
+
+
+class DockerOraclelinux9Container(DockerCentosContainer):
     pass
 
 
@@ -113,24 +135,59 @@ class DockerDebian10Container(DockerDebianContainer):
     pass
 
 
+class DockerDebian11Container(DockerDebianContainer):
+    pass
+
+
 class DockerUbuntu20Container(DockerDebianContainer):
+    pass
+
+
+class DockerUbuntu22Container(DockerDebianContainer):
+    pass
+
+"""
+SUSE family
+"""
+class DockerSuseContainer(DockerContainer):
+    def start_sshd(self):
+        self.exec('/bin/systemctl start sshd')
+
+
+class DockerSuse15Container(DockerSuseContainer):
     pass
 
 
 def DockerOSContainer(id, os):
     if os == 'centos7':
         return DockerCentos7Container(id)
+    elif os == 'centos8':
+        return DockerCentos8Container(id)
     elif os == 'rocky8':
         return DockerRocky8Container(id)
+    elif os == 'rocky9':
+        return DockerRocky9Container(id)
+    elif os == 'rhel8':
+        return DockerRHEL8Container(id)
     elif os == 'almalinux8':
         return DockerAlmalinux8Container(id)
     elif os == 'debian9':
         return DockerDebian9Container(id)
     elif os == 'debian10':
         return DockerDebian10Container(id)
+    elif os == 'debian11':
+        return DockerDebian11Container(id)
     elif os == 'ubuntu20':
         return DockerUbuntu20Container(id)
+    elif os == 'ubuntu22':
+        return DockerUbuntu22Container(id)
+    elif os == 'suse15':
+        return DockerSuse15Container(id)
     elif os == 'oraclelinux7':
         return DockerOraclelinux7Container(id)
+    elif os == 'oraclelinux8':
+        return DockerOraclelinux8Container(id)
+    elif os == 'oraclelinux9':
+        return DockerOraclelinux9Container(id)
     else:
         raise Exception("Unknown OS %s" % os)

--- a/tests/test-runner.py
+++ b/tests/test-runner.py
@@ -32,8 +32,8 @@ class PgTypeChecker(argparse.Action):
 
 
 class OSChecker(argparse.Action):
-    available_os = ['centos7', 'rocky8', 'almalinux8', 'debian9', 'debian10', 'ubuntu20',
-                    'oraclelinux7']
+    available_os = ['centos7', 'centos8', 'rocky8', 'rocky9', 'rhel8', 'almalinux8', 'debian9', 'debian10', 'debian11',
+                    'ubuntu20', 'ubuntu22', 'suse15', 'oraclelinux7', 'oraclelinux8', 'oraclelinux9']
 
     def __call__(self, parser, namespace, values, option_string=None):
         for v in values:


### PR DESCRIPTION
Added new systemd dockerfiles, added OS to test config scripts, makefiles, and included how to run containers within the `setup_repo` role. 
The following OS's were added:

- CentOS8
- RHEL8
- Debian11 bullseye
- SUSE15 leap
- Ubuntu22 jammy jellyfish
- OracleLinux8
- OracleLinux9
- Rocky9