### PR TITLE
core dump related updates

### DIFF
--- a/roles/manage_operating_system/tasks/enable_core_dump.yml
+++ b/roles/manage_operating_system/tasks/enable_core_dump.yml
@@ -27,3 +27,10 @@
     state: present
   when: ansible_os_family == 'RedHat'
   become: true
+
+- name: Install systemd-coredump
+  ansible.builtin.package:
+    name: systemd-coredump
+    state: present
+  when: ansible_os_family == 'Debian'
+  become: true

--- a/roles/manage_operating_system/tasks/enable_core_dump.yml
+++ b/roles/manage_operating_system/tasks/enable_core_dump.yml
@@ -1,4 +1,18 @@
 ---
+# This and reloading sysctl can be removed when tpaexec doesn't force any
+# kernel.core_pattern to be set.
+- name: Remove kernel.core_pattern from tpaexec installed sysctl file
+  ansible.builtin.lineinfile:
+    path: /etc/sysctl.conf
+    search_string: kernel.core_pattern=core.%e.%p.%t
+    state: absent
+  become: true
+
+- name: Reload sysctl settings
+  ansible.builtin.command:
+    cmd: sysctl -p --system
+  become: true
+
 - name: Enable unlimited core size for all users
   community.general.pam_limits:
     domain: "*"

--- a/roles/setup_dbt2/tasks/validate_setup_dbt2.yml
+++ b/roles/setup_dbt2/tasks/validate_setup_dbt2.yml
@@ -3,6 +3,13 @@
 - name: Set dbt2_db_pkg_list
   ansible.builtin.set_fact:
     dbt2_db_pkg_list: ['perf', 'rsync', 'tmux', 'fuse', 'fuse-libs', 'sysstat', 'dejavu-fonts-common', 'fontconfig']
+  when: ansible_os_family == 'RedHat'
+
+# validate dbt2 db packages installation
+- name: Set dbt2_db_pkg_list
+  ansible.builtin.set_fact:
+    dbt2_db_pkg_list: ['linux-perf', 'rsync', 'tmux', 'fuse', 'libfuse2', 'sysstat', 'fonts-dejavu', 'fontconfig']
+  when: ansible_os_family == 'Debian'
 
 - name: Gather the package facts
   ansible.builtin.package_facts:


### PR DESCRIPTION
* clear out potential kernel.core_pattern conflicts from tpaexec
* install systemd-coredump on debian based distros