### PR TITLE
minor updates to ensure patroni running smoothly

### DIFF
--- a/roles/manage_dbserver/handlers/main.yml
+++ b/roles/manage_dbserver/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
+# needs to be run with become: true because of daemon_reload
 - name: Reload the pg service
   ansible.builtin.systemd:
     name: "{{ pg_service }}"
     daemon_reload: true
     state: reloaded
+  become: true

--- a/roles/setup_patroni/tasks/patroni_generate_basic_passwords.yml
+++ b/roles/setup_patroni/tasks/patroni_generate_basic_passwords.yml
@@ -8,12 +8,14 @@
     input_password: "{{ pg_superuser_password }}"
   no_log: "{{ disable_logging }}"
   when: pg_superuser_password|length < 1
+  run_once: true
 
 - name: Set pg_superuser_password
   ansible.builtin.set_fact:
     pg_superuser_password: "{{ input_password }}"
   no_log: "{{ disable_logging }}"
   when: pg_superuser_password|length < 1
+  run_once: true
 
 - name: Add superuser password in pgpass
   ansible.builtin.include_role:
@@ -25,6 +27,7 @@
         password: "{{ pg_superuser_password }}"
         create: true
   no_log: "{{ disable_logging }}"
+  run_once: true
 
 - name: Generate the pg_replication_user_password
   ansible.builtin.include_role:
@@ -35,12 +38,14 @@
     input_password: "{{ pg_replication_user_password }}"
   no_log: "{{ disable_logging }}"
   when: pg_replication_user_password|length < 1
+  run_once: true
 
 - name: Set pg_replication_user_password
   ansible.builtin.set_fact:
     pg_replication_user_password: "{{ input_password }}"
   no_log: "{{ disable_logging }}"
   when: pg_replication_user_password|length < 1
+  run_once: true
 
 - name: Add replication password in pgpass
   ansible.builtin.include_role:
@@ -52,6 +57,7 @@
         password: "{{ pg_replication_user_password }}"
         create: true
   no_log: "{{ disable_logging }}"
+  run_once: true
 
 - name: Generate the pg_rewind_user_password
   ansible.builtin.include_role:
@@ -62,12 +68,14 @@
     input_password: "{{ pg_rewind_user_password }}"
   no_log: "{{ disable_logging }}"
   when: pg_rewind_user_password|length < 1
+  run_once: true
 
 - name: Set pg_rewind_user_password
   ansible.builtin.set_fact:
     pg_rewind_user_password: "{{ input_password }}"
   no_log: "{{ disable_logging }}"
   when: pg_rewind_user_password|length < 1
+  run_once: true
 
 - name: Add rewind password in pgpass
   ansible.builtin.include_role:
@@ -79,3 +87,4 @@
         password: "{{ pg_rewind_user_password }}"
         create: true
   no_log: "{{ disable_logging }}"
+  run_once: true

--- a/roles/setup_patroni/tasks/patroni_set_user_passwords_privs.yml
+++ b/roles/setup_patroni/tasks/patroni_set_user_passwords_privs.yml
@@ -7,12 +7,14 @@
     input_user: "{{ pg_superuser }}"
     input_password: "{{ pg_superuser_password }}"
   no_log: "{{ disable_logging }}"
+  run_once: true
   when: pg_superuser_password|length < 1
 
 - name: Set pg_superuser_password
   ansible.builtin.set_fact:
     pg_superuser_password: "{{ input_password }}"
   no_log: "{{ disable_logging }}"
+  run_once: true
   when: pg_superuser_password|length < 1
 
 - name: Set postgres superuser's database cluster password
@@ -24,6 +26,7 @@
       - name: "{{ pg_superuser }}"
         pass: "{{ pg_superuser_password }}"
   no_log: "{{ disable_logging }}"
+  run_once: true
 
 - name: Set postgres replication database cluster password
   ansible.builtin.include_role:
@@ -35,6 +38,7 @@
         pass: "{{ pg_replication_user_password }}"
         role_attr_flags: replication
   no_log: "{{ disable_logging }}"
+  run_once: true
 
 - name: Set postgres rewind database cluster password
   ansible.builtin.include_role:
@@ -45,6 +49,7 @@
       - name: "{{ pg_rewind_user }}"
         pass: "{{ pg_rewind_user_password }}"
   no_log: "{{ disable_logging }}"
+  run_once: true
 
 - name: Grant minimum privileges to rewind user for rewind
   ansible.builtin.include_role:
@@ -65,6 +70,7 @@
         roles: "{{ pg_rewind_user }}"
         database: "{{ pg_database }}"
   no_log: "{{ disable_logging }}"
+  run_once: true
 
 - name: Set postgres primary_slot_name
   ansible.builtin.include_role:
@@ -79,3 +85,4 @@
     - pg_version|int > 11
     - use_replication_slots
   no_log: "{{ disable_logging }}"
+  run_once: true

--- a/roles/setup_patroni/tasks/primary_synchronous_param.yml
+++ b/roles/setup_patroni/tasks/primary_synchronous_param.yml
@@ -35,3 +35,19 @@
         value: "{{ synchronous_standby_names }}"
   when: synchronous_standby_names|length > 0
   no_log: "{{ disable_logging }}"
+
+# restart here otherwise cluster will start with restart required on primary
+# execute restart here to flush out any pending restart requirement
+- name: Restart postgres after change of postgresql parameters
+  ansible.builtin.shell: >
+    {{ patroni_bin_dir }}/patronictl -c {{ patroni_config_file }} \
+        restart {{ pg_instance_name }} {{ inventory_hostname }} --force
+  args:
+    executable: /bin/bash
+  register: patronictl_exec
+  changed_when: patronictl_exec.rc == 0
+  failed_when: patronictl_exec.rc != 0
+  when:
+    - not pg_version_stat.stat.exists
+  become_user: "{{ pg_owner }}"
+  become: true

--- a/roles/setup_patroni/tasks/setup_patroni.yml
+++ b/roles/setup_patroni/tasks/setup_patroni.yml
@@ -150,11 +150,10 @@
 
 - name: Update primary for synchronous replication
   ansible.builtin.import_tasks: primary_synchronous_param.yml
-  when: >-
-      _synchronous_standbys is defined and (
-      _synchronous_standbys|length > 0
-      or synchronous_standby_names|length > 0 )
-      and 'primary' in group_names and not validate_only|bool
+  when:
+    - synchronous_standby_names|length > 0 or (_synchronous_standbys is defined and _synchronous_standbys|length > 0)
+    - "'primary' in group_names"
+    - not validate_only|bool
   run_once: true
   no_log: "{{ disable_logging }}"
 

--- a/roles/setup_patroni/tasks/validate_setup_patroni.yml
+++ b/roles/setup_patroni/tasks/validate_setup_patroni.yml
@@ -105,6 +105,7 @@
       - patroni_stat_query_result.results[0].query_result|length == patroni_standby_list|length
     fail_msg: "Replication was not successful on primary"
     success_msg: "Replication was successful on primary"
+  run_once: true
   when: patroni_standby_list|length > 0
 
 # validate patroni wal receiver - on standby's

--- a/roles/setup_patroni/templates/patroni.config.yml.j2
+++ b/roles/setup_patroni/templates/patroni.config.yml.j2
@@ -40,7 +40,7 @@ bootstrap:
     {% endfor %}
 
 postgresql:
-  listen: "0.0.0.0:{{ pg_port }}"
+  listen: "*"
   connect_address: "{{ hostvars[inventory_hostname].private_ip }}:{{ pg_port }}"
   use_unix_socket: true
   data_dir: "{{ pg_data }}"

--- a/roles/setup_patroni/templates/postgresql.conf.template
+++ b/roles/setup_patroni/templates/postgresql.conf.template
@@ -3,7 +3,7 @@
 unix_socket_directories = '{{ pg_unix_socket_directories | join(",") }}'
 port = {{ pg_port }}
 listen_addresses = '*'
-wal_level = replica
+wal_level = logical
 max_wal_senders = 10
 hot_standby = on
 max_replication_slots = 10


### PR DESCRIPTION
made some minor updates to ensure Patroni is running smoothly while benchmarking. 

- Updated `manage_dbserver/handlers/main.yml` to include a `become: true` parameter; this is required because the parameter `daemon_reload: true` requires root priviliges. 
- Updated `patroni.config.yml.j2` to set the postgresql `listen: "*"` as this parameter must match the `listen_addresses = '*'` parameter set in `postgresql.auto.conf` otherwise Patroni thinks you are trying to change the listen address.
- Updated `postgresql.conf.template` to sync up the `wal_level: logical` set in `patroni.config.yml.j2` and now is a default in the `init_dbserver` role. 
- Added `run_once: true` to more validate tasks and tasks within `patroni_generate_basic_password.yml` and `patroni_set_user_password_privs.yml`.
- Added an additional cluster restart within `primary_synchronous_params.yml` to ensure the cluster starts without the `restart required` label on primary. 