### PR TITLE
setup_pgd pgd_commit_scopes default empty list

### DIFF
--- a/roles/setup_pgd/defaults/main.yml
+++ b/roles/setup_pgd/defaults/main.yml
@@ -112,7 +112,7 @@ max_prepared_transactions: 100
 #  - member_nodes: ['edb-primary3']
 #  - default_group_cs: true
 #  - cs_rule: "ALL ( pgd_remaining_nodes ) GROUP COMMIT"
-pgd_commit_scopes: ""
+pgd_commit_scopes: []
 
 etc_hosts_lists: []
 


### PR DESCRIPTION
The default value for pgd_commit_scopes should be an empty list as opposed to an empty string because all of the validations are written for lists as opposed to strings.