### PR TITLE
Added support for Ubuntu22.

### DIFF
--- a/roles/execute_binary_upgrade/defaults/main.yml
+++ b/roles/execute_binary_upgrade/defaults/main.yml
@@ -52,6 +52,7 @@ supported_os:
   - RedHat8
   - RedHat9
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/init_dbserver/defaults/main.yml
+++ b/roles/init_dbserver/defaults/main.yml
@@ -110,6 +110,7 @@ supported_os:
   - RedHat8
   - RedHat9
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/install_dbserver/defaults/main.yml
+++ b/roles/install_dbserver/defaults/main.yml
@@ -39,6 +39,7 @@ supported_os:
   - RedHat8
   - RedHat9
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/install_dbserver/tasks/install_dbserver.yml
+++ b/roles/install_dbserver/tasks/install_dbserver.yml
@@ -22,7 +22,7 @@
     pg_type == 'EPAS' and
     ((pg_version|int < 12 and os in ['RedHat8','CentOS8','Rocky8','AlmaLinux8']) or
      (pg_version|int < 11 and os in ['Ubuntu18', 'Debian9']) or
-     (pg_version|int < 13 and os in ['Ubuntu20'])  or
+     (pg_version|int < 13 and os in ['Ubuntu20', 'Ubuntu22'])  or
      (pg_version|int < 12 and os in ['Debian10']))
 
 - name: Remove Postgres packages

--- a/roles/manage_dbpatches/README.md
+++ b/roles/manage_dbpatches/README.md
@@ -24,7 +24,7 @@ When executing the role via ansible these are the required variables:
 
   * ***os***
 
-    Operating Systems supported are: CentOS7, CentOS8, RHEL7, RHEL8, Rocky8, AlmaLinux8, Debian10 and Ubuntu20
+    Operating Systems supported are: CentOS7, CentOS8, RHEL7, RHEL8, Rocky8, AlmaLinux8, Debian10, Ubuntu20, and Ubuntu22
 
 The rest of the variables can be configured and are available in the:
 

--- a/roles/manage_dbpatches/defaults/main.yml
+++ b/roles/manage_dbpatches/defaults/main.yml
@@ -60,6 +60,7 @@ supported_os:
   - RedHat7
   - RedHat8
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/manage_efm/README.md
+++ b/roles/manage_efm/README.md
@@ -42,7 +42,7 @@ When executing the role via ansible there are three required variables:
 
   * ***os***
 
-  Operating Systems supported are: CentOS7, RHEL7, CentOS8, RHEL8, Debian10, Ubuntu20 and AlmaLinux8
+  Operating Systems supported are: CentOS7, RHEL7, CentOS8, RHEL8, Debian10, Ubuntu20, Ubuntu22, and AlmaLinux8
 
   * ***pg_version***
 

--- a/roles/manage_efm/defaults/main.yml
+++ b/roles/manage_efm/defaults/main.yml
@@ -50,6 +50,7 @@ supported_os:
   - RedHat7
   - RedHat8
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/manage_pgbouncer/README.md
+++ b/roles/manage_pgbouncer/README.md
@@ -16,7 +16,7 @@ When executing the role via ansible these are the required variables:
 
   * ***os***
 
-    Operating Systems supported are: CentOS7, CentOS8, RHEL7, RHEL8, Rocky8, Ubuntu20, Debian10 and AlmaLinux8
+    Operating Systems supported are: CentOS7, CentOS8, RHEL7, RHEL8, Rocky8, Ubuntu20, Ubuntu22, Debian10 and AlmaLinux8
 
 The rest of the variables can be configured and are available in the:
 

--- a/roles/manage_pgbouncer/defaults/main.yml
+++ b/roles/manage_pgbouncer/defaults/main.yml
@@ -21,3 +21,4 @@ supported_os:
   - Debian10
   - OracleLinux7
   - Ubuntu20
+  - Ubuntu22

--- a/roles/manage_pgpool2/defaults/main.yml
+++ b/roles/manage_pgpool2/defaults/main.yml
@@ -19,6 +19,7 @@ supported_os:
   - AlmaLinux8
   - OracleLinux7
   - Ubuntu20
+  - Ubuntu22
   - Debian10
 
 supported_pg_version:

--- a/roles/setup_barman/defaults/main.yml
+++ b/roles/setup_barman/defaults/main.yml
@@ -33,3 +33,4 @@ supported_os:
   - AlmaLinux8
   - OracleLinux7
   - Ubuntu20
+  - Ubuntu22

--- a/roles/setup_barmanserver/defaults/main.yml
+++ b/roles/setup_barmanserver/defaults/main.yml
@@ -34,3 +34,4 @@ supported_os:
   - AlmaLinux8
   - OracleLinux7
   - Ubuntu20
+  - Ubuntu22

--- a/roles/setup_efm/README.md
+++ b/roles/setup_efm/README.md
@@ -41,7 +41,7 @@ When executing the role via ansible there are three required variables:
 
   * ***os***
 
-  Operating Systems supported are: CentOS7, RHEL7, CentOS8, RHEL8, Debian10, Ubuntu20 and AlmaLinux8
+  Operating Systems supported are: CentOS7, RHEL7, CentOS8, RHEL8, Debian10, Ubuntu20, Ubuntu22, and AlmaLinux8
 
   * ***pg_version***
 

--- a/roles/setup_efm/defaults/main.yml
+++ b/roles/setup_efm/defaults/main.yml
@@ -115,6 +115,7 @@ supported_os:
   - RedHat7
   - RedHat8
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/setup_etcd/README.md
+++ b/roles/setup_etcd/README.md
@@ -26,7 +26,7 @@ When executing the role via ansible there are three required variables:
 
   * ***os***
 
-  Operating Systems supported are: CentOS7, RHEL7, CentOS8, RHEL8, AlmaLinux8, Debian10 and Ubuntu20
+  Operating Systems supported are: CentOS7, RHEL7, CentOS8, RHEL8, AlmaLinux8, Debian10, Ubuntu20, and Ubuntu22
 
   * ***pg_version***
 

--- a/roles/setup_etcd/defaults/main.yml
+++ b/roles/setup_etcd/defaults/main.yml
@@ -77,6 +77,7 @@ supported_os:
   - RedHat7
   - RedHat8
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/setup_fio/defaults/main.yml
+++ b/roles/setup_fio/defaults/main.yml
@@ -17,6 +17,7 @@ supported_os:
   - Debian10
   - OracleLinux8
   - Ubuntu20
+  - Ubuntu22
 
 use_patroni: false
 

--- a/roles/setup_hammerdb/defaults/main.yml
+++ b/roles/setup_hammerdb/defaults/main.yml
@@ -35,6 +35,7 @@ supported_os:
   - Debian10
   - OracleLinux8
   - Ubuntu20
+  - Ubuntu22
 
 use_patroni: false
 

--- a/roles/setup_patroni/README.md
+++ b/roles/setup_patroni/README.md
@@ -29,7 +29,7 @@ When executing the role via ansible there are three required variables:
 
 ### os
 
-Operating Systems supported are: CentOS7, RHEL7, CentOS8, RHEL8, AlmaLinux8, Debian10 and Ubuntu20
+Operating Systems supported are: CentOS7, RHEL7, CentOS8, RHEL8, AlmaLinux8, Debian10, Ubuntu20, and Ubuntu22
 
 ### pg_version
 

--- a/roles/setup_patroni/defaults/main.yml
+++ b/roles/setup_patroni/defaults/main.yml
@@ -151,6 +151,7 @@ supported_os:
   - RedHat7
   - RedHat8
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/setup_pemagent/defaults/main.yml
+++ b/roles/setup_pemagent/defaults/main.yml
@@ -60,6 +60,7 @@ supported_os:
   - OracleLinux7
   - Debian10
   - Ubuntu20
+  - Ubuntu22
 
 supported_pg_type:
   - EPAS

--- a/roles/setup_pemserver/defaults/main.yml
+++ b/roles/setup_pemserver/defaults/main.yml
@@ -74,6 +74,7 @@ supported_os:
   - OracleLinux7
   - Debian10
   - Ubuntu20
+  - Ubuntu22
 
 supported_pg_type:
   - EPAS

--- a/roles/setup_pgbackrest/defaults/main.yml
+++ b/roles/setup_pgbackrest/defaults/main.yml
@@ -36,3 +36,4 @@ supported_os:
   - AlmaLinux8
   - Debian10
   - Ubuntu20
+  - Ubuntu22

--- a/roles/setup_pgbackrestserver/defaults/main.yml
+++ b/roles/setup_pgbackrestserver/defaults/main.yml
@@ -64,6 +64,7 @@ supported_os:
   - AlmaLinux8
   - Debian10
   - Ubuntu20
+  - Ubuntu22
 
 supported_log_level:
   - 'off'

--- a/roles/setup_pgbouncer/defaults/main.yml
+++ b/roles/setup_pgbouncer/defaults/main.yml
@@ -76,3 +76,4 @@ supported_os:
   - Debian10
   - OracleLinux7
   - Ubuntu20
+  - Ubuntu22

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -67,6 +67,7 @@ supported_os:
   - AlmaLinux8
   - OracleLinux7
   - Ubuntu20
+  - Ubuntu22
   - Debian10
 
 supported_pg_version:

--- a/roles/setup_replication/README.md
+++ b/roles/setup_replication/README.md
@@ -23,7 +23,7 @@ When executing the role via ansible there are three required variables:
 
   * ***os***
 
-  Operating Systems supported are: CentOS7, CentOS8, RHEL7, RHEL8, Rocky8, AlmaLinux8, Debian9, Debian10 and Ubuntu20 
+  Operating Systems supported are: CentOS7, CentOS8, RHEL7, RHEL8, Rocky8, AlmaLinux8, Debian9, Debian10, Ubuntu20, and Ubuntu22
 
   * ***pg_version***
 

--- a/roles/setup_replication/defaults/main.yml
+++ b/roles/setup_replication/defaults/main.yml
@@ -67,6 +67,7 @@ supported_os:
   - RedHat8
   - RedHat9
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/setup_repmgr/defaults/main.yml
+++ b/roles/setup_repmgr/defaults/main.yml
@@ -52,6 +52,7 @@ supported_os:
   - RedHat8
   - RedHat9
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -91,6 +91,7 @@ supported_os:
   - RedHat8
   - RedHat9
   - Ubuntu20
+  - Ubuntu22
   - Debian9
   - Debian10
   - Rocky8

--- a/roles/setup_repo/tasks/setup_repo.yml
+++ b/roles/setup_repo/tasks/setup_repo.yml
@@ -22,7 +22,7 @@
     pg_type == 'EPAS' and
     ( pg_version|int < 12 and os in ['RedHat8','CentOS8', 'Rocky8', 'AlmaLinux8'] or
       pg_version|int < 11 and os in ['Ubuntu18', 'Debian9'] or
-      pg_version|int < 13 and os in ['Ubuntu20']  or
+      pg_version|int < 13 and os in ['Ubuntu20', 'Ubuntu22']  or
       pg_version|int < 12 and os in ['Debian10'] )
 
 - name: Validate Credentials


### PR DESCRIPTION
Given that edb-ansible supports Ubuntu20, Ubuntu22 should also be compatible. I didn't physically test every single role, but have worked extensively with install_dbserver, setup_patroni, and setup_etcd, which are all necessary to set up a basic Patroni cluster. None of these were affected simply by adding "Ubuntu22" as a patch, which was necessary for various unrelated tests.