### PR TITLE
add repo_token to test execution

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -108,7 +108,7 @@ Usage:
 
 ```shell
 usage: test-runner.py [-h] [-j JOBS] [--configuration CONFIGURATION] --edb-repo-username EDB_REPO_USERNAME --edb-repo-password
-                      EDB_REPO_PASSWORD [--pg-version PG_VERSION [PG_VERSION ...]] [--pg-type PG_TYPE [PG_TYPE ...]]
+                      EDB_REPO_PASSWORD [--edb-repo-token EDB_REPO_TOKEN] [--pg-version PG_VERSION [PG_VERSION ...]] [--pg-type PG_TYPE [PG_TYPE ...]]
                       [--ansible-core-version ANSIBLE_CORE_VERSION [ANSIBLE_CORE_VERSION ...]]
                       [--os OS [OS ...]] [-k KEYWORD [KEYWORD ...]]
 
@@ -118,9 +118,11 @@ optional arguments:
   --configuration CONFIGURATION
                         Configuration file
   --edb-repo-username EDB_REPO_USERNAME
-                        EDB package repository username
+                        EDB package repository 1.0 username
   --edb-repo-password EDB_REPO_PASSWORD
-                        EDB package repository password
+                        EDB package repository 1.0 password
+  --edb-repo-token EDB_REPO_TOKEN
+                        EDB package repository 2.0 token
   --pg-version PG_VERSION [PG_VERSION ...]
                         Postgres versions list. Default: ['14']
   --pg-type PG_TYPE [PG_TYPE ...]
@@ -179,6 +181,7 @@ $ export EDB_PG_TYPE=<pg-type>
 $ export EDB_PG_VERSION=<pg-version>
 $ export EDB_REPO_USERNAME=<edb-repo-username>
 $ export EDB_REPO_PASSWORD=<edb-repo-password>
+$ export EDB_REPO_TOKEN=<edb-repo-token>
 $ export ANSIBLE_CORE_VERSION=<ansible-core-version>
 $ make -C cases/<test-case> <os>
 ```
@@ -191,6 +194,7 @@ $ export EDB_PG_TYPE=PG
 $ export EDB_PG_VERSION=14
 $ export EDB_REPO_USERNAME=<edb-repo-username>
 $ export EDB_REPO_PASSWORD=<edb-repo-password>
+$ export EDB_REPO_TOKEN=<edb-repo-token>
 $ export ANSIBLE_CORE_VERSION=2.13
 $ make -C cases/init_dbserver rocky8
 ```

--- a/tests/cases/init_dbserver/docker-compose.yml
+++ b/tests/cases/init_dbserver/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/init_tdedbserver/docker-compose.yml
+++ b/tests/cases/init_tdedbserver/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/install_dbserver/docker-compose.yml
+++ b/tests/cases/install_dbserver/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/manage_dbpatches/docker-compose.yml
+++ b/tests/cases/manage_dbpatches/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/manage_dbserver/docker-compose.yml
+++ b/tests/cases/manage_dbserver/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/manage_efm/docker-compose.yml
+++ b/tests/cases/manage_efm/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/manage_pgbouncer/docker-compose.yml
+++ b/tests/cases/manage_pgbouncer/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/manage_pgpool2/docker-compose.yml
+++ b/tests/cases/manage_pgpool2/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/manage_touchstone_tools/docker-compose.yml
+++ b/tests/cases/manage_touchstone_tools/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_barman/docker-compose.yml
+++ b/tests/cases/setup_barman/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_barmanserver/docker-compose.yml
+++ b/tests/cases/setup_barmanserver/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_dbt2/docker-compose.yml
+++ b/tests/cases/setup_dbt2/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_dbt2_client/docker-compose.yml
+++ b/tests/cases/setup_dbt2_client/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_dbt2_driver/docker-compose.yml
+++ b/tests/cases/setup_dbt2_driver/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_dbt3/docker-compose.yml
+++ b/tests/cases/setup_dbt3/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_dbt7/docker-compose.yml
+++ b/tests/cases/setup_dbt7/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_efm/docker-compose.yml
+++ b/tests/cases/setup_efm/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_hammerdb/docker-compose.yml
+++ b/tests/cases/setup_hammerdb/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_patroni/docker-compose.yml
+++ b/tests/cases/setup_patroni/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_pemagent/docker-compose.yml
+++ b/tests/cases/setup_pemagent/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_pemserver/docker-compose.yml
+++ b/tests/cases/setup_pemserver/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_pgbackrest/docker-compose.yml
+++ b/tests/cases/setup_pgbackrest/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_pgbackrestserver/docker-compose.yml
+++ b/tests/cases/setup_pgbackrestserver/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_pgbouncer/docker-compose.yml
+++ b/tests/cases/setup_pgbouncer/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_pgpool2/docker-compose.yml
+++ b/tests/cases/setup_pgpool2/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_replication/docker-compose.yml
+++ b/tests/cases/setup_replication/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_repmgr/docker-compose.yml
+++ b/tests/cases/setup_repmgr/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/cases/setup_repo/docker-compose.yml
+++ b/tests/cases/setup_repo/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
       - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+      - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
       - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
       - EDB_PG_TYPE
       - EDB_PG_VERSION

--- a/tests/cases/setup_tdereplication/docker-compose.yml
+++ b/tests/cases/setup_tdereplication/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
     - EDB_REPO_USERNAME="${EDB_REPO_USERNAME:- }"
     - EDB_REPO_PASSWORD="${EDB_REPO_PASSWORD:- }"
+    - EDB_REPO_TOKEN="${EDB_REPO_TOKEN:- }"
     - EDB_ENABLE_REPO=${EDB_ENABLE_REPO:-true}
     - EDB_PG_TYPE
     - EDB_PG_VERSION

--- a/tests/docker/exec-tests.sh
+++ b/tests/docker/exec-tests.sh
@@ -11,6 +11,7 @@ ANSIBLE_PIPELINING=1 ansible-playbook \
 	-i /workspace/tests/cases/${CASE_NAME}/inventory.yml \
 	--extra-vars "repo_username=${EDB_REPO_USERNAME}" \
 	--extra-vars "repo_password=${EDB_REPO_PASSWORD}" \
+	--extra-vars "repo_token=${EDB_REPO_TOKEN}" \
 	--extra-vars "enable_edb_repo=${EDB_ENABLE_REPO}" \
 	--extra-vars "pg_type=${EDB_PG_TYPE}" \
 	--extra-vars "pg_version=${EDB_PG_VERSION}" \

--- a/tests/test-runner.py
+++ b/tests/test-runner.py
@@ -57,7 +57,7 @@ def load_configuration(configuration):
 
 
 def exec_test_case(case_name, case_config, edb_repo_username,
-                   edb_repo_password, pg_version_list, pg_type_list, os_list,
+                   edb_repo_password, edb_repo_token, pg_version_list, pg_type_list, os_list,
                    edb_enable_repo, ansible_core_version_list):
     n_success = 0
     n_executed = 0
@@ -78,6 +78,7 @@ def exec_test_case(case_name, case_config, edb_repo_username,
                         case_name,
                         edb_repo_username,
                         edb_repo_password,
+                        edb_repo_token,
                         os,
                         pg_type,
                         pg_version,
@@ -90,12 +91,13 @@ def exec_test_case(case_name, case_config, edb_repo_username,
     return (n_success, n_executed)
 
 
-def exec_test(case_name, edb_repo_username, edb_repo_password, os, pg_type,
+def exec_test(case_name, edb_repo_username, edb_repo_password, edb_repo_token, os, pg_type,
               pg_version, edb_enable_repo, ansible_core_version):
     env = os_.environ.copy()
     env.update({
         'EDB_REPO_USERNAME': edb_repo_username,
         'EDB_REPO_PASSWORD': edb_repo_password,
+        'EDB_REPO_TOKEN': edb_repo_token,
         'EDB_ENABLE_REPO': edb_enable_repo,
         'EDB_PG_VERSION': pg_version,
         'EDB_PG_TYPE': pg_type,
@@ -197,14 +199,21 @@ if __name__ == '__main__':
         dest='edb_repo_username',
         type=str,
         default='',
-        help="EDB package repository username",
+        help="EDB package repository 1.0 username",
     )
     parser.add_argument(
         '--edb-repo-password',
         dest='edb_repo_password',
         type=str,
         default='',
-        help="EDB package repository password",
+        help="EDB package repository 1.0 password",
+    )
+    parser.add_argument(
+        '--edb-repo-token',
+        dest='edb_repo_token',
+        type=str,
+        default='',
+        help="EDB package repository 2.0 token",
     )
     parser.add_argument(
         '--edb-enable-repo',
@@ -263,7 +272,7 @@ if __name__ == '__main__':
             continue
 
         test_cases.append(
-            (name, config, env.edb_repo_username, env.edb_repo_password,
+            (name, config, env.edb_repo_username, env.edb_repo_password, env.edb_repo_token,
              env.pg_version, env.pg_type, env.os, env.edb_enable_repo,
              env.ansible_core_version)
         )


### PR DESCRIPTION
Adds option to pass through `EDB_REPO_TOKEN` for use of edb repo 2.0 within a test case execution.