### PR TITLE
setup_dbt2: remove flame graph installation

### DIFF
--- a/roles/setup_dbt2/tasks/dbt2_install_packages_driver.yml
+++ b/roles/setup_dbt2/tasks/dbt2_install_packages_driver.yml
@@ -1,18 +1,4 @@
 ---
-- name: Download stackcollapse-perf.pl
-  ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/brendangregg/FlameGraph/master/stackcollapse-perf.pl
-    dest: /usr/bin/stackcollapse-perf.pl
-    mode: '0755'
-  become: true
-
-- name: Download flamegraph.pl
-  ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/brendangregg/FlameGraph/master/flamegraph.pl
-    dest: /usr/bin/flamegraph.pl
-    mode: '0755'
-  become: true
-
 - name: Install DBT-2 Driver supporting packages
   ansible.builtin.package:
     name:


### PR DESCRIPTION
These are provided by the dbt2 appimage.  No longer need to install them separately.