### PR TITLE
update powertools for RedHat8

### DIFF
--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -61,6 +61,7 @@
     - ansible_distribution_major_version == '8'
     - enable_epel_repo|bool
 
+# for RedHat8, use subscription-manager to enable codeready-builder repo, if required.
 - name: Enable powertools for EL8
   ansible.builtin.command: >
     dnf config-manager --set-enabled powertools
@@ -68,6 +69,7 @@
   changed_when: true
   when:
     - ansible_distribution_major_version == '8'
+    - os not in ['RedHat8']
     - enable_epel_repo|bool
 
 - name: Install EPEL repo for EL8

--- a/tests/cases/init_dbserver/Makefile
+++ b/tests/cases/init_dbserver/Makefile
@@ -6,6 +6,9 @@ build-centos7:
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 
+build-rhel8:
+	docker compose up primary1-rhel8 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 

--- a/tests/cases/init_dbserver/docker-compose.yml
+++ b/tests/cases/init_dbserver/docker-compose.yml
@@ -30,6 +30,17 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rhel8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rhel8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/install_dbserver/Makefile
+++ b/tests/cases/install_dbserver/Makefile
@@ -6,6 +6,9 @@ build-centos7:
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 
+build-rhel8:
+	docker compose up primary1-rhel8 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 

--- a/tests/cases/install_dbserver/docker-compose.yml
+++ b/tests/cases/install_dbserver/docker-compose.yml
@@ -30,6 +30,17 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rhel8:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rhel8
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:


### PR DESCRIPTION
No powertools repo available in RedHat8, equivalent would be to run `sudo subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms` but with the UBI base-image used, there is no subscription to manage. The rest of the tasks work as the powertools/codeready builder repo does not prohibit the EPEL repo in RedHat8. 