### PR TITLE
setup_dbt2 dbt2_configure_pgpass: fix logic

### DIFF
--- a/roles/setup_dbt2/tasks/dbt2_configure_pgpass.yml
+++ b/roles/setup_dbt2/tasks/dbt2_configure_pgpass.yml
@@ -14,27 +14,10 @@
     pg_superuser_password: "{{ input_password }}"
   when: pg_superuser_password|length < 1
 
-- name: Generate .pgpass file for the DBT-2
-  ansible.builtin.template:
-    dest: "{{ pg_user_home }}/.pgpass"
+- name: Add entry to pgpass file for the DBT-2 user
+  ansible.builtin.lineinfile:
+    path: "{{ pg_user_home }}/.pgpass"
     mode: "0600"
-    src: pgpass.template
-  vars:
-    pg_superuser_override: "{{ pg_owner }}"
-    pg_superuser_password_override: "{{ pg_superuser_password }}"
+    line: "*:*:*:{{ pg_owner }}:{{ pg_superuser_password }}"
+    create: true
   become_user: "{{ pg_owner }}"
-  when:
-    - azure_db_hackery is defined and azure_db_hackery|bool
-
-- name: Add superuser password in pgpass
-  ansible.builtin.include_role:
-    name: manage_dbserver
-    tasks_from: manage_pgpass
-  vars:
-    pg_pgpass_values:
-      - user: "{{ pg_superuser }}"
-        password: "{{ pg_superuser_password }}"
-        create: true
-  when:
-    - (azure_db_hackery is defined and not azure_db_hackery|bool) or (azure_db_hackery is not defined)
-  no_log: "{{ disable_logging }}"

--- a/roles/setup_dbt2/templates/pgpass.template
+++ b/roles/setup_dbt2/templates/pgpass.template
@@ -1,5 +1,0 @@
-{% if azure_db_hackery is defined and azure_db_hackery %}
-*:*:*:{{ pg_superuser_connect }}:{{ pg_superuser_password_override | default(pg_superuser_password, true) }}
-{% else %}
-*:*:*:{{ pg_superuser_override | default(pg_superuser, true) }}:{{ pg_superuser_password_override | default(pg_superuser_password, true) }}
-{% endif %}


### PR DESCRIPTION
Fix two issues:

Don't overwrite an exist .pgpass file.  This playbook previously wasn't taking into consideration that the .pgpass file it is editing was already exist of not, always override it with a template.  Using ansible.builtin.lineinfile is hopefully the best way to handle that.

Don't assume we're not a DBaaS system.  manage_dbserver playbooks will fail if we're setting up a system that is testing a DBaaS database.  The ansible.builtin.lineinfile task should be able to handle both cases appropriates.