### PR TITLE
Make pgpool2 backend flag configurable

### DIFF
--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -49,6 +49,7 @@ pgpool2_ssl_csr_dn:
   EMAIL: "example@mail.com"
 
 pgpool2_service_users: []
+pgpool2_backend_flag: "ALLOW_TO_FAILOVER"
 
 # setting validate_only to true allows you to validate setup on an existing node
 # use_validation flag applies to deployment configuration and validation after setup

--- a/roles/setup_pgpool2/tasks/pgpool2_configure_backends.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_configure_backends.yml
@@ -36,7 +36,7 @@
         },
         {
           'key': 'backend_flag' + ansible_loop.index0 | string,
-          'value': 'ALLOW_TO_FAILOVER',
+          'value': pgpool2_backend_flag,
           'state': 'present',
           'quoted': true
         }


### PR DESCRIPTION
Leaving the default as `ALLOW_TO_FAILOVER`.