### PR TITLE
Add manage_operating_system role

### DIFF
--- a/roles/manage_operating_system/README.md
+++ b/roles/manage_operating_system/README.md
@@ -1,0 +1,81 @@
+# manage_operating_system
+
+This role is for managing operating system settings.
+
+## Requirements
+
+Following are the requirements of this role.
+  1. Ansible
+  2. An already initialized system running Linux.
+
+## Role Variables
+
+When executing the role via Ansible these are the applicable variables:
+
+  * ***enable_user_profiling***
+
+    When `true`, sets relevant operating system settings such that any user and
+    profile the system as well as disabling any masking of operating system
+    kernel memory addresses.  Default: `false`
+
+These variables can be assigned in the `pre_tasks` definition of the Playbook.
+
+## Example Playbook
+
+### Inventory file content
+
+Content of the `inventory.yml`:
+
+```yaml
+all:
+  children:
+    primary:
+      hosts:
+        pgsql1.dbt2.internal:
+          ansible_host: 10.1.1.3
+          private_ip: 10.1.1.3
+```
+
+### Playbook file content
+
+Content of the `inventory.yml` file:
+
+```yaml
+---
+- hosts: all
+  name: Example
+  become: yes
+
+  pre_tasks:
+    - name: Initialize the user defined variables
+      ansible.builtin.set_fact:
+        enable_user_profiling: true
+
+  collections:
+    - edb_devops.edb_postgres
+
+  roles:
+    - role: manage_operating_system
+```
+
+## Playbook execution examples
+
+```bash
+$ ansible-playbook playbook.yml \
+  -i inventory.yml \
+  -u centos \
+  --private-key <key.pem> \
+  --extra-vars="enable_user_profiling=true"
+```
+
+## License
+
+BSD
+
+## Author information
+
+Author:
+
+  * Mark Wong
+  * EDB Postgres
+  * edb-devops@enterprisedb.com www.enterprisedb.com

--- a/roles/manage_operating_system/defaults/main.yml
+++ b/roles/manage_operating_system/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+enable_user_profiling: false

--- a/roles/manage_operating_system/meta/main.yml
+++ b/roles/manage_operating_system/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: EDB
+  description: Manage Operating System
+  company: "EnterpriseDB"
+
+  license: BSD
+
+  min_ansible_version: "2.8"
+
+  galaxy_tags:
+    - operating system
+
+dependencies: []

--- a/roles/manage_operating_system/tasks/disable_user_profiling.yml
+++ b/roles/manage_operating_system/tasks/disable_user_profiling.yml
@@ -1,0 +1,12 @@
+---
+- name: reset use of all profiling events by all users
+  ansible.posix.sysctl:
+    name: kernel.perf_event_paranoid
+    state: absent
+  become: true
+
+- name: reset restrictions on exposing kernel address
+  ansible.posix.sysctl:
+    name: kernel.kptr_restrict
+    state: absent
+  become: true

--- a/roles/manage_operating_system/tasks/enable_user_profiling.yml
+++ b/roles/manage_operating_system/tasks/enable_user_profiling.yml
@@ -1,0 +1,18 @@
+---
+- name: allow use of all profiling events by all users
+  ansible.posix.sysctl:
+    name: kernel.perf_event_paranoid
+    value: '-1'
+    sysctl_set: true
+    state: present
+    reload: true
+  become: true
+
+- name: remove restrictions on exposing kernel address
+  ansible.posix.sysctl:
+    name: kernel.kptr_restrict
+    value: '0'
+    sysctl_set: true
+    state: present
+    reload: true
+  become: true

--- a/roles/manage_operating_system/tasks/main.yml
+++ b/roles/manage_operating_system/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Enable user level profiling
+  ansible.builtin.include_tasks: enable_user_profiling.yml
+  when:
+    - enable_user_profiling | bool


### PR DESCRIPTION
This role is for managing operating system tasks.  The first task included is to enable profiling for unprivileged users.