### PR TITLE
Add support for standard EDB subscription plan for repo script download

### DIFF
--- a/roles/setup_repo/README.md
+++ b/roles/setup_repo/README.md
@@ -54,6 +54,10 @@ When executing the role via Ansible these are the required variables:
   EDB repository token used to access EDB package repository.
   Required when **enable_edb_repo** is set to `true` and **repo_username** and **repo_password** aren't used.
 
+  * **repo_plan**
+
+  Configure the EDB support plan. Plans supported are: `standard` and `enterprise`. Default: `enterprise`
+
   * **enable_pgdg_repo** 
 
   Configure access to the PGDG package repository. Default: `true`. Only set to `false` when using local repositories. 

--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -5,11 +5,12 @@
 # PG_RPMREPO: "https://yum.enterprisedb.com/edb-repo-rpms/edb-repo-latest.noarch.rpm"
 # After 06/23/2020 - Redesigned EDB Portal
 
-# EDB repository username, password and subscription token
+# EDB repository username, password, subscription token and subscription plan
 enable_edb_repo: true
 repo_token: ""
 repo_username: ""
 repo_password: ""
+repo_plan: "enterprise"
 
 # TPA Specific token variable
 tpa_subscription_token: ""
@@ -37,7 +38,7 @@ edb_2q_repositories:
   - bdr4/release
   - harp/release
 edb_repo_base_download: "https://downloads.enterprisedb.com/{{ repo_token }}"
-edb_repo_script_link: "{{ edb_repo_base_download }}/enterprise/setup.{{ 'rpm' if ansible_os_family == 'RedHat' else 'deb' }}.sh"
+edb_repo_script_link: "{{ edb_repo_base_download }}/{{ repo_plan }}/setup.{{ 'rpm' if ansible_os_family == 'RedHat' else 'deb' }}.sh"
 
 # EDB postgres_distributed RPM repo links
 pgd_rpm_repo:


### PR DESCRIPTION
This is in addition to the current support for the enterprise plan, and makes it configurable, with the default remaining enterprise.

Addresses #619.