### PR TITLE
add dynamic postgres params in patroni config

### DIFF
--- a/roles/setup_patroni/README.md
+++ b/roles/setup_patroni/README.md
@@ -27,20 +27,47 @@ The requirements for this ansible galaxy role are:
 
 When executing the role via ansible there are three required variables:
 
-  * ***os***
+### os
 
-  Operating Systems supported are: CentOS7, RHEL7, CentOS8, RHEL8, AlmaLinux8, Debian10 and Ubuntu20
+Operating Systems supported are: CentOS7, RHEL7, CentOS8, RHEL8, AlmaLinux8, Debian10 and Ubuntu20
 
-  * ***pg_version***
+### pg_version
 
-  Postgres Versions supported are: 10, 11, 12, 13, 14 and 15
+Postgres Versions supported are: 10, 11, 12, 13, 14 and 15
 
-  * ***pg_type***
+### pg_type
 
   Database Engine supported are: PG and EPAS
 
+### patroni_pg_init_params
+
+Certain parameters are restricted by Patroni and are required to be set in the Patroni DCS configuration file.
+These parameters and their Patroni defaults are: 
+* `max_wal_senders: 5` 
+* `max_replication_slots: 5` 
+* `wal_keep_segments: 8`
+* `wal_keep_size: 128MB`
+
+[Learn more about PostgreSQL parameters controlled by Patroni](https://patroni.readthedocs.io/en/latest/patroni_configuration.html#important-rules).
+
+Using this parameter you can customize these and other Postgres parameters in the Patroni DCS config file.
+*Note*: To ensure the playbook runs successfully, input parameter names and values as strings.
+
+Example:
+```yaml
+patroni_pg_init_params:
+  - name: 'max_keep_segments'
+    value: '32'
+```
+The resulting Patroni DCS config will appear as such:
+```yaml
+postgresql:
+  parameters:
+    max_keep_segments: '32'
+```
+
 These and other variables can be assigned in the `pre_tasks` definition of the
-section: *How to include the `setup_patroni` role in your Playbook*
+section: [How to include the `setup_patroni` role in your Playbook](#how-to-include-the-setuppatroni-role-in-your-playbook)
 
 The rest of the variables can be configured and are available in the:
 
@@ -112,6 +139,9 @@ Below is an example of how to include the `setup_patroni` role:
         pg_type: "PG"
         pg_version: 14
         use_patroni: true
+        patroni_pg_init_params:
+          - name: 'max_keep_size'
+            value: '160'
 
   roles:
     - role: setup_repo

--- a/roles/setup_patroni/defaults/main.yml
+++ b/roles/setup_patroni/defaults/main.yml
@@ -66,6 +66,25 @@ pg_init_conf_params: []
 # postgres port
 pg_port: 5432
 
+# certain parameters must be placed in the DCS parameters for patroni to recognize
+# it will overide any values in postgresql.conf and postgresql.auto.conf for the following parameters:
+#  - max_wal_senders: 5
+#  - max_replication_slots: 5
+#  - wal_keep_segments: 8
+#  - wal_keep_size: '128MB'
+# to override these values, place parameters and value in patroni_pg_init_params
+# parameters to be configured in postgresql params in patroni DCS config file
+# will be placed:
+# postgresql:
+#   parameters:
+#     - wal_keep_segments: '32'
+# ----- example:
+# patroni_pg_init_params:
+#  - name: 'wal_keep_segments'
+#    value: '32'
+
+patroni_pg_init_params: ""
+
 # postgres database
 pg_database: "postgres"
 

--- a/roles/setup_patroni/tasks/patroni_configure.yml
+++ b/roles/setup_patroni/tasks/patroni_configure.yml
@@ -1,4 +1,20 @@
 ---
+- name: Set patroni_pg_init_params_list
+  ansible.builtin.set_fact:
+    patroni_pg_init_params_list: >-
+      {{ patroni_pg_init_params_list | default([]) + [
+        {
+          "name": parameter.name,
+          "value": parameter.value
+        }
+      ] }}
+  when: patroni_pg_init_params|length > 0
+  with_items: "{{ patroni_pg_init_params }}"
+  loop_control:
+    loop_var: parameter
+  run_once: true
+  no_log: "{{ disable_logging }}"
+
 - name: Create patroni configuration file
   ansible.builtin.template:
     src: patroni.config.yml.j2
@@ -7,6 +23,7 @@
     group: "{{ pg_group }}"
     mode: "0600"
   become: true
+  no_log: "{{ disable_logging }}"
 
 - name: Create patroni unit file
   ansible.builtin.template:

--- a/roles/setup_patroni/templates/patroni.config.yml.j2
+++ b/roles/setup_patroni/templates/patroni.config.yml.j2
@@ -52,6 +52,8 @@ postgresql:
     - write-recovery-conf
     - checkpoint: 'fast'
     - label: 'standby'
+    - create-slot
+    - slot: "{{ inventory_hostname | regex_replace('[^a-zA-Z0-9_]', '_') }}"
 {% if pg_wal|length > 0 and pg_data not in pg_wal %}
     - waldir: {{ pg_wal }}
 {% endif %}
@@ -62,6 +64,13 @@ postgresql:
       username: {{ pg_superuser }}
     pg_rewind:
       username: {{ pg_rewind_user }}
+{% if patroni_pg_init_params|length > 0 %}
+  parameters:
+  {% for param in patroni_pg_init_params_list %}
+    {{ param.name }}: "{{ param.value }}"
+  {% endfor %}
+{% endif %}
+
 tags:
   nosync: false
 log:

--- a/tests/cases/setup_patroni/vars.json
+++ b/tests/cases/setup_patroni/vars.json
@@ -2,4 +2,14 @@
   "use_hostname": false,
   "pg_data": "/opt/pg_data/pgdata",
   "pg_wal": "/opt/pg_wal/pgwal",
+  "patroni_pg_init_params": [
+    {
+      "name": "wal_keep_segments",
+      "value": "32"
+    },
+    {
+      "name": "wal_keep_size",
+      "value": "160"
+    }
+  ]
 }


### PR DESCRIPTION
Certain postgres parameters must be set in the Patroni configuration file otherwise they will be overridden by Patroni default values. To allow customization of these parameters, the `patroni_pg_init_params` variable is added and the parameters listed, if any, are included in the PostgreSQL parameters section of the Patroni config file. 
The README has been updated to include information about the default settings, how and why to customize, what the resulting setting will look like in the config file, and links back to the Patroni documentation _Patroni configuation important rules_.

Under the `basebackup` method section in the Patroni config file, the `--create-slot` and `--slot inventory_hostname` `pg_basebackup` parameters have also been added because the log file showed it was recreating the slots perpetually, so explicitly listing out to create them removes the amount of junk in the log file.