### PR TITLE
force pgbackrest template config file name

### DIFF
--- a/roles/setup_pgbackrest/tasks/configure_pgbackrest.yml
+++ b/roles/setup_pgbackrest/tasks/configure_pgbackrest.yml
@@ -36,7 +36,7 @@
 
 - name: Build configuration file {{ pgbackrest_configuration_file }}
   ansible.builtin.template:
-    src: "./templates/pgbackrest_{{ group_names[0] }}.{{ pgbackrest_archive_method }}.conf.template"
+    src: "./templates/pgbackrest_{{ group_names |select('match', 'primary|slave') |first }}.{{ pgbackrest_archive_method }}.conf.template"
     dest: "{{ pgbackrest_configuration_file }}"
     owner: "{{ pg_owner }}"
     group: "{{ pg_group }}"


### PR DESCRIPTION
When using the same server for both primary and pgbackrestserver roles, pgbackrest role will fail with following error :
```
Could not find or access
'./templates/pgbackrest_pgbackrestserver.async.conf.template'
```
This is due to server belonging to both 'pgbackrestserver' and 'primary' inventory groups.