### PR TITLE
fix class KeyError original message: ansible_host

### DIFF
--- a/plugins/lookup/barman_server.py
+++ b/plugins/lookup/barman_server.py
@@ -63,7 +63,7 @@ class LookupModule(LookupBase):
             return [
                 dict(
                     node_type='barmanserver',
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
                     private_ip=hostvars['private_ip'],
                     inventory_hostname=hostvars['inventory_hostname']

--- a/plugins/lookup/dbt2_client.py
+++ b/plugins/lookup/dbt2_client.py
@@ -63,7 +63,7 @@ class LookupModule(LookupBase):
             return [
                 dict(
                     node_type='dbt2client',
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
                     private_ip=hostvars['private_ip'],
                     inventory_hostname=hostvars['inventory_hostname']

--- a/plugins/lookup/efm_nodes.py
+++ b/plugins/lookup/efm_nodes.py
@@ -65,7 +65,7 @@ class LookupModule(LookupBase):
             efm_clusters[private_ip].append(
                 dict(
                     node_type='primary',
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname',
                                           hostvars.get('ansible_hostname')),
                     private_ip=hostvars['private_ip'],
@@ -82,7 +82,7 @@ class LookupModule(LookupBase):
                 hostvars = myvars['hostvars'][host]
                 efm_standbys[host] = dict(
                     node_type='standby',
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname',
                                           hostvars.get('ansible_hostname')),
                     private_ip=hostvars['private_ip'],
@@ -100,7 +100,7 @@ class LookupModule(LookupBase):
                 hostvars = myvars['hostvars'][host]
                 efm_witnesses[host] = dict(
                     node_type='witness',
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname',
                                           hostvars.get('ansible_hostname')),
                     private_ip=hostvars['private_ip'],

--- a/plugins/lookup/etcd_cluster_nodes.py
+++ b/plugins/lookup/etcd_cluster_nodes.py
@@ -81,7 +81,7 @@ class LookupModule(LookupBase):
                         continue
 
                     etcd_node = dict(
-                        ansible_host=hostvars['ansible_host'],
+                        ansible_host=hostvars.get('ansible_host'),
                         hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
                         private_ip=hostvars['private_ip'],
                         inventory_hostname=hostvars['inventory_hostname'],

--- a/plugins/lookup/hammerdb.py
+++ b/plugins/lookup/hammerdb.py
@@ -63,7 +63,7 @@ class LookupModule(LookupBase):
             return [
                 dict(
                     node_type='hammerdb',
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
                     private_ip=hostvars['private_ip'],
                     inventory_hostname=hostvars['inventory_hostname']

--- a/plugins/lookup/haproxy_backends.py
+++ b/plugins/lookup/haproxy_backends.py
@@ -68,7 +68,7 @@ class LookupModule(LookupBase):
                         continue
 
                     backend_node = dict(
-                        ansible_host=hostvars['ansible_host'],
+                        ansible_host=hostvars.get('ansible_host'),
                         inventory_hostname=hostvars['inventory_hostname'],
                         hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
                         proxy_location=hostvars.get('proxy_location', hostvars['proxy_location']),

--- a/plugins/lookup/pem_agents.py
+++ b/plugins/lookup/pem_agents.py
@@ -62,7 +62,7 @@ class LookupModule(LookupBase):
                 nodes.append(
                     dict(
                         node_type=node_type,
-                        ansible_host=hv['ansible_host'],
+                        ansible_host=hv.get('ansible_host'),
                         hostname=hv.get('hostname', hv['ansible_hostname']),
                         private_ip=hv['private_ip'],
                         inventory_hostname=hv['inventory_hostname']

--- a/plugins/lookup/pem_server.py
+++ b/plugins/lookup/pem_server.py
@@ -62,7 +62,7 @@ class LookupModule(LookupBase):
             return [
                 dict(
                     node_type='pemserver',
-                    ansible_host=hv['ansible_host'],
+                    ansible_host=hv.get('ansible_host'),
                     hostname=hv.get('hostname', hv.get('ansible_hostname', None)),
                     private_ip=hv['private_ip'],
                     inventory_hostname=hv['inventory_hostname']

--- a/plugins/lookup/pg_service.py
+++ b/plugins/lookup/pg_service.py
@@ -19,8 +19,8 @@ from ansible.plugins.lookup import LookupBase
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
 
-        pg_type = variables.get('pg_type', '13')
-        pg_version = variables.get('pg_version', 'PG')
+        pg_type = variables.get('pg_type', 'PG')
+        pg_version = variables.get('pg_version', '13')
         pg_instance_name = variables.get('pg_instance_name', 'main')
         ansible_os_family = variables.get('ansible_os_family', 'RedHat')
 

--- a/plugins/lookup/pg_sr_cluster_nodes.py
+++ b/plugins/lookup/pg_sr_cluster_nodes.py
@@ -64,7 +64,7 @@ class LookupModule(LookupBase):
             pg_clusters[private_ip].append(
                 dict(
                     node_type='primary',
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname',
                                           hostvars.get('ansible_hostname')),
                     private_ip=hostvars['private_ip'],
@@ -81,7 +81,7 @@ class LookupModule(LookupBase):
                 hostvars = myvars['hostvars'][host]
                 pg_standbys[host] = dict(
                     node_type='standby',
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname',
                                           hostvars.get('ansible_hostname')),
                     private_ip=hostvars['private_ip'],

--- a/plugins/lookup/pgbackrest_nodes.py
+++ b/plugins/lookup/pgbackrest_nodes.py
@@ -93,7 +93,7 @@ class LookupModule(LookupBase):
                     pgbr_nodes.append(dict(
                         node_type='primary',
                         inventory_hostname=hostvars['inventory_hostname'],
-                        ansible_host=hostvars['ansible_host'],
+                        ansible_host=hostvars.get('ansible_host'),
                         hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
                         private_ip=hostvars['private_ip'],
                         index_var=str(counter)
@@ -128,7 +128,7 @@ class LookupModule(LookupBase):
                             pgbr_nodes.append(dict(
                                 node_type='standby',
                                 inventory_hostname=hostvars['inventory_hostname'],
-                                ansible_host=hostvars['ansible_host'],
+                                ansible_host=hostvars.get('ansible_host'),
                                 hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
                                 private_ip=hostvars['private_ip'],
                                 index_var=str(counter)

--- a/plugins/lookup/pgbackrest_server.py
+++ b/plugins/lookup/pgbackrest_server.py
@@ -63,7 +63,7 @@ class LookupModule(LookupBase):
             return [
                 dict(
                     node_type='pgbackrestserver',
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
                     private_ip=hostvars['private_ip'],
                     inventory_hostname=hostvars['inventory_hostname']

--- a/plugins/lookup/pgd_lead_primary.py
+++ b/plugins/lookup/pgd_lead_primary.py
@@ -72,7 +72,7 @@ class LookupModule(LookupBase):
 
             pgd_node = dict(
                 node_type='primary',
-                ansible_host=hostvars['ansible_host'],
+                ansible_host=hostvars.get('ansible_host'),
                 hostname=hostvars.get(
                     'hostname', hostvars.get('ansible_hostname')
                 ),

--- a/plugins/lookup/pgd_nodes.py
+++ b/plugins/lookup/pgd_nodes.py
@@ -63,7 +63,7 @@ class LookupModule(LookupBase):
 
             pgd_node = dict(
                 node_type='primary',
-                ansible_host=hostvars['ansible_host'],
+                ansible_host=hostvars.get('ansible_host'),
                 hostname=hostvars.get(
                     'hostname', hostvars.get('ansible_hostname')
                 ),

--- a/plugins/lookup/pgpool2_nodes.py
+++ b/plugins/lookup/pgpool2_nodes.py
@@ -59,7 +59,7 @@ class LookupModule(LookupBase):
                 dict(
                     node_id=node_id,
                     node_type='pgpool2',
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     private_ip=hostvars['private_ip'],
                     hostname=hostvars.get('hostname', hostvars['ansible_hostname']),
                     inventory_hostname=hostvars['inventory_hostname'],

--- a/plugins/lookup/repmgr_nodes.py
+++ b/plugins/lookup/repmgr_nodes.py
@@ -68,7 +68,7 @@ class LookupModule(LookupBase):
                 dict(
                     node_type='primary',
                     id=node_id[private_ip],
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname',
                                           hostvars.get('ansible_hostname')),
                     private_ip=hostvars['private_ip'],
@@ -87,7 +87,7 @@ class LookupModule(LookupBase):
                 repmgr_standbys[host] = dict(
                     node_type='standby',
                     id=node_id[hostvars['upstream_node_private_ip']],
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname',
                                           hostvars.get('ansible_hostname')),
                     private_ip=hostvars['private_ip'],
@@ -107,7 +107,7 @@ class LookupModule(LookupBase):
                 repmgr_witnesses[host] = dict(
                     node_type='witness',
                     id=node_id[hostvars['upstream_node_private_ip']],
-                    ansible_host=hostvars['ansible_host'],
+                    ansible_host=hostvars.get('ansible_host'),
                     hostname=hostvars.get('hostname',
                                           hostvars.get('ansible_hostname')),
                     private_ip=hostvars['private_ip'],


### PR DESCRIPTION
When ansible_host is defined in an inventory file in the .ini format, ansible is unable to retrieve the value and fails with following error:

TASK [edb_devops.edb_postgres.setup_replication : Gather the cluster_nodes information] ************************************************************************************************************* task path: /home/user/.ansible/collections/ansible_collections/edb_devops/edb_postgres/roles/setup_replication/tasks/setup_replication.yml:51 fatal: [hostname]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'edb_devops.edb_postgres.pg_sr_cluster_nodes'. Error was a <class 'KeyError'>, original message: 'ansible_host'. 'ansible_host'"}

inventory example:
```
[primary]
primary1 ansible_host=primary1 private_ip=x.x.x.1

[standby]
standby1 ansible_host=standby1 private_ip=x.x.x.2 upstream_node_private_ip=x.x.x.1 replication_type=synchronous
standby2 ansible_host=standby2 private_ip=x.x.x.3 upstream_node_private_ip=x.x.x.1 replication_type=synchronous
```