### PR TITLE
update minimum ansible version to 2.11

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: ">=2.10"
+requires_ansible: ">=2.11"


### PR DESCRIPTION
There is a bug in ansible 2.10 where rocky systems are not recognized to be within the `RedHat ansible_os_family`. This bug is fixed in ansible 2.11.