### PR TITLE
fix edb_wait_states for RH EPAS13 and fix new repo token testing

### DIFF
--- a/roles/install_dbserver/tasks/EPAS_Debian_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_Debian_install.yml
@@ -24,8 +24,8 @@
     state: present
     update_cache: true
   become: true
-  when: >-
-    pg_version|int < 14
+  when:
+    - pg_version|int < 14
 
 - name: "Install EPAS >= 14 Packages"
   ansible.builtin.package:
@@ -34,8 +34,8 @@
     state: present
     update_cache: true
   become: true
-  when: >-
-    pg_version|int >= 14
+  when:
+    - pg_version|int >= 14
 
 - name: Install sslutils
   ansible.builtin.package:
@@ -62,9 +62,9 @@
       - edb-bdr{{ pgd_version }}-{{ pg_type | lower }}{{ pg_version }}-debuginfo
     state: present
   become: true
-  when: >-
-    pg_version|int >= 14
-    and install_pgd|bool
+  when:
+    - pg_version|int >= 14
+    - install_pgd|bool
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/roles/install_dbserver/tasks/EPAS_Debian_rm_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_Debian_rm_install.yml
@@ -27,7 +27,6 @@
       - python3-psycopg2
       - edb-as{{ pg_version }}-server
       - edb-as{{ pg_version }}-server-core
-      - edb-as{{ pg_version }}-server-edb-modules
       - edb-as{{ pg_version }}-server-client
       - edb-as{{ pg_version }}-server-indexadvisor
       - edb-as{{ pg_version }}-server-sqlprofiler
@@ -35,6 +34,26 @@
     state: absent
     update_cache: true
   become: true
+
+- name: Remove edb-modules for EPAS < 14
+  ansible.builtin.package:
+    name:
+      - edb-as{{ pg_version }}-server-edb-modules
+    state: absent
+    update_cache: true
+  become: true
+  when:
+    - pg_version|int < 14
+
+- name: Remove edb-wait-states for EPAS >= 14
+  ansible.builtin.package:
+    name:
+      - edb-as{{ pg_version }}-server-edb-wait-states
+    state: absent
+    update_cache: true
+  become: true
+  when:
+    - pg_version|int >= 14
 
 - name: Remove python-psycopg2
   ansible.builtin.package:

--- a/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
@@ -32,28 +32,10 @@
       - edb-as{{ pg_version }}-server-sqlprotect
     state: present
   become: true
-  when: >-
-    pg_version|int < 11
+  when:
+    - pg_version|int < 11
 
-- name: "Install EPAS 11,12,13 packages"
-  ansible.builtin.package:
-    name:
-      - edb-as{{ pg_version }}-server
-      - edb-as{{ pg_version }}-server-core
-      - edb-as{{ pg_version }}-server-edb-modules
-      - edb-as{{ pg_version }}-server-contrib
-      - edb-as{{ pg_version }}-server-libs
-      - edb-as{{ pg_version }}-server-client
-      - edb-as{{ pg_version }}-server-llvmjit
-      - edb-as{{ pg_version }}-server-indexadvisor
-      - edb-as{{ pg_version }}-server-sqlprofiler
-      - edb-as{{ pg_version }}-server-sqlprotect
-    state: present
-  become: true
-  when: >-
-    pg_version|int > 10 and pg_version|int < 14
-
-- name: "Install EPAS >= 14 packages"
+- name: "Install EPAS >= 11 packages"
   ansible.builtin.package:
     name:
       - edb-as{{ pg_version }}-server
@@ -68,8 +50,8 @@
       - edb-as{{ pg_version }}-server-edb_wait_states
     state: present
   become: true
-  when: >-
-    pg_version|int >= 14
+  when:
+    - pg_version|int >= 11
 
 - name: "Install PGD packages for EPAS >= 14"
   ansible.builtin.package:
@@ -78,9 +60,9 @@
       - edb-bdr{{ pgd_version }}-{{ pg_type | lower }}{{ pg_version }}-debuginfo
     state: present
   become: true
-  when: >-
-    pg_version|int >= 14
-    and install_pgd|bool
+  when:
+    - pg_version|int >= 14
+    - install_pgd|bool
 
 - name: Install sslutils
   ansible.builtin.package:

--- a/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
@@ -24,16 +24,24 @@
     name:
       - edb-as{{ pg_version }}-server
       - edb-as{{ pg_version }}-server-core
-      - edb-as{{ pg_version }}-server-edb_wait_states
       - edb-as{{ pg_version }}-server-contrib
       - edb-as{{ pg_version }}-server-libs
       - edb-as{{ pg_version }}-server-client
-      - edb-as{{ pg_version }}-server-llvmjit
       - edb-as{{ pg_version }}-server-indexadvisor
       - edb-as{{ pg_version }}-server-sqlprofiler
       - edb-as{{ pg_version }}-server-sqlprotect
     state: absent
   become: true
+
+- name: Remove EPAS >= 11 packages
+  ansible.builtin.package:
+    name:
+      - edb-as{{ pg_version }}-server-edb_wait_states
+      - edb-as{{ pg_version }}-server-llvmjit
+    state: absent
+  become: true
+  when:
+    - pg_version|int >= 11
 
 - name: Remove python packages on EL7
   ansible.builtin.package:

--- a/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
@@ -24,7 +24,7 @@
     name:
       - edb-as{{ pg_version }}-server
       - edb-as{{ pg_version }}-server-core
-      - edb-as{{ pg_version }}-server-edb-modules
+      - edb-as{{ pg_version }}-server-edb_wait_states
       - edb-as{{ pg_version }}-server-contrib
       - edb-as{{ pg_version }}-server-libs
       - edb-as{{ pg_version }}-server-client

--- a/roles/install_dbserver/tasks/PG_Debian_install.yml
+++ b/roles/install_dbserver/tasks/PG_Debian_install.yml
@@ -41,9 +41,9 @@
       - edb-bdr{{ pgd_version }}-{{ pg_type | lower }}{{ pg_version }}-debuginfo
     state: present
   become: true
-  when: >-
-    pg_version|int >= 14
-    and install_pgd|bool
+  when:
+    - pg_version|int >= 14
+    - install_pgd|bool
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/roles/install_dbserver/tasks/PG_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_install.yml
@@ -50,9 +50,9 @@
       - edb-bdr{{ pgd_version }}-{{ pg_type | lower }}{{ pg_version }}-debuginfo
     state: present
   become: true
-  when: >-
-    pg_version|int >= 14
-    and install_pgd|bool
+  when:
+    - pg_version|int >= 14
+    - install_pgd|bool
 
 - name: Install sslutils
   ansible.builtin.package:

--- a/roles/install_dbserver/tasks/validate_install_dbserver.yml
+++ b/roles/install_dbserver/tasks/validate_install_dbserver.yml
@@ -47,7 +47,7 @@
         'edb-as' + pg_version | string + '-server', 'edb-as' + pg_version | string + '-server-core',
         'edb-as' + pg_version | string + '-server-contrib', 'edb-as' + pg_version | string + '-server-libs',
         'edb-as' + pg_version | string + '-server-client', 'edb-as' + pg_version | string + '-server-indexadvisor',
-        'edb-as' + pg_version | string + '-server-sqlprofiler', 'edb-as' + pg_version | string + '-server-sqlprotect',
+        'edb-as' + pg_version | string + '-server-sqlprofiler', 'edb-as' + pg_version | string + '-server-sqlprotect'
       ] }}
   when:
     - ansible_os_family == 'RedHat'

--- a/roles/install_dbserver/tasks/validate_install_dbserver.yml
+++ b/roles/install_dbserver/tasks/validate_install_dbserver.yml
@@ -47,7 +47,8 @@
         'edb-as' + pg_version | string + '-server', 'edb-as' + pg_version | string + '-server-core',
         'edb-as' + pg_version | string + '-server-contrib', 'edb-as' + pg_version | string + '-server-libs',
         'edb-as' + pg_version | string + '-server-client', 'edb-as' + pg_version | string + '-server-indexadvisor',
-        'edb-as' + pg_version | string + '-server-sqlprofiler', 'edb-as' + pg_version | string + '-server-sqlprotect'
+        'edb-as' + pg_version | string + '-server-sqlprofiler', 'edb-as' + pg_version | string + '-server-sqlprotect',
+        'edb-as' + pg_version | string + '-server-edb_wait_states'
       ] }}
   when:
     - ansible_os_family == 'RedHat'
@@ -92,25 +93,6 @@
     - pg_type == 'EPAS'
     - ansible_os_family == 'RedHat'
     - pg_version|int > 10
-
-- name: Add 10 < pg_version < 14 packages to EPAS RedHat package_list
-  ansible.builtin.set_fact:
-    package_list: >-
-      {{ package_list | default([]) + ['edb-as' + pg_version | string + '-server-edb-modules'] }}
-  when:
-    - pg_type == 'EPAS'
-    - ansible_os_family == 'RedHat'
-    - pg_version|int > 10
-    - pg_version|int < 14
-
-- name: Add pg_version >= 14 packages to EPAS RedHat package_list
-  ansible.builtin.set_fact:
-    package_list: >-
-      {{ package_list | default([]) + ['edb-as' + pg_version | string + '-server-edb_wait_states'] }}
-  when:
-    - pg_type == 'EPAS'
-    - ansible_os_family == 'RedHat'
-    - pg_version|int >= 14
 
 - name: Install python-apt package
   ansible.builtin.package:

--- a/roles/install_dbserver/tasks/validate_install_dbserver.yml
+++ b/roles/install_dbserver/tasks/validate_install_dbserver.yml
@@ -48,7 +48,6 @@
         'edb-as' + pg_version | string + '-server-contrib', 'edb-as' + pg_version | string + '-server-libs',
         'edb-as' + pg_version | string + '-server-client', 'edb-as' + pg_version | string + '-server-indexadvisor',
         'edb-as' + pg_version | string + '-server-sqlprofiler', 'edb-as' + pg_version | string + '-server-sqlprotect',
-        'edb-as' + pg_version | string + '-server-edb_wait_states'
       ] }}
   when:
     - ansible_os_family == 'RedHat'
@@ -88,7 +87,10 @@
 - name: Add pg_version > 10 packages to EPAS RedHat package_list
   ansible.builtin.set_fact:
     package_list: >-
-      {{ package_list | default([]) + ['edb-as' + pg_version | string + '-server-llvmjit'] }}
+      {{ package_list | default([]) + [
+        'edb-as' + pg_version | string + '-server-llvmjit',
+        'edb-as' + pg_version | string + '-server-edb_wait_states'
+      ] }}
   when:
     - pg_type == 'EPAS'
     - ansible_os_family == 'RedHat'

--- a/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
@@ -3,8 +3,10 @@
   ansible.builtin.stat:
     path: "{{ edb_auth_conf }}"
   register: auth_conf
-  when: >
-    os != 'Debian9' and enable_edb_repo|bool and repo_token|length <= 1
+  when:
+    - os != 'Debian9'
+    - enable_edb_repo|bool
+    - repo_token|length <= 1
   become: true
 
 - name: Build EDB auth conf
@@ -33,21 +35,30 @@
     state: present
   become: true
 
+- name: Install curl
+  ansible.builtin.package:
+    name: curl
+    state: present
+  become: true
+
 - name: Add EDB GPGP Debian keys
   ansible.builtin.apt_key:
     url: "{{ edb_deb_keys }}"
     state: present
   become: true
-  when: >
-    enable_edb_repo|bool and repo_token|length <= 1
+  when:
+    - enable_edb_repo|bool
+    - repo_token|length <= 1
 
 - name: Add EDB Debian repo
   ansible.builtin.apt_repository:
     repo: "{{ edb_deb_repo_url }}"
     state: present
     filename: "edb-{{ ansible_distribution_release }}"
-  when: >
-    os != 'Debian9' and enable_edb_repo|bool and repo_token|length <= 1
+  when:
+    - os != 'Debian9'
+    - enable_edb_repo|bool
+    - repo_token|length <= 1
   become: true
 
 - name: Install apt-transport-https
@@ -63,8 +74,10 @@
     repo: "{{ edb_deb_9_repo_url }}"
     state: present
     filename: "edb-{{ ansible_distribution_release }}"
-  when: >
-      os == 'Debian9' and enable_edb_repo|bool and repo_token|length <= 1
+  when:
+    - os == 'Debian9'
+    - enable_edb_repo|bool
+    - repo_token|length <= 1
   become: true
 
 - name: Add PG Debian keys
@@ -106,10 +119,10 @@
   failed_when: >
     reposub.rc != 0 or 'error: ' in reposub.stdout.lower()
   changed_when: reposub.rc == '0'
-  when: >
-    tpa_subscription_token|length > 0
-    and install_pgd|bool
-    and pg_version|int == 14
+  when:
+    - tpa_subscription_token|length > 0
+    - install_pgd|bool
+    - pg_version|int == 14
   loop: "{{ edb_2q_repositories }}"
 
 - name: Install EDB repository 2.0
@@ -123,5 +136,6 @@
   failed_when: >
     reposub.rc != 0 or 'error: ' in reposub.stdout.lower()
   changed_when: reposub.rc == '0'
-  when: >
-    enable_edb_repo|bool and repo_token|length > 1
+  when:
+    - enable_edb_repo|bool
+    - repo_token|length > 1

--- a/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_Debian_setuprepos.yml
@@ -4,7 +4,7 @@
     path: "{{ edb_auth_conf }}"
   register: auth_conf
   when: >
-    os != 'Debian9' and enable_edb_repo|bool and repo_token|length < 1
+    os != 'Debian9' and enable_edb_repo|bool and repo_token|length <= 1
   become: true
 
 - name: Build EDB auth conf
@@ -17,7 +17,7 @@
     mode: "0600"
   when:
     - os != 'Debian9'
-    - enable_edb_repo|bool and repo_token|length < 1
+    - enable_edb_repo|bool and repo_token|length <= 1
     - not auth_conf.stat.exists or auth_conf.stat.size == 0
   become: true
 
@@ -39,7 +39,7 @@
     state: present
   become: true
   when: >
-    enable_edb_repo|bool and repo_token|length < 1
+    enable_edb_repo|bool and repo_token|length <= 1
 
 - name: Add EDB Debian repo
   ansible.builtin.apt_repository:
@@ -47,7 +47,7 @@
     state: present
     filename: "edb-{{ ansible_distribution_release }}"
   when: >
-    os != 'Debian9' and enable_edb_repo|bool and repo_token|length < 1
+    os != 'Debian9' and enable_edb_repo|bool and repo_token|length <= 1
   become: true
 
 - name: Install apt-transport-https
@@ -64,7 +64,7 @@
     state: present
     filename: "edb-{{ ansible_distribution_release }}"
   when: >
-      os == 'Debian9' and enable_edb_repo|bool and repo_token|length < 1
+      os == 'Debian9' and enable_edb_repo|bool and repo_token|length <= 1
   become: true
 
 - name: Add PG Debian keys

--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -98,7 +98,7 @@
   become: true
   when:
     - enable_edb_repo|bool
-    - repo_token|length < 1
+    - repo_token|length <= 1
 
 - name: Set Credentials for EDB Yum Repo
   ansible.builtin.replace:
@@ -108,7 +108,7 @@
   become: true
   when:
     - enable_edb_repo|bool
-    - repo_token|length < 1
+    - repo_token|length <= 1
 
 - name: Add additional Redhat repositories
   ansible.builtin.yum_repository:

--- a/roles/setup_repo/tasks/validate_setup_repo.yml
+++ b/roles/setup_repo/tasks/validate_setup_repo.yml
@@ -24,7 +24,7 @@
   when:
     - ansible_os_family == 'RedHat'
     - enable_edb_repo|bool
-    - repo_token|length < 1
+    - repo_token|length <= 1
 
 - name: Check for EDB Repo 2.0 on RedHat
   ansible.builtin.assert:

--- a/tests/tests/test_install_dbserver.py
+++ b/tests/tests/test_install_dbserver.py
@@ -64,6 +64,7 @@ def test_install_dbserver_epas_centos():
         'edb-as%s-server-sqlprofiler' % pg_version,
         'edb-as%s-server-sqlprotect' % pg_version,
         'edb-as%s-server-sslutils' % pg_version,
+        'edb-as%s-server-edb_wait_states' % pg_version,
     ]
     if get_os() in ['centos7', 'oraclelinux7']:
         packages += [
@@ -79,14 +80,6 @@ def test_install_dbserver_epas_centos():
     if pg_version > 10:
         packages += [
             'edb-as%s-server-llvmjit' % pg_version,
-        ]
-    if pg_version > 10 and pg_version < 14:
-        packages += [
-            'edb-as%s-server-edb-modules' % pg_version,
-        ]
-    elif pg_version >= 14:
-        packages += [
-            'edb-as%s-server-edb_wait_states' % pg_version,
         ]
     for package in packages:
         assert host.package(package).is_installed, \

--- a/tests/tests/test_install_dbserver.py
+++ b/tests/tests/test_install_dbserver.py
@@ -64,7 +64,6 @@ def test_install_dbserver_epas_centos():
         'edb-as%s-server-sqlprofiler' % pg_version,
         'edb-as%s-server-sqlprotect' % pg_version,
         'edb-as%s-server-sslutils' % pg_version,
-        'edb-as%s-server-edb_wait_states' % pg_version,
     ]
     if get_os() in ['centos7', 'oraclelinux7']:
         packages += [
@@ -80,6 +79,7 @@ def test_install_dbserver_epas_centos():
     if pg_version > 10:
         packages += [
             'edb-as%s-server-llvmjit' % pg_version,
+            'edb-as%s-server-edb_wait_states' % pg_version,
         ]
     for package in packages:
         assert host.package(package).is_installed, \


### PR DESCRIPTION
Fixes EPAS <= 13 package validation of `edb-as1x-server-edb-modules, which installs `edb-as1x-server-edb_wait_states` on RedHat only, to recognize the `edb_wait_states` package instead of the `edb-modules` package. 

Also fixes within the `setup_repo` role, when no `repo_token` is provided in the new testing setup, which allows users to optionally pass a repo token in, it sees the `repo_token` variable as a blank string of length 1. To accurately not skip over these tasks, the conditional has been made inclusive of 1 instead of exclusive of 1. 