### PR TITLE
setup_dbt2: make sure hostssl rules exist for driver and client conne…

### DIFF
--- a/roles/setup_dbt2/tasks/dbt2_update_pg_hba.yml
+++ b/roles/setup_dbt2/tasks/dbt2_update_pg_hba.yml
@@ -1,56 +1,59 @@
 ---
-- name: Gather DBT-2 client addresses
-  ansible.builtin.set_fact:
-    dbt2client_item: >-
-      {
-        'users': 'all',
-        'databases': 'all',
-        'contype': 'host',
-        'source': '{{ hostvars[item]['private_ip'] }}/32',
-        'method': 'trust'
-      }
+# Cannot use manage_dbserver.manage_hba_conf because it uses
+# community.postgresql.postgresql_pg_hba, which does not let us create a host
+# and hostssl line for the same source because contype is not part of the
+# unique identifier that community.postgresql.postgresql_pg_hba uses.
+
+- name: Find the hba file location
+  community.postgresql.postgresql_query:
+    login_user: "{{ pg_owner }}"
+    port: "{{ pg_port }}"
+    login_unix_socket: "{{ pg_unix_socket_directories[0] }}"
+    query: "show hba_file;"
+    db: "{{ pg_database }}"
+  become: true
+  become_user: "{{ pg_owner }}"
+  no_log: "{{ disable_logging }}"
+  register: hba_info
+
+- name: Update pg_hba.conf with DBT-2 client host connections
+  ansible.builtin.lineinfile:
+    path: "{{ hba_info.query_result[0].hba_file }}"
+    line: "host all all {{ hostvars[item]['private_ip'] }}/32 trust"
+    create: true
   with_items: "{{ groups['dbt2_client'] }}"
+  become: true
+  become_user: "{{ pg_owner }}"
   when: "'dbt2_client' in groups"
-  register: dbt2client_list
+  no_log: "{{ disable_logging }}"
 
-- name: Gather DBT-2 driver addresses
-  ansible.builtin.set_fact:
-    dbt2driver_item: >-
-      {
-        'users': 'all',
-        'databases': 'all',
-        'contype': 'host',
-        'source': '{{ hostvars[item]['private_ip'] }}/32',
-        'method': 'trust'
-      }
+- name: Update pg_hba.conf with DBT-2 client hostssl connections
+  ansible.builtin.lineinfile:
+    path: "{{ hba_info.query_result[0].hba_file }}"
+    line: "hostssl all all {{ hostvars[item]['private_ip'] }}/32 trust"
+    create: true
+  with_items: "{{ groups['dbt2_client'] }}"
+  become: true
+  become_user: "{{ pg_owner }}"
+  when: "'dbt2_client' in groups"
+  no_log: "{{ disable_logging }}"
+
+- name: Update pg_hba.conf with DBT-2 driver host connections
+  ansible.builtin.lineinfile:
+    path: "{{ hba_info.query_result[0].hba_file }}"
+    line: "host all all {{ hostvars[item]['private_ip'] }}/32 trust"
+    create: true
   with_items: "{{ groups['dbt2_driver'] }}"
-  register: dbt2driver_list
+  become: true
+  become_user: "{{ pg_owner }}"
+  no_log: "{{ disable_logging }}"
 
-- name: Make a list of DBT-2 client addresses
-  ansible.builtin.set_fact:
-    hba_entries: "{{ dbt2client_list.results | map(attribute='ansible_facts.dbt2client_item') | list }}"
-  when: "'dbt2_client' in groups"
-
-- name: Make a list of DBT-2 driver addresses
-  ansible.builtin.set_fact:
-    hba_entries_driver: "{{ dbt2driver_list.results | map(attribute='ansible_facts.dbt2driver_item') | list }}"
-
-- name: Update pg_hba.conf for access from the DBT-2 clients' private IP addresses
-  ansible.builtin.include_role:
-    name: manage_dbserver
-    tasks_from: manage_hba_conf
-  vars:
-    pg_hba_ip_addresses: "{{ hba_entries }}"
-  when: "'dbt2_client' in groups"
-
-- name: Update pg_hba.conf for access from the DBT-2 drivers' private IP addresses
-  ansible.builtin.include_role:
-    name: manage_dbserver
-    tasks_from: manage_hba_conf
-  vars:
-    pg_hba_ip_addresses: "{{ hba_entries_driver }}"
-
-- name: Reset hba_entries
-  ansible.builtin.set_fact:
-    hba_entries: []
-    hba_entries_driver: []
+- name: Update pg_hba.conf with DBT-2 driver hostssl connections
+  ansible.builtin.lineinfile:
+    path: "{{ hba_info.query_result[0].hba_file }}"
+    line: "hostssl all all {{ hostvars[item]['private_ip'] }}/32 trust"
+    create: true
+  with_items: "{{ groups['dbt2_driver'] }}"
+  become: true
+  become_user: "{{ pg_owner }}"
+  no_log: "{{ disable_logging }}"


### PR DESCRIPTION
…ctions

This hopefully covers all default connection behavior by setting host and hostssl rules for any PostgreSQL clients programs used by DBT-2. The default behavior seems to vary for one reason or another.

Cannot use manage_dbserver.manage_hba_conf because it uses community.postgresql.postgresql_pg_hba, which does not let us create a host and hostssl line for the same source because contype is not part of the unique identifier that community.postgresql.postgresql_pg_hba uses.