### PR TITLE
Adjust python-apt package to be findable on newer Debian/Ubuntu versions

### DIFF
--- a/roles/install_dbserver/tasks/validate_install_dbserver.yml
+++ b/roles/install_dbserver/tasks/validate_install_dbserver.yml
@@ -97,12 +97,21 @@
     - ansible_os_family == 'RedHat'
     - pg_version|int > 10
 
-- name: Install python-apt package
+- name: Install python-apt package for Debian 9/10
+  ansible.builtin.package:
+    name: python-apt
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_distribution_major_version in ['9', '10']
+
+- name: Install python3-apt package for Debian 11/12
   ansible.builtin.package:
     name: python3-apt
     state: present
   when:
     - ansible_os_family == 'Debian'
+    - ansible_distribution_major_version in ['11', '12']
 
 - name: Set package list for PG Debian
   ansible.builtin.set_fact:

--- a/roles/install_dbserver/tasks/validate_install_dbserver.yml
+++ b/roles/install_dbserver/tasks/validate_install_dbserver.yml
@@ -99,7 +99,7 @@
 
 - name: Install python-apt package
   ansible.builtin.package:
-    name: python-apt
+    name: python3-apt
     state: present
   when:
     - ansible_os_family == 'Debian'


### PR DESCRIPTION
At the moment `python-apt` is installed on Debian-based distros using the following:

```
 - name: Install python-apt package
   ansible.builtin.package:
     name: python-apt
     state: present
   when:
     - ansible_os_family == 'Debian'
```

On newer versions of these distros, the `python-apt` package has been superseded by `python3-apt`, so the playbook fails at this point. Since all other references in `roles/install_dbserver/tasks/validate_install_dbserver.yml` are already configured to use the `python3` versions, e.g.:

```
grep python3 roles/install_dbserver/tasks/validate_install_dbserver.yml
        'python3-pycurl', 'python3-libselinux', 'python3-psycopg2', 'glibc-langpack-en'
        'python3-pip', 'python3-psycopg2'
        'ca-certificates', 'python3-pycurl', 'python3-psycopg2', 'postgresql-' + pg_version | string,
        'python3-pip', 'python3-psycopg2', 'edb-as' + pg_version | string + '-server',
```

We are probably safe to proceed with this change. 