### PR TITLE
fix repo token length for test cases

### DIFF
--- a/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
@@ -124,4 +124,4 @@
     reposub.rc != 0 or 'error: ' in reposub.stdout.lower()
   changed_when: reposub.rc == '0'
   when: >
-    enable_edb_repo|bool and repo_token|length > 0
+    enable_edb_repo|bool and repo_token|length > 1

--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -172,7 +172,7 @@
     enabled: true
   when:
     - enable_edb_repo|bool
-    - repo_token|length > 0
+    - repo_token|length > 1
     - install_pgd|bool
     - pg_version|int >= 15
     - pgd_version|int >= 5
@@ -191,4 +191,4 @@
   changed_when: reposub.rc == '0'
   when:
     - enable_edb_repo|bool
-    - repo_token|length > 0
+    - repo_token|length > 1

--- a/roles/setup_repo/tasks/validate_setup_repo.yml
+++ b/roles/setup_repo/tasks/validate_setup_repo.yml
@@ -35,7 +35,7 @@
   when:
     - ansible_os_family == 'RedHat'
     - enable_edb_repo|bool
-    - repo_token|length > 0
+    - repo_token|length > 1
 
 - name: Check for PGDG Repo on RedHat
   ansible.builtin.assert:


### PR DESCRIPTION
The `repo_token|length = 1` when `repo_token` is set to `""` within the test cases, causing the install and validation to fail. This fixes those issues. 