### PR TITLE
Add rhel9/rocky9 support

### DIFF
--- a/roles/execute_binary_upgrade/defaults/main.yml
+++ b/roles/execute_binary_upgrade/defaults/main.yml
@@ -50,6 +50,7 @@ supported_os:
   - CentOS8
   - RedHat7
   - RedHat8
+  - RedHat9
   - Ubuntu20
   - Debian9
   - Debian10

--- a/roles/execute_binary_upgrade/defaults/main.yml
+++ b/roles/execute_binary_upgrade/defaults/main.yml
@@ -54,6 +54,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/execute_binary_upgrade/tasks/EPAS_install.yml
+++ b/roles/execute_binary_upgrade/tasks/EPAS_install.yml
@@ -12,7 +12,7 @@
     - ansible_distribution_major_version == '7'
   become: true
 
-- name: Install python packages on EL8
+- name: Install python packages on EL8 and EL9
   ansible.builtin.package:
     name:
       - python3-pip
@@ -20,7 +20,7 @@
     state: present
   when:
     - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version == '8'
+    - ansible_distribution_major_version in ['8', '9']
   become: true
 
 - name: Install EPAS >= 11 packages on RedHat

--- a/roles/execute_binary_upgrade/tasks/PG_install.yml
+++ b/roles/execute_binary_upgrade/tasks/PG_install.yml
@@ -12,7 +12,7 @@
   become: true
   when:
     - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version == '8'
+    - ansible_distribution_major_version in ['8', '9']
 
 - name: Install require python package on EL7
   ansible.builtin.package:
@@ -27,7 +27,7 @@
     - ansible_distribution_major_version == '7'
   become: true
 
-- name: Install require python package on EL8
+- name: Install require python package on EL8 and EL9
   ansible.builtin.package:
     name:
       - python3-pycurl
@@ -37,7 +37,7 @@
   become: true
   when:
     - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version == '8'
+    - ansible_distribution_major_version in ['8', '9']
 
 - name: Install Postgres on RedHat
   ansible.builtin.package:

--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -110,6 +110,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -106,6 +106,7 @@ supported_os:
   - CentOS8
   - RedHat7
   - RedHat8
+  - RedHat9
   - Ubuntu20
   - Debian9
   - Debian10

--- a/roles/install_dbserver/defaults/main.yml
+++ b/roles/install_dbserver/defaults/main.yml
@@ -41,6 +41,7 @@ supported_os:
   - CentOS8
   - RedHat7
   - RedHat8
+  - RedHat9
   - Ubuntu20
   - Debian9
   - Debian10

--- a/roles/install_dbserver/defaults/main.yml
+++ b/roles/install_dbserver/defaults/main.yml
@@ -45,6 +45,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_install.yml
@@ -10,13 +10,13 @@
   when: ansible_distribution_major_version == '7'
   become: true
 
-- name: Install python packages on EL8
+- name: Install python packages on EL8 and EL9
   ansible.builtin.package:
     name:
       - python3-pip
       - python3-psycopg2
     state: present
-  when: ansible_distribution_major_version == '8'
+  when: ansible_distribution_major_version in ['8', '9']
   become: true
 
 - name: "Install EPAS 10 packages"

--- a/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/EPAS_RedHat_rm_install.yml
@@ -52,11 +52,11 @@
   when: ansible_distribution_major_version == '7'
   become: true
 
-- name: Remove python packages on EL8
+- name: Remove python packages on EL8 and EL9
   ansible.builtin.package:
     name:
       - python3-pip
       - python3-psycopg2
     state: absent
-  when: ansible_distribution_major_version == '8'
+  when: ansible_distribution_major_version in ['8', '9']
   become: true

--- a/roles/install_dbserver/tasks/PG_RedHat_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_install.yml
@@ -9,7 +9,7 @@
   failed_when: disable_builtin_postgres.rc != 0
   ignore_errors: true
   become: true
-  when: ansible_distribution_major_version == '8'
+  when: ansible_distribution_major_version in ['8', '9']
 
 - name: Install require python package on EL7
   ansible.builtin.package:
@@ -22,7 +22,7 @@
   when: ansible_distribution_major_version == '7'
   become: true
 
-- name: Install require python package on EL8
+- name: Install require python package on EL8 and EL9
   ansible.builtin.package:
     name:
       - python3-pycurl
@@ -30,7 +30,7 @@
       - python3-psycopg2
     state: present
   become: true
-  when: ansible_distribution_major_version == '8'
+  when: ansible_distribution_major_version in ['8', '9']
 
 - name: Install Postgres
   ansible.builtin.package:

--- a/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
@@ -22,7 +22,7 @@
   when: ansible_distribution_major_version == '7'
   become: true
 
-- name: Remove require python package on EL8
+- name: Remove require python package on EL8 and EL9
   ansible.builtin.package:
     name:
       - python3-pycurl
@@ -30,7 +30,7 @@
       - python3-psycopg2
     state: absent
   become: true
-  when: ansible_distribution_major_version == '8'
+  when: ansible_distribution_major_version in ['8', '9']
 
 - name: Remove Postgres
   ansible.builtin.package:

--- a/roles/install_dbserver/tasks/validate_install_dbserver.yml
+++ b/roles/install_dbserver/tasks/validate_install_dbserver.yml
@@ -38,7 +38,7 @@
   when:
     - pg_type == 'PG'
     - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version == '8'
+    - ansible_distribution_major_version in ['8', '9']
 
 - name: Set package list for EPAS RedHat
   ansible.builtin.set_fact:
@@ -82,7 +82,7 @@
   when:
     - pg_type == 'EPAS'
     - ansible_os_family == 'RedHat'
-    - ansible_distribution_major_version == '8'
+    - ansible_distribution_major_version in ['8', '9']
 
 - name: Add pg_version > 10 packages to EPAS RedHat package_list
   ansible.builtin.set_fact:

--- a/roles/manage_dbpatches/defaults/main.yml
+++ b/roles/manage_dbpatches/defaults/main.yml
@@ -63,7 +63,6 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
-  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/manage_dbpatches/defaults/main.yml
+++ b/roles/manage_dbpatches/defaults/main.yml
@@ -63,6 +63,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/manage_efm/defaults/main.yml
+++ b/roles/manage_efm/defaults/main.yml
@@ -53,7 +53,6 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
-  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/manage_efm/defaults/main.yml
+++ b/roles/manage_efm/defaults/main.yml
@@ -49,10 +49,12 @@ supported_os:
   - CentOS8
   - RedHat7
   - RedHat8
+  - RedHat9
   - Ubuntu20
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/manage_efm/defaults/main.yml
+++ b/roles/manage_efm/defaults/main.yml
@@ -49,12 +49,10 @@ supported_os:
   - CentOS8
   - RedHat7
   - RedHat8
-  - RedHat9
   - Ubuntu20
   - Debian9
   - Debian10
   - Rocky8
-  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/manage_efm/defaults/main.yml
+++ b/roles/manage_efm/defaults/main.yml
@@ -53,6 +53,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/manage_pgbouncer/defaults/main.yml
+++ b/roles/manage_pgbouncer/defaults/main.yml
@@ -15,6 +15,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - Debian10
   - OracleLinux7

--- a/roles/manage_pgbouncer/defaults/main.yml
+++ b/roles/manage_pgbouncer/defaults/main.yml
@@ -14,6 +14,7 @@ supported_os:
   - CentOS8
   - RHEL7
   - RHEL8
+  - RedHat9
   - Rocky8
   - Rocky9
   - AlmaLinux8

--- a/roles/manage_pgbouncer/vars/EPAS_RedHat.yml
+++ b/roles/manage_pgbouncer/vars/EPAS_RedHat.yml
@@ -6,8 +6,8 @@ pgbouncer_user: "enterprisedb"
 pgbouncer_group: "enterprisedb"
 
 # Databases configuration file
-pgbouncer_databases_file: "/etc/edb/pgbouncer1.17/databases.ini"
+pgbouncer_databases_file: "/etc/edb/pgbouncer1.20/databases.ini"
 # Authentication file path
-pgbouncer_auth_file: "/etc/edb/pgbouncer1.17/userlist.txt"
+pgbouncer_auth_file: "/etc/edb/pgbouncer1.20/userlist.txt"
 # PID file
-pgbouncer_pid_file: "/run/edb/pgbouncer1.17/edb-pgbouncer-1.17.pid"
+pgbouncer_pid_file: "/run/edb/pgbouncer1.20/edb-pgbouncer-1.20.pid"

--- a/roles/manage_pgpool2/defaults/main.yml
+++ b/roles/manage_pgpool2/defaults/main.yml
@@ -14,6 +14,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
   - Ubuntu20

--- a/roles/manage_pgpool2/defaults/main.yml
+++ b/roles/manage_pgpool2/defaults/main.yml
@@ -13,6 +13,7 @@ supported_os:
   - CentOS8
   - RHEL7
   - RHEL8
+  - RHEL9
   - Rocky8
   - Rocky9
   - AlmaLinux8

--- a/roles/manage_pgpool2/defaults/main.yml
+++ b/roles/manage_pgpool2/defaults/main.yml
@@ -30,3 +30,4 @@ supported_pg_version:
 
 supported_pgpool2_version:
   - 4.3
+  - 4.4

--- a/roles/manage_pgpool2/vars/EPAS_RedHat.yml
+++ b/roles/manage_pgpool2/vars/EPAS_RedHat.yml
@@ -1,5 +1,5 @@
 ---
-pgpool2_version: 4.3
+pgpool2_version: 4.4
 pgpool2_configuration_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pgpool.conf"
 pgpool2_pool_passwd_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pool_passwd"
 pgpool2_user: "enterprisedb"

--- a/roles/setup_barman/defaults/main.yml
+++ b/roles/setup_barman/defaults/main.yml
@@ -27,6 +27,7 @@ supported_os:
   - CentOS8
   - RHEL7
   - RHEL8
+  - RHEl9
   - Rocky8
   - Rocky9
   - AlmaLinux8

--- a/roles/setup_barman/defaults/main.yml
+++ b/roles/setup_barman/defaults/main.yml
@@ -28,6 +28,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
   - Ubuntu20

--- a/roles/setup_barman/tasks/rm_barman_install_config.yml
+++ b/roles/setup_barman/tasks/rm_barman_install_config.yml
@@ -7,8 +7,9 @@
       {{ barman_cli_package }}.*el{{ os[-1:] }}
   when:
     - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version in ['7', '8']
 
-- name: Remove Barman packages on EL
+- name: Remove Barman packages on EL7 and EL8
   ansible.builtin.package:
     name:
       - "{{ _barman_package }}"
@@ -16,6 +17,18 @@
     state: absent
   when:
     - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version in ['7', '8']
+  become: true
+
+- name: Remove Barman packages on EL9
+  ansible.builtin.package:
+    name:
+      - barman
+      - barman-cli
+    state: absent
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == '9'
   become: true
 
 - name: Remove Barman packages on Debian

--- a/roles/setup_barmanserver/defaults/main.yml
+++ b/roles/setup_barmanserver/defaults/main.yml
@@ -28,6 +28,7 @@ supported_os:
   - CentOS8
   - RHEL7
   - RHEL8
+  - RHEL9
   - Rocky8
   - Rocky9
   - AlmaLinux8

--- a/roles/setup_barmanserver/defaults/main.yml
+++ b/roles/setup_barmanserver/defaults/main.yml
@@ -29,6 +29,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
   - Ubuntu20

--- a/roles/setup_barmanserver/tasks/install_packages.yml
+++ b/roles/setup_barmanserver/tasks/install_packages.yml
@@ -22,7 +22,7 @@
     - ansible_os_family == 'RedHat'
   become: true
 
-- name: Install Barman packages on EL
+- name: Install Barman packages on EL7 and EL8
   ansible.builtin.package:
     name:
       - "{{ _barman_package }}"
@@ -30,6 +30,18 @@
     state: present
   when:
     - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version in ['7', '8']
+  become: true
+
+- name: Install Barman packages on EL9
+  ansible.builtin.package:
+    name:
+      - barman
+      - barman-cli
+    state: present
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == '9'
   become: true
 
 - name: Install Barman packages on Debian

--- a/roles/setup_barmanserver/tasks/rm_barmanserver_install_config.yml
+++ b/roles/setup_barmanserver/tasks/rm_barmanserver_install_config.yml
@@ -33,8 +33,9 @@
       {{ barman_cli_package }}.*el{{ os[-1:] }}
   when:
     - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version in ['7', '8']
 
-- name: Remove Barman packages on EL
+- name: Remove Barman packages on EL7 and EL8
   ansible.builtin.package:
     name:
       - "{{ _barman_package }}"
@@ -42,6 +43,18 @@
     state: absent
   when:
     - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version in ['7', '8']
+  become: true
+
+- name: Remove Barman packages on EL9
+  ansible.builtin.package:
+    name:
+      - barman
+      - barman-cli
+    state: absent
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == '9'
   become: true
 
 - name: Remove Barman packages on Debian

--- a/roles/setup_efm/defaults/main.yml
+++ b/roles/setup_efm/defaults/main.yml
@@ -118,7 +118,6 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
-  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/setup_efm/defaults/main.yml
+++ b/roles/setup_efm/defaults/main.yml
@@ -118,6 +118,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/setup_etcd/defaults/main.yml
+++ b/roles/setup_etcd/defaults/main.yml
@@ -80,5 +80,6 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7

--- a/roles/setup_etcd/defaults/main.yml
+++ b/roles/setup_etcd/defaults/main.yml
@@ -80,6 +80,5 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
-  - Rocky9
   - AlmaLinux8
   - OracleLinux7

--- a/roles/setup_patroni/defaults/main.yml
+++ b/roles/setup_patroni/defaults/main.yml
@@ -155,6 +155,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/setup_patroni/defaults/main.yml
+++ b/roles/setup_patroni/defaults/main.yml
@@ -155,7 +155,6 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
-  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/setup_pemagent/defaults/main.yml
+++ b/roles/setup_pemagent/defaults/main.yml
@@ -56,6 +56,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
   - Debian10

--- a/roles/setup_pemagent/defaults/main.yml
+++ b/roles/setup_pemagent/defaults/main.yml
@@ -56,7 +56,6 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
-  - Rocky9
   - AlmaLinux8
   - OracleLinux7
   - Debian10

--- a/roles/setup_pemserver/defaults/main.yml
+++ b/roles/setup_pemserver/defaults/main.yml
@@ -70,6 +70,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
   - Debian10

--- a/roles/setup_pemserver/defaults/main.yml
+++ b/roles/setup_pemserver/defaults/main.yml
@@ -70,7 +70,6 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
-  - Rocky9
   - AlmaLinux8
   - OracleLinux7
   - Debian10

--- a/roles/setup_pgbackrest/defaults/main.yml
+++ b/roles/setup_pgbackrest/defaults/main.yml
@@ -30,6 +30,7 @@ supported_os:
   - CentOS8
   - RHEL7
   - RHEL8
+  - RHEL9
   - Rocky8
   - Rocky9
   - AlmaLinux8

--- a/roles/setup_pgbackrest/defaults/main.yml
+++ b/roles/setup_pgbackrest/defaults/main.yml
@@ -31,6 +31,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - Debian10
   - Ubuntu20

--- a/roles/setup_pgbackrest/tasks/rm_pgbackrest_install_config.yml
+++ b/roles/setup_pgbackrest/tasks/rm_pgbackrest_install_config.yml
@@ -16,6 +16,7 @@
     pg_gpg_key_8: "http://yum.postgresql.org/RPM-GPG-KEY-PGDG"
     pg_rpm_repo_7: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     pg_rpm_repo_8: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+    pg_rpm_repo_9: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
   when:
     - ansible_os_family == 'RedHat'
     - pg_type == 'EPAS'
@@ -30,12 +31,12 @@
     - pg_type == 'EPAS'
 
 # Remove PG repo for RHEL
-- name: Remove PGDG GPG key for EL8
+- name: Remove PGDG GPG key for EL8 and EL9
   ansible.builtin.rpm_key:
     key: "{{ pg_gpg_key_8 }}"
     state: absent
   when:
-    - ansible_distribution_major_version == '8'
+    - ansible_distribution_major_version in ['8', '9']
     - ansible_os_family == 'RedHat'
     - pg_type == 'EPAS'
   become: true
@@ -57,6 +58,16 @@
   become: true
   when:
     - ansible_distribution_major_version == '8'
+    - ansible_os_family == 'RedHat'
+    - pg_type == 'EPAS'
+
+- name: Remove PG repo for EL9
+  ansible.builtin.package:
+    name: "{{ pg_rpm_repo_9 }}"
+    state: absent
+  become: true
+  when:
+    - ansible_distribution_major_version == '9'
     - ansible_os_family == 'RedHat'
     - pg_type == 'EPAS'
 

--- a/roles/setup_pgbackrestserver/defaults/main.yml
+++ b/roles/setup_pgbackrestserver/defaults/main.yml
@@ -58,6 +58,7 @@ supported_os:
   - CentOS8
   - RHEL7
   - RHEL8
+  - RHEL9
   - Rocky8
   - Rocky9
   - AlmaLinux8

--- a/roles/setup_pgbackrestserver/defaults/main.yml
+++ b/roles/setup_pgbackrestserver/defaults/main.yml
@@ -59,6 +59,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - Debian10
   - Ubuntu20

--- a/roles/setup_pgbackrestserver/tasks/pgbackrest_install_EPAS.yml
+++ b/roles/setup_pgbackrestserver/tasks/pgbackrest_install_EPAS.yml
@@ -8,6 +8,7 @@
     pg_gpg_key_8: "http://yum.postgresql.org/RPM-GPG-KEY-PGDG"
     pg_rpm_repo_7: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     pg_rpm_repo_8: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+    pg_rpm_repo_9: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
   when: ansible_os_family == 'RedHat'
 
 # add repo facts for Debian
@@ -18,12 +19,12 @@
   when: ansible_os_family == 'Debian'
 
 # Add PG repo for RHEL
-- name: Download PGDG GPG key for EL8
+- name: Download PGDG GPG key for EL8 and EL9
   ansible.builtin.rpm_key:
     key: "{{ pg_gpg_key_8 }}"
     state: present
   when:
-    - ansible_distribution_major_version == '8'
+    - ansible_distribution_major_version in ['8', '9']
     - ansible_os_family == 'RedHat'
   become: true
 
@@ -43,6 +44,15 @@
   become: true
   when:
     - ansible_distribution_major_version == '8'
+    - ansible_os_family == 'RedHat'
+
+- name: Install PG repo for EL9
+  ansible.builtin.package:
+    name: "{{ pg_rpm_repo_9 }}"
+    state: present
+  become: true
+  when:
+    - ansible_distribution_major_version == '9'
     - ansible_os_family == 'RedHat'
 
 # Add PG repo for Debian

--- a/roles/setup_pgbackrestserver/tasks/rm_pgbackrestserver_install_config.yml
+++ b/roles/setup_pgbackrestserver/tasks/rm_pgbackrestserver_install_config.yml
@@ -35,6 +35,7 @@
     pg_gpg_key_8: "http://yum.postgresql.org/RPM-GPG-KEY-PGDG"
     pg_rpm_repo_7: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     pg_rpm_repo_8: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+    pg_rpm_repo_9: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
   when:
     - ansible_os_family == 'RedHat'
     - pg_type == 'EPAS'
@@ -49,12 +50,12 @@
     - pg_type == 'EPAS'
 
 # Remove PG repo for RHEL
-- name: Remove PGDG GPG key for EL8
+- name: Remove PGDG GPG key for EL8 and EL9
   ansible.builtin.rpm_key:
     key: "{{ pg_gpg_key_8 }}"
     state: absent
   when:
-    - ansible_distribution_major_version == '8'
+    - ansible_distribution_major_version in ['8', '9']
     - ansible_os_family == 'RedHat'
     - pg_type == 'EPAS'
   become: true
@@ -76,6 +77,16 @@
   become: true
   when:
     - ansible_distribution_major_version == '8'
+    - ansible_os_family == 'RedHat'
+    - pg_type == 'EPAS'
+
+- name: Remove PG repo for EL9
+  ansible.builtin.package:
+    name: "{{ pg_rpm_repo_9 }}"
+    state: absent
+  become: true
+  when:
+    - ansible_distribution_major_version == '9'
     - ansible_os_family == 'RedHat'
     - pg_type == 'EPAS'
 

--- a/roles/setup_pgbouncer/defaults/main.yml
+++ b/roles/setup_pgbouncer/defaults/main.yml
@@ -70,6 +70,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - Debian10
   - OracleLinux7

--- a/roles/setup_pgbouncer/defaults/main.yml
+++ b/roles/setup_pgbouncer/defaults/main.yml
@@ -69,6 +69,7 @@ supported_os:
   - CentOS8
   - RHEL7
   - RHEL8
+  - RHEL9
   - Rocky8
   - Rocky9
   - AlmaLinux8

--- a/roles/setup_pgbouncer/vars/EPAS_Debian.yml
+++ b/roles/setup_pgbouncer/vars/EPAS_Debian.yml
@@ -1,25 +1,25 @@
 ---
 # RPM package name
-pgbouncer_package_name: "edb-pgbouncer117"
+pgbouncer_package_name: "edb-pgbouncer120"
 
 # PgBouncer service name
-pgbouncer_service_name: "edb-pgbouncer117"
+pgbouncer_service_name: "edb-pgbouncer120"
 
 # PgBouncer system user & group
 pgbouncer_user: "enterprisedb"
 pgbouncer_group: "enterprisedb"
 
 # PgBouncer authentication part
-pgbouncer_auth_file: "/etc/edb/pgbouncer1.17/userlist.txt"
+pgbouncer_auth_file: "/etc/edb/pgbouncer1.20/userlist.txt"
 
 # PID file
-pgbouncer_pid_file: "/var/run/edb/pgbouncer1.17/edb-pgbouncer-1.17.pid"
+pgbouncer_pid_file: "/var/run/edb/pgbouncer1.20/edb-pgbouncer-1.20.pid"
 # Configuration file
-pgbouncer_config_file: "/etc/edb/pgbouncer1.17/pgbouncer.ini"
+pgbouncer_config_file: "/etc/edb/pgbouncer1.20/pgbouncer.ini"
 # Log file
-pgbouncer_log_file: "/var/log/edb/pgbouncer1.17/edb-pgbouncer-1.17.log"
+pgbouncer_log_file: "/var/log/edb/pgbouncer1.20/edb-pgbouncer-1.20.log"
 # Databases configuration file
-pgbouncer_databases_file: "/etc/edb/pgbouncer1.17/databases.ini"
+pgbouncer_databases_file: "/etc/edb/pgbouncer1.20/databases.ini"
 
 # SSL dir
-pgbouncer_ssl_dir: "/etc/edb/pgbouncer1.17/ssl"
+pgbouncer_ssl_dir: "/etc/edb/pgbouncer1.20/ssl"

--- a/roles/setup_pgbouncer/vars/EPAS_RedHat.yml
+++ b/roles/setup_pgbouncer/vars/EPAS_RedHat.yml
@@ -1,25 +1,25 @@
 ---
 # RPM package name
-pgbouncer_package_name: "edb-pgbouncer117"
+pgbouncer_package_name: "edb-pgbouncer120"
 
 # PgBouncer service name
-pgbouncer_service_name: "edb-pgbouncer-1.17"
+pgbouncer_service_name: "edb-pgbouncer-1.20"
 
 # PgBouncer system user & group
 pgbouncer_user: "enterprisedb"
 pgbouncer_group: "enterprisedb"
 
 # PgBouncer authentication part
-pgbouncer_auth_file: "/etc/edb/pgbouncer1.17/userlist.txt"
+pgbouncer_auth_file: "/etc/edb/pgbouncer1.20/userlist.txt"
 
 # PID file
-pgbouncer_pid_file: "/run/edb/pgbouncer1.17/edb-pgbouncer-1.17.pid"
+pgbouncer_pid_file: "/run/edb/pgbouncer1.20/edb-pgbouncer-1.20.pid"
 # Configuration file
-pgbouncer_config_file: "/etc/edb/pgbouncer1.17/edb-pgbouncer-1.17.ini"
+pgbouncer_config_file: "/etc/edb/pgbouncer1.20/edb-pgbouncer-1.20.ini"
 # Log file
-pgbouncer_log_file: "/var/log/edb/pgbouncer1.17/edb-pgbouncer-1.17.log"
+pgbouncer_log_file: "/var/log/edb/pgbouncer1.20/edb-pgbouncer-1.20.log"
 # Databases configuration file
-pgbouncer_databases_file: "/etc/edb/pgbouncer1.17/databases.ini"
+pgbouncer_databases_file: "/etc/edb/pgbouncer1.20/databases.ini"
 
 # SSL dir
-pgbouncer_ssl_dir: "/etc/edb/pgbouncer1.17/ssl"
+pgbouncer_ssl_dir: "/etc/edb/pgbouncer1.20/ssl"

--- a/roles/setup_pgd/defaults/main.yml
+++ b/roles/setup_pgd/defaults/main.yml
@@ -122,6 +122,7 @@ supported_os:
   - RedHat7
   - RedHat8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/setup_pgd/defaults/main.yml
+++ b/roles/setup_pgd/defaults/main.yml
@@ -122,7 +122,6 @@ supported_os:
   - RedHat7
   - RedHat8
   - Rocky8
-  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -61,6 +61,7 @@ supported_os:
   - CentOS8
   - RHEL7
   - RHEL8
+  - RHEL9
   - Rocky8
   - Rocky9
   - AlmaLinux8

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -78,3 +78,4 @@ supported_pg_version:
 
 supported_pgpool2_version:
   - 4.3
+  - 4.4

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -62,6 +62,7 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
   - Ubuntu20

--- a/roles/setup_pgpool2/vars/EPAS_RedHat.yml
+++ b/roles/setup_pgpool2/vars/EPAS_RedHat.yml
@@ -1,5 +1,5 @@
 ---
-pgpool2_version: 4.3
+pgpool2_version: 4.4
 pgpool2_package_name: "edb-pgpool{{ pgpool2_version | string | replace('.', '') }}"
 pgpool2_configuration_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pgpool.conf"
 pgpool2_pool_passwd_file: "/etc/sysconfig/edb/pgpool{{ pgpool2_version | string }}/pool_passwd"

--- a/roles/setup_replication/defaults/main.yml
+++ b/roles/setup_replication/defaults/main.yml
@@ -67,6 +67,7 @@ supported_os:
   - CentOS8
   - RedHat7
   - RedHat8
+  - RedHat9
   - Ubuntu20
   - Debian9
   - Debian10

--- a/roles/setup_replication/defaults/main.yml
+++ b/roles/setup_replication/defaults/main.yml
@@ -71,6 +71,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/setup_repmgr/defaults/main.yml
+++ b/roles/setup_repmgr/defaults/main.yml
@@ -50,6 +50,7 @@ supported_os:
   - CentOS8
   - RedHat7
   - RedHat8
+  - RedHat9
   - Ubuntu20
   - Debian9
   - Debian10

--- a/roles/setup_repmgr/defaults/main.yml
+++ b/roles/setup_repmgr/defaults/main.yml
@@ -54,6 +54,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - OracleLinux7
 
 supported_pg_type:

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -85,6 +85,7 @@ supported_os:
   - Debian9
   - Debian10
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7
 

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -63,12 +63,15 @@ pg_deb_keys: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 # Postgresql Repos
 pg_rpm_repo_7: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
 pg_rpm_repo_8: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+pg_rpm_repo_9: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
 pg_gpg_key_8: "http://yum.postgresql.org/RPM-GPG-KEY-PGDG"
 
 # epel Repo
 epel_repo_7: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 epel_repo_8: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+epel_repo_9: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm "
 epel_gpg_key_8: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8"
+epel_gpg_key_9: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9"
 
 os: ""
 pg_type: "PG"

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -84,6 +84,7 @@ supported_os:
   - CentOS8
   - RedHat7
   - RedHat8
+  - RedHat9
   - Ubuntu20
   - Debian9
   - Debian10

--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos.yml
@@ -14,12 +14,12 @@
     - enable_edb_repo|bool
   become: true
 
-- name: Download PGDG GPG key for EL8
+- name: Download PGDG GPG key for EL8 and EL9
   ansible.builtin.rpm_key:
     key: "{{ pg_gpg_key_8 }}"
     state: present
   when:
-    - ansible_distribution_major_version == '8'
+    - ansible_distribution_major_version in ['8', '9']
     - pg_type == 'PG'
     - enable_pgdg_repo|bool
   become: true
@@ -30,6 +30,15 @@
     state: present
   when:
     - ansible_distribution_major_version == '8'
+    - enable_epel_repo|bool
+  become: true
+
+- name: Download EPEL GPG key for EL9
+  ansible.builtin.rpm_key:
+    key: "{{ epel_gpg_key_9 }}"
+    state: present
+  when:
+    - ansible_distribution_major_version == '9'
     - enable_epel_repo|bool
   become: true
 
@@ -52,13 +61,13 @@
     - pg_type == 'PG'
     - enable_pgdg_repo|bool
 
-- name: Install dnf-plugins-core for EL8
+- name: Install dnf-plugins-core for EL8 and EL9
   ansible.builtin.package:
     name: dnf-plugins-core
     state: present
   become: true
   when:
-    - ansible_distribution_major_version == '8'
+    - ansible_distribution_major_version in ['8', '9']
     - enable_epel_repo|bool
 
 # for RedHat8, use subscription-manager to enable codeready-builder repo, if required.
@@ -72,12 +81,31 @@
     - os not in ['RedHat8']
     - enable_epel_repo|bool
 
+- name: Enable CodeReady Builder for EL9
+  ansible.builtin.command: >
+    dnf config-manager --set-enabled crb
+  become: true
+  changed_when: true
+  when:
+    - ansible_distribution_major_version == '9'
+    - os not in ['RedHat9']
+    - enable_epel_repo|bool
+
 - name: Install EPEL repo for EL8
   ansible.builtin.package:
     name: "{{ epel_repo_8 }}"
     state: present
   when:
     - ansible_distribution_major_version == '8'
+    - enable_epel_repo|bool
+  become: true
+
+- name: Install EPEL repo for EL9
+  ansible.builtin.package:
+    name: "{{ epel_repo_9 }}"
+    state: present
+  when:
+    - ansible_distribution_major_version == '9'
     - enable_epel_repo|bool
   become: true
 
@@ -88,6 +116,16 @@
   become: true
   when:
     - ansible_distribution_major_version == '8'
+    - pg_type == 'PG'
+    - enable_pgdg_repo|bool
+
+- name: Install PG repo for EL9
+  ansible.builtin.package:
+    name: "{{ pg_rpm_repo_9 }}"
+    state: present
+  become: true
+  when:
+    - ansible_distribution_major_version == '9'
     - pg_type == 'PG'
     - enable_pgdg_repo|bool
 
@@ -141,6 +179,7 @@
     name: curl
     state: present
   become: true
+  when: ansible_distribution_major_version in ['7', '8']
 
 - name: Install PGD4 packages repo if tpa_subscription_token is given
   ansible.builtin.shell: >

--- a/roles/setup_repo/tasks/setup_repo.yml
+++ b/roles/setup_repo/tasks/setup_repo.yml
@@ -32,6 +32,14 @@
     - enable_edb_repo|bool
     - repo_token | length < 1 and (repo_username | length < 1 or repo_password | length < 1)
 
+- name: Validate repos 2.0 if Rocky9
+  ansible.builtin.fail:
+    msg: "Repo token required to setup Rocky9."
+  when:
+    - enable_edb_repo|bool
+    - repo_token | length < 1
+    - os in ['Rocky9']
+
 - name: Capture if pgd_nod_ips if defined
   ansible.builtin.set_fact:
     pgd_node_ips: "{{ lookup('edb_devops.edb_postgres.pgd_nodes') | flatten | map(attribute='ansible_host') | flatten }}"

--- a/roles/tuning/defaults/main.yml
+++ b/roles/tuning/defaults/main.yml
@@ -14,5 +14,6 @@ supported_os:
   - RHEL7
   - RHEL8
   - Rocky8
+  - Rocky9
   - AlmaLinux8
   - OracleLinux7

--- a/tests/cases/execute_binary_upgrade/Makefile
+++ b/tests/cases/execute_binary_upgrade/Makefile
@@ -4,6 +4,10 @@ build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up standby1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up standby1-almalinux8 -d

--- a/tests/cases/execute_binary_upgrade/docker-compose.yml
+++ b/tests/cases/execute_binary_upgrade/docker-compose.yml
@@ -42,6 +42,28 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/init_dbserver/Makefile
+++ b/tests/cases/init_dbserver/Makefile
@@ -6,6 +6,9 @@ build-centos7:
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+
 build-rhel8:
 	docker compose up primary1-rhel8 -d
 

--- a/tests/cases/init_dbserver/docker-compose.yml
+++ b/tests/cases/init_dbserver/docker-compose.yml
@@ -31,6 +31,17 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-rhel8:
     privileged: true
     build:

--- a/tests/cases/init_tdedbserver/Makefile
+++ b/tests/cases/init_tdedbserver/Makefile
@@ -6,6 +6,9 @@ build-centos7:
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 

--- a/tests/cases/init_tdedbserver/docker-compose.yml
+++ b/tests/cases/init_tdedbserver/docker-compose.yml
@@ -31,6 +31,17 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/install_dbserver/Makefile
+++ b/tests/cases/install_dbserver/Makefile
@@ -6,6 +6,9 @@ build-centos7:
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+
 build-rhel8:
 	docker compose up primary1-rhel8 -d
 

--- a/tests/cases/install_dbserver/docker-compose.yml
+++ b/tests/cases/install_dbserver/docker-compose.yml
@@ -31,6 +31,17 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-rhel8:
     privileged: true
     build:

--- a/tests/cases/manage_dbpatches/Makefile
+++ b/tests/cases/manage_dbpatches/Makefile
@@ -10,6 +10,11 @@ build-rocky8:
 	docker compose up standby1-rocky8 -d
 	docker compose up standby2-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+	docker compose up standby2-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up standby1-almalinux8 -d

--- a/tests/cases/manage_dbpatches/docker-compose.yml
+++ b/tests/cases/manage_dbpatches/docker-compose.yml
@@ -53,6 +53,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/manage_dbserver/Makefile
+++ b/tests/cases/manage_dbserver/Makefile
@@ -6,6 +6,9 @@ build-centos7:
 build-rocky8:
 	docker compose up primary1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 

--- a/tests/cases/manage_dbserver/docker-compose.yml
+++ b/tests/cases/manage_dbserver/docker-compose.yml
@@ -31,6 +31,17 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/manage_efm/Makefile
+++ b/tests/cases/manage_efm/Makefile
@@ -10,6 +10,11 @@ build-rocky8:
 	docker compose up standby1-rocky8 -d
 	docker compose up standby2-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+	docker compose up standby2-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up standby1-almalinux8 -d

--- a/tests/cases/manage_efm/docker-compose.yml
+++ b/tests/cases/manage_efm/docker-compose.yml
@@ -53,6 +53,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/manage_pgbouncer/Makefile
+++ b/tests/cases/manage_pgbouncer/Makefile
@@ -8,6 +8,10 @@ build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up pooler1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up pooler1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up pooler1-almalinux8 -d

--- a/tests/cases/manage_pgbouncer/docker-compose.yml
+++ b/tests/cases/manage_pgbouncer/docker-compose.yml
@@ -42,6 +42,28 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  pooler1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/manage_pgpool2/Makefile
+++ b/tests/cases/manage_pgpool2/Makefile
@@ -8,6 +8,10 @@ build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up pool1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up pool1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up pool1-almalinux8 -d

--- a/tests/cases/manage_pgpool2/docker-compose.yml
+++ b/tests/cases/manage_pgpool2/docker-compose.yml
@@ -42,6 +42,28 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  pool1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_barman/Makefile
+++ b/tests/cases/setup_barman/Makefile
@@ -8,6 +8,10 @@ build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up barman1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up barman1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up barman1-almalinux8 -d

--- a/tests/cases/setup_barman/docker-compose.yml
+++ b/tests/cases/setup_barman/docker-compose.yml
@@ -42,6 +42,28 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  barman1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_barmanserver/Makefile
+++ b/tests/cases/setup_barmanserver/Makefile
@@ -8,6 +8,10 @@ build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up barman1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up barman1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up barman1-almalinux8 -d

--- a/tests/cases/setup_barmanserver/docker-compose.yml
+++ b/tests/cases/setup_barmanserver/docker-compose.yml
@@ -42,6 +42,28 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  barman1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_efm/Makefile
+++ b/tests/cases/setup_efm/Makefile
@@ -10,6 +10,11 @@ build-rocky8:
 	docker compose up standby1-rocky8 -d
 	docker compose up standby2-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+	docker compose up standby2-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up standby1-almalinux8 -d

--- a/tests/cases/setup_efm/docker-compose.yml
+++ b/tests/cases/setup_efm/docker-compose.yml
@@ -53,6 +53,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_haproxy/Makefile
+++ b/tests/cases/setup_haproxy/Makefile
@@ -6,6 +6,12 @@ build-rocky8:
 	docker compose up standby2-rocky8 -d
 	docker compose up pooler1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+	docker compose up standby2-rocky9 -d
+	docker compose up pooler1-rocky9 -d
+
 build-centos7:
 	docker compose up primary1-centos7 -d
 	docker compose up standby1-centos7 -d

--- a/tests/cases/setup_haproxy/docker-compose.yml
+++ b/tests/cases/setup_haproxy/docker-compose.yml
@@ -64,6 +64,50 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  pooler1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_patroni/Makefile
+++ b/tests/cases/setup_patroni/Makefile
@@ -10,6 +10,11 @@ build-rocky8:
 	docker compose up standby1-rocky8 -d
 	docker compose up standby2-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+	docker compose up standby2-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up standby1-almalinux8 -d

--- a/tests/cases/setup_patroni/docker-compose.yml
+++ b/tests/cases/setup_patroni/docker-compose.yml
@@ -53,6 +53,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_pemagent/Makefile
+++ b/tests/cases/setup_pemagent/Makefile
@@ -10,6 +10,10 @@ build-rocky8:
 	docker compose up pem1-rocky8 -d
 	docker compose up barman1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up pem1-rocky9 -d
+	docker compose up barman1-rocky9 -d
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up pem1-almalinux8 -d

--- a/tests/cases/setup_pemagent/docker-compose.yml
+++ b/tests/cases/setup_pemagent/docker-compose.yml
@@ -53,6 +53,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  barman1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  pem1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_pemserver/Makefile
+++ b/tests/cases/setup_pemserver/Makefile
@@ -6,6 +6,9 @@ build-centos7:
 build-rocky8:
 	docker compose up pem1-rocky8 -d
 
+build-rocky9:
+	docker compose up pem1-rocky9 -d
+
 build-almalinux8:
 	docker compose up pem1-almalinux8 -d
 

--- a/tests/cases/setup_pemserver/docker-compose.yml
+++ b/tests/cases/setup_pemserver/docker-compose.yml
@@ -31,6 +31,17 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  pem1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   pem1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_pgbackrest/Makefile
+++ b/tests/cases/setup_pgbackrest/Makefile
@@ -10,6 +10,11 @@ build-rocky8:
 	docker compose up standby1-rocky8 -d
 	docker compose up pgbackrest1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+	docker compose up pgbackrest1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up standby1-almalinux8 -d

--- a/tests/cases/setup_pgbackrest/docker-compose.yml
+++ b/tests/cases/setup_pgbackrest/docker-compose.yml
@@ -56,6 +56,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  pgbackrest1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     # Required for running systemd containers via GitHub actions
     privileged: true

--- a/tests/cases/setup_pgbackrestserver/Makefile
+++ b/tests/cases/setup_pgbackrestserver/Makefile
@@ -10,6 +10,11 @@ build-rocky8:
 	docker compose up standby1-rocky8 -d
 	docker compose up pgbackrest1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+	docker compose up pgbackrest1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up standby1-almalinux8 -d

--- a/tests/cases/setup_pgbackrestserver/docker-compose.yml
+++ b/tests/cases/setup_pgbackrestserver/docker-compose.yml
@@ -56,6 +56,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  pgbackrest1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     # Required for running systemd containers via GitHub actions
     privileged: true

--- a/tests/cases/setup_pgbouncer/Makefile
+++ b/tests/cases/setup_pgbouncer/Makefile
@@ -8,6 +8,10 @@ build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up pooler1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up pooler1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up pooler1-almalinux8 -d

--- a/tests/cases/setup_pgbouncer/docker-compose.yml
+++ b/tests/cases/setup_pgbouncer/docker-compose.yml
@@ -42,6 +42,28 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  pooler1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_pgd/Makefile
+++ b/tests/cases/setup_pgd/Makefile
@@ -5,6 +5,11 @@ build-rocky8:
 	docker compose up primary2-rocky8 -d
 	docker compose up primary3-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up primary2-rocky9 -d
+	docker compose up primary3-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up primary2-almalinux8 -d

--- a/tests/cases/setup_pgd/docker-compose.yml
+++ b/tests/cases/setup_pgd/docker-compose.yml
@@ -53,6 +53,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  primary2-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  primary3-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_pgpool2/Makefile
+++ b/tests/cases/setup_pgpool2/Makefile
@@ -8,6 +8,10 @@ build-rocky8:
 	docker compose up primary1-rocky8 -d
 	docker compose up pool1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up pool1-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up pool1-almalinux8 -d

--- a/tests/cases/setup_pgpool2/docker-compose.yml
+++ b/tests/cases/setup_pgpool2/docker-compose.yml
@@ -42,6 +42,28 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  pool1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_replication/Makefile
+++ b/tests/cases/setup_replication/Makefile
@@ -10,6 +10,11 @@ build-rocky8:
 	docker compose up standby1-rocky8 -d
 	docker compose up standby2-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+	docker compose up standby2-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up standby1-almalinux8 -d

--- a/tests/cases/setup_replication/docker-compose.yml
+++ b/tests/cases/setup_replication/docker-compose.yml
@@ -53,6 +53,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/cases/setup_repmgr/Makefile
+++ b/tests/cases/setup_repmgr/Makefile
@@ -10,6 +10,11 @@ build-rocky8:
 	docker compose up standby1-rocky8 -d
 	docker compose up witness1-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+	docker compose up witness1-rocky9 -d
+
 build-debian10:
 	docker compose up primary1-debian10 -d
 	docker compose up standby1-debian10 -d

--- a/tests/cases/setup_repmgr/docker-compose.yml
+++ b/tests/cases/setup_repmgr/docker-compose.yml
@@ -53,6 +53,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  witness1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-centos7:
     privileged: true
     build:

--- a/tests/cases/setup_tdereplication/Makefile
+++ b/tests/cases/setup_tdereplication/Makefile
@@ -10,6 +10,11 @@ build-rocky8:
 	docker compose up standby1-rocky8 -d
 	docker compose up standby2-rocky8 -d
 
+build-rocky9:
+	docker compose up primary1-rocky9 -d
+	docker compose up standby1-rocky9 -d
+	docker compose up standby2-rocky9 -d
+
 build-almalinux8:
 	docker compose up primary1-almalinux8 -d
 	docker compose up standby1-almalinux8 -d

--- a/tests/cases/setup_tdereplication/docker-compose.yml
+++ b/tests/cases/setup_tdereplication/docker-compose.yml
@@ -53,6 +53,39 @@ services:
     - .:/workspace
     - /sys/fs/cgroup/:/sys/fs/cgroup:ro
     command: /usr/sbin/init
+  primary1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby1-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+  standby2-rocky9:
+    privileged: true
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.rocky9
+    cap_add:
+    - SYS_ADMIN
+    volumes:
+    - .:/workspace
+    - /sys/fs/cgroup/:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
   primary1-almalinux8:
     privileged: true
     build:

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -40,6 +40,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian9
     - debian10
@@ -59,6 +60,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian9
     - debian10
@@ -72,6 +74,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian9
     - debian10
@@ -91,6 +94,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian9
     - debian10
@@ -110,6 +114,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian9
     - debian10
@@ -123,6 +128,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian9
     - debian10
@@ -142,6 +148,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian9
     - debian10
@@ -161,6 +168,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - oraclelinux7
     - debian10
@@ -179,6 +187,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - oraclelinux7
     - debian10
@@ -197,6 +206,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - oraclelinux7
     - ubuntu20
@@ -215,6 +225,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - oraclelinux7
     - ubuntu20
@@ -233,6 +244,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian10
     - oraclelinux7
@@ -251,6 +263,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian10
     - oraclelinux7
@@ -269,6 +282,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian10
     - oraclelinux7
@@ -287,6 +301,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian10
     - oraclelinux7
@@ -304,6 +319,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - debian9
     - debian10
     - ubuntu20
@@ -321,6 +337,7 @@ cases:
     - EPAS
     os:
     - rocky8
+    - rocky9
     - almalinux8
     - debian10
     - ubuntu20
@@ -337,6 +354,7 @@ cases:
     - EPAS
     os:
     - rocky8
+    - rocky9
     - almalinux8
     - centos7
   setup_dbt2_client:
@@ -352,6 +370,7 @@ cases:
     - EPAS
     os:
     - rocky8
+    - rocky9
     - almalinux8
     - centos7
   setup_dbt2:
@@ -367,6 +386,7 @@ cases:
     - EPAS
     os:
     - rocky8
+    - rocky9
     - almalinux8
     - centos7
   setup_dbt3:
@@ -382,6 +402,7 @@ cases:
       - EPAS
     os:
       - rocky8
+      - rocky9
       - almalinux8
       - centos7
   setup_dbt7:
@@ -397,6 +418,7 @@ cases:
       - EPAS
     os:
       - rocky8
+      - rocky9
       - almalinux8
       - centos7
   manage_dbpatches:
@@ -414,6 +436,7 @@ cases:
     - centos7
     - oraclelinux7
     - rocky8
+    - rocky9
     - almalinux8
     - debian9
     - debian10
@@ -444,6 +467,7 @@ cases:
     - EPAS
     os:
     - rocky8
+    - rocky9
     - almalinux8
     - centos7
     - debian10
@@ -459,6 +483,7 @@ cases:
     - EPAS
     os:
     - rocky8
+    - rocky9
     - almalinux8
     - centos7
     - debian10
@@ -477,6 +502,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian10
     - ubuntu20
@@ -495,6 +521,7 @@ cases:
     os:
     - centos7
     - rocky8
+    - rocky9
     - almalinux8
     - debian10
     - ubuntu20
@@ -509,6 +536,7 @@ cases:
     - EPAS
     os:
     - rocky8
+    - rocky9
     - almalinux8
   setup_pgd:
     pg_version:
@@ -531,6 +559,7 @@ cases:
     - EPAS
     os:
     - rocky8
+    - rocky9
     - almalinux8
     - debian10
     - ubuntu20
@@ -546,5 +575,6 @@ cases:
     - EPAS
     os:
     - rocky8
+    - rocky9
     - centos7
     - almalinux8

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -206,9 +206,9 @@ def get_pgbouncer_pid_file():
             return '/var/run/pgbouncer/pgbouncer.pid'
     elif pg_type == 'EPAS':
         if os_family() == 'RedHat':
-            return '/run/edb/pgbouncer1.17/edb-pgbouncer-1.17.pid'
+            return '/run/edb/pgbouncer1.20/edb-pgbouncer-1.20.pid'
         elif os_family() == 'Debian':
-            return '/var/run/edb/pgbouncer1.17/edb-pgbouncer-1.17.pid'
+            return '/var/run/edb/pgbouncer1.20/edb-pgbouncer-1.20.pid'
 
 
 def get_pgbouncer_auth_file():
@@ -220,9 +220,9 @@ def get_pgbouncer_auth_file():
             return '/etc/pgbouncer/userlist.txt'
     elif pg_type == 'EPAS':
         if os_family() == 'RedHat':
-            return '/etc/edb/pgbouncer1.17/userlist.txt'
+            return '/etc/edb/pgbouncer1.20/userlist.txt'
         elif os_family() == 'Debian':
-            return '/etc/edb/pgbouncer1.17/userlist.txt'
+            return '/etc/edb/pgbouncer1.20/userlist.txt'
 
 
 def get_enable_edb_tde():

--- a/tests/tests/test_setup_pgbouncer.py
+++ b/tests/tests/test_setup_pgbouncer.py
@@ -20,7 +20,7 @@ def test_setup_pgbouncer_service():
         if os_family() == 'Debian':
             service = 'edb-pgbouncer117'
         elif os_family() == 'RedHat':
-            service = 'edb-pgbouncer-1.17'
+            service = 'edb-pgbouncer-1.20'
 
     assert host.service(service).is_running, \
         "pgbouncer service not running"
@@ -38,7 +38,7 @@ def test_setup_pgbouncer_packages():
 
     if get_pg_type() == 'EPAS':
         packages = [
-            'edb-pgbouncer117'
+            'edb-pgbouncer120'
         ]
 
     for package in packages:

--- a/tests/tests/test_setup_pgpool2.py
+++ b/tests/tests/test_setup_pgpool2.py
@@ -18,7 +18,7 @@ def test_setup_pgpool2():
         if os_family() == 'Debian':
             service = 'edb-pgpool43'
         elif os_family() == 'RedHat':
-            service = 'edb-pgpool-4.3'
+            service = 'edb-pgpool-4.4'
 
     if get_pg_type() == 'PG':
         if os_family() == 'Debian':
@@ -38,7 +38,10 @@ def test_setup_pgpool_packages():
     packages = ['openssl']
 
     if get_pg_type() == 'EPAS':
-        packages.append('edb-pgpool43')
+        if os_family() == 'Debian':
+            packages.append('edb-pgpool43')
+        elif os_family() == 'RedHat':
+            packages.append('edb-pgpool44')
 
     if get_pg_type() == 'PG':
         if os_family() == 'Debian':


### PR DESCRIPTION
Adds support for RHEL9 and Rocky9, when applicable. Some packages are not available in EL9 repos yet and `main.yml` `supported_os` reflects accurately.