### PR TITLE
More patroni setup

### DIFF
--- a/roles/init_dbserver/tasks/validate_init_dbserver.yml
+++ b/roles/init_dbserver/tasks/validate_init_dbserver.yml
@@ -67,7 +67,7 @@
   ansible.builtin.wait_for:
     port: "{{ pg_port }}"
     state: started
-    msg: "Port {{ pg_port }} is not listening."
+    msg: "Port {{ pg_port }} is listening."
   become: true
 
 - name: Check pg_unix_socket_directories socket

--- a/roles/setup_etcd/README.md
+++ b/roles/setup_etcd/README.md
@@ -102,7 +102,7 @@ Below is an example of how to include the `setup_etcd` role:
   pre_tasks:
     - name: Initialize the user defined variables
       set_fact:
-        etcd_version: 3.5.6
+        etcd_version: 3.5.7
         etcd_architecture: "amd64"
 
   roles:

--- a/roles/setup_patroni/defaults/main.yml
+++ b/roles/setup_patroni/defaults/main.yml
@@ -66,25 +66,6 @@ pg_init_conf_params: []
 # postgres port
 pg_port: 5432
 
-# certain parameters must be placed in the DCS parameters for patroni to recognize
-# it will overide any values in postgresql.conf and postgresql.auto.conf for the following parameters:
-#  - max_wal_senders: 5
-#  - max_replication_slots: 5
-#  - wal_keep_segments: 8
-#  - wal_keep_size: '128MB'
-# to override these values, place parameters and value in patroni_pg_init_params
-# parameters to be configured in postgresql params in patroni DCS config file
-# will be placed:
-# postgresql:
-#   parameters:
-#     - wal_keep_segments: '32'
-# ----- example:
-# patroni_pg_init_params:
-#  - name: 'wal_keep_segments'
-#    value: '32'
-
-patroni_pg_init_params: ""
-
 # postgres database
 pg_database: "postgres"
 

--- a/roles/setup_patroni/defaults/main.yml
+++ b/roles/setup_patroni/defaults/main.yml
@@ -66,6 +66,25 @@ pg_init_conf_params: []
 # postgres port
 pg_port: 5432
 
+# certain parameters must be placed in the DCS parameters for patroni to recognize
+# it will overide any values in postgresql.conf and postgresql.auto.conf for the following parameters:
+#  - max_wal_senders: 5
+#  - max_replication_slots: 5
+#  - wal_keep_segments: 8
+#  - wal_keep_size: '128MB'
+# to override these values, place parameters and value in patroni_pg_init_params
+# parameters to be configured in postgresql params in patroni DCS config file
+# will be placed:
+# postgresql:
+#   parameters:
+#     - wal_keep_segments: '32'
+# ----- example:
+# patroni_pg_init_params:
+#  - name: 'wal_keep_segments'
+#    value: '32'
+
+patroni_pg_init_params: ""
+
 # postgres database
 pg_database: "postgres"
 

--- a/roles/setup_patroni/tasks/patroni_generate_basic_passwords.yml
+++ b/roles/setup_patroni/tasks/patroni_generate_basic_passwords.yml
@@ -27,7 +27,6 @@
         password: "{{ pg_superuser_password }}"
         create: true
   no_log: "{{ disable_logging }}"
-  run_once: true
 
 - name: Generate the pg_replication_user_password
   ansible.builtin.include_role:
@@ -57,7 +56,6 @@
         password: "{{ pg_replication_user_password }}"
         create: true
   no_log: "{{ disable_logging }}"
-  run_once: true
 
 - name: Generate the pg_rewind_user_password
   ansible.builtin.include_role:
@@ -87,4 +85,3 @@
         password: "{{ pg_rewind_user_password }}"
         create: true
   no_log: "{{ disable_logging }}"
-  run_once: true

--- a/roles/setup_patroni/tasks/primary_synchronous_param.yml
+++ b/roles/setup_patroni/tasks/primary_synchronous_param.yml
@@ -35,19 +35,3 @@
         value: "{{ synchronous_standby_names }}"
   when: synchronous_standby_names|length > 0
   no_log: "{{ disable_logging }}"
-
-# restart here otherwise cluster will start with restart required on primary
-# execute restart here to flush out any pending restart requirement
-- name: Restart postgres after change of postgresql parameters
-  ansible.builtin.shell: >
-    {{ patroni_bin_dir }}/patronictl -c {{ patroni_config_file }} \
-        restart {{ pg_instance_name }} {{ inventory_hostname }} --force
-  args:
-    executable: /bin/bash
-  register: patronictl_exec
-  changed_when: patronictl_exec.rc == 0
-  failed_when: patronictl_exec.rc != 0
-  when:
-    - not pg_version_stat.stat.exists
-  become_user: "{{ pg_owner }}"
-  become: true

--- a/roles/setup_patroni/tasks/validate_setup_patroni.yml
+++ b/roles/setup_patroni/tasks/validate_setup_patroni.yml
@@ -1,4 +1,9 @@
 ---
+# validation of replication on primary will fail if not given time to reload and settle
+- name: Pause for few seconds for postgres to be available
+  ansible.builtin.pause:
+    seconds: 30
+
 - name: Prepare primary_private_ip
   ansible.builtin.set_fact:
     primary_private_ip: "{{ node.private_ip }}"

--- a/roles/setup_patroni/templates/patroni.config.yml.j2
+++ b/roles/setup_patroni/templates/patroni.config.yml.j2
@@ -46,6 +46,15 @@ postgresql:
   data_dir: "{{ pg_data }}"
   bin_dir: "{{ pg_bin_path }}"
   pgpass: {{ pgpass_file }}
+  create_replica_methods:
+    - basebackup
+  basebackup:
+    - write-recovery-conf
+    - checkpoint: 'fast'
+    - label: 'standby'
+{% if pg_wal|length > 0 and pg_data not in pg_wal %}
+    - waldir: {{ pg_wal }}
+{% endif %}
   authentication:
     replication:
       username: {{ pg_replication_user }}
@@ -53,6 +62,12 @@ postgresql:
       username: {{ pg_superuser }}
     pg_rewind:
       username: {{ pg_rewind_user }}
+{% if patroni_pg_init_params|length > 0 %}
+  parameters:
+{% for param in patroni_pg_init_params -%}
+    - {{ param.name }}: '{{ param.value }}'
+{% endfor %}
+{% endif %}
 tags:
   nosync: false
 log:

--- a/roles/setup_patroni/templates/patroni.config.yml.j2
+++ b/roles/setup_patroni/templates/patroni.config.yml.j2
@@ -62,12 +62,6 @@ postgresql:
       username: {{ pg_superuser }}
     pg_rewind:
       username: {{ pg_rewind_user }}
-{% if patroni_pg_init_params|length > 0 %}
-  parameters:
-{% for param in patroni_pg_init_params -%}
-    - {{ param.name }}: '{{ param.value }}'
-{% endfor %}
-{% endif %}
 tags:
   nosync: false
 log:

--- a/tests/cases/setup_patroni/vars.json
+++ b/tests/cases/setup_patroni/vars.json
@@ -2,10 +2,4 @@
   "use_hostname": false,
   "pg_data": "/opt/pg_data/pgdata",
   "pg_wal": "/opt/pg_wal/pgwal",
-  "patroni_pg_init_params": [
-    {
-      "name": "wal_keep_segments",
-      "value": "32"
-    }
-  ]
 }

--- a/tests/cases/setup_patroni/vars.json
+++ b/tests/cases/setup_patroni/vars.json
@@ -1,5 +1,11 @@
 {
   "use_hostname": false,
   "pg_data": "/opt/pg_data/pgdata",
-  "pg_wal": "/opt/pg_wal/pgwal"
+  "pg_wal": "/opt/pg_wal/pgwal",
+  "patroni_pg_init_params": [
+    {
+      "name": "wal_keep_segments",
+      "value": "32"
+    }
+  ]
 }


### PR DESCRIPTION
- Fixes some run errors from wrong changes yesterday - reverting by removing `run_once: true`
- Add pg_basebackup options to Patroni config file - task was timing out and causing the setup to fail and added the `- checkpoint: ‘fast’` to run the basebackup faster
- Documented changes in code 