### PR TITLE
Fix EDB package repo assertion failure when repo token is used on Debian

### DIFF
--- a/roles/setup_repo/tasks/validate_setup_repo_aarch64.yml
+++ b/roles/setup_repo/tasks/validate_setup_repo_aarch64.yml
@@ -52,7 +52,7 @@
 # - name: Check for EDB Repo on Debian
 #   ansible.builtin.assert:
 #     that:
-#       - "'apt.enterprisedb.com' in apt_sources.stdout"
+#       - "'enterprisedb.com' in apt_sources.stdout"
 #     fail_msg: "Access to the EDB package repository is not configured"
 #     success_msg: "Access to the EDB package repository has been configured successfully"
 #   when:

--- a/roles/setup_repo/tasks/validate_setup_repo_x86_64.yml
+++ b/roles/setup_repo/tasks/validate_setup_repo_x86_64.yml
@@ -106,7 +106,7 @@
 - name: Check for EDB Repo on Debian
   ansible.builtin.assert:
     that:
-      - "'apt.enterprisedb.com' in apt_sources.stdout"
+      - "'enterprisedb.com' in apt_sources.stdout"
     fail_msg: "Access to the EDB package repository is not configured"
     success_msg: "Access to the EDB package repository has been configured successfully"
   when:


### PR DESCRIPTION
The current Ansible repo check on Debian looks as follows:

```
 - name: Check for EDB Repo on Debian
   ansible.builtin.assert:
     that:
      - "'apt.enterprisedb.com' in apt_sources.stdout"
     fail_msg: "Access to the EDB package repository is not configured"
     success_msg: "Access to the EDB package repository has been configured successfully"
```

The trouble is that when the repo token is used, the line in the apt source looks as follows:

```
deb [signed-by=/usr/share/keyrings/enterprisedb-standard-archive-keyring.gpg] https://downloads.enterprisedb.com/<redacted>/standard/deb/ubuntu <codename> main
```

Since it configures `downloads.enterprisedb.com` it does not match `apt.enterprisedb.com` and the assertion fails, abandoning the rest of the playbook. The patch removes the prefix and checks only for `enterprisedb.com` to ensure that both options are supported.