### PR TITLE
Fix yum.postgresql.org repository GPG key path

### DIFF
--- a/roles/setup_pgbackrest/tasks/rm_pgbackrest_install_config.yml
+++ b/roles/setup_pgbackrest/tasks/rm_pgbackrest_install_config.yml
@@ -13,7 +13,7 @@
 # add repo facts for RHEL
 - name: Set repo facts for RH os
   ansible.builtin.set_fact:
-    pg_gpg_key_8: "http://yum.postgresql.org/RPM-GPG-KEY-PGDG"
+    pg_gpg_key_8: "http://yum.postgresql.org/keys/RPM-GPG-KEY-PGDG"
     pg_rpm_repo_7: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     pg_rpm_repo_8: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     pg_rpm_repo_9: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm"

--- a/roles/setup_pgbackrestserver/tasks/pgbackrest_install_EPAS.yml
+++ b/roles/setup_pgbackrestserver/tasks/pgbackrest_install_EPAS.yml
@@ -5,7 +5,7 @@
 # add repo facts for RHEL
 - name: Set repo facts for RH os
   ansible.builtin.set_fact:
-    pg_gpg_key_8: "http://yum.postgresql.org/RPM-GPG-KEY-PGDG"
+    pg_gpg_key_8: "http://yum.postgresql.org/keys/RPM-GPG-KEY-PGDG"
     pg_rpm_repo_7: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     pg_rpm_repo_8: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     pg_rpm_repo_9: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm"

--- a/roles/setup_pgbackrestserver/tasks/rm_pgbackrestserver_install_config.yml
+++ b/roles/setup_pgbackrestserver/tasks/rm_pgbackrestserver_install_config.yml
@@ -32,7 +32,7 @@
 # add repo facts for RHEL
 - name: Set repo facts for RH os
   ansible.builtin.set_fact:
-    pg_gpg_key_8: "http://yum.postgresql.org/RPM-GPG-KEY-PGDG"
+    pg_gpg_key_8: "http://yum.postgresql.org/keys/RPM-GPG-KEY-PGDG"
     pg_rpm_repo_7: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     pg_rpm_repo_8: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
     pg_rpm_repo_9: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm"

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -64,7 +64,7 @@ pg_deb_keys: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 pg_rpm_repo_7_x86_64: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
 pg_rpm_repo_8_x86_64: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
 pg_rpm_repo_9_x86_64: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
-pg_gpg_key_8_x86_64: "http://yum.postgresql.org/RPM-GPG-KEY-PGDG"
+pg_gpg_key_8_x86_64: "http://yum.postgresql.org/keys/RPM-GPG-KEY-PGDG"
 # Postgresql Repos aarch64
 pg_rpm_repo_8_aarch64: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-aarch64/pgdg-redhat-repo-latest.noarch.rpm"
 pg_rpm_repo_9_aarch64: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-aarch64/pgdg-redhat-repo-latest.noarch.rpm"


### PR DESCRIPTION
The current path for the PostgreSQL yum repository GPG key is invalid, and returns a 404 error: http://yum.postgresql.org/RPM-GPG-KEY-PGDG

The key is in fact at: http://yum.postgresql.org/keys/RPM-GPG-KEY-PGDG

This patch fixes that.