### PR TITLE
Disable RPM GPG key checks for PGDG repo and fix key paths

### DIFF
--- a/roles/setup_repo/defaults/main.yml
+++ b/roles/setup_repo/defaults/main.yml
@@ -65,12 +65,12 @@ pg_deb_keys: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 pg_rpm_repo_7_x86_64: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
 pg_rpm_repo_8_x86_64: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
 pg_rpm_repo_9_x86_64: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
-pg_gpg_key_8_x86_64: "http://yum.postgresql.org/keys/RPM-GPG-KEY-PGDG"
+pg_gpg_key_8_x86_64: "https://yum.postgresql.org/keys/RPM-GPG-KEY-PGDG"
 # Postgresql Repos aarch64
 pg_rpm_repo_8_aarch64: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-aarch64/pgdg-redhat-repo-latest.noarch.rpm"
 pg_rpm_repo_9_aarch64: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-aarch64/pgdg-redhat-repo-latest.noarch.rpm"
-pg_gpg_key_8_aarch64: "https://yum.postgresql.org/RPM-GPG-KEY-PGDG-AARCH64-RHEL8"
-pg_gpg_key_9_aarch64: "https://yum.postgresql.org/RPM-GPG-KEY-PGDG-AARCH64-RHEL9"
+pg_gpg_key_8_aarch64: "https://yum.postgresql.org/keys/RPM-GPG-KEY-PGDG-AARCH64-RHEL8"
+pg_gpg_key_9_aarch64: "https://yum.postgresql.org/keys/RPM-GPG-KEY-PGDG-AARCH64-RHEL9"
 
 # epel Repo
 epel_repo_7: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"

--- a/roles/setup_repo/tasks/PG_RedHat_setuprepos_x86_64.yml
+++ b/roles/setup_repo/tasks/PG_RedHat_setuprepos_x86_64.yml
@@ -55,6 +55,7 @@
   ansible.builtin.package:
     name: "{{ pg_rpm_repo_7_x86_64 }}"
     state: present
+    disable_gpg_check: true
   become: true
   when:
     - ansible_distribution_major_version == '7'
@@ -113,6 +114,7 @@
   ansible.builtin.package:
     name: "{{ pg_rpm_repo_8_x86_64 }}"
     state: present
+    disable_gpg_check: true
   become: true
   when:
     - ansible_distribution_major_version == '8'


### PR DESCRIPTION
This should allow the Github tests to start succeeding as well. It seems that the GPG keys are for the packages in the yum repo, not for the RPM package to install the repo, so it doesn't succeed with a GPG check.