### PR TITLE
Remove jinja2 templating from assertion predicates

### DIFF
--- a/roles/execute_binary_upgrade/tasks/validate_execute_binary_upgrade.yml
+++ b/roles/execute_binary_upgrade/tasks/validate_execute_binary_upgrade.yml
@@ -204,7 +204,7 @@
 - name: Check that all required packages have been installed
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[package] }} is defined"
+      - ansible_facts.packages[package] is defined
     fail_msg: "Package {{ package }} has not been installed."
     success_msg: "Package {{ package }} has been installed."
   loop: "{{ package_list }}"

--- a/roles/install_dbserver/tasks/validate_install_dbserver.yml
+++ b/roles/install_dbserver/tasks/validate_install_dbserver.yml
@@ -187,7 +187,7 @@
 - name: Check that all required packages have been installed
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[package] }} is defined"
+      - ansible_facts.packages[package] is defined
     fail_msg: "Package {{ package }} has not been installed."
     success_msg: "Package {{ package }} has been installed."
   loop: "{{ package_list }}"

--- a/roles/setup_barman/tasks/validate_setup_barman.yml
+++ b/roles/setup_barman/tasks/validate_setup_barman.yml
@@ -42,7 +42,7 @@
 - name: Check if backup server has been configured correctly.
   ansible.builtin.assert:
     that:
-      - barman_list_server_res.stdout_lines is search('{{ primary_inventory_hostname }}')
+      - barman_list_server_res.stdout_lines is search(primary_inventory_hostname)
     fail_msg: "{{ primary_inventory_hostname }} backup server was not configured correctly."
     success_msg: "{{ primary_inventory_hostname }} backup server was configured correctly."
   run_once: true
@@ -64,7 +64,7 @@
 - name: Check if barman home directory has been configured correctly
   ansible.builtin.assert:
     that:
-      - barman_show_server_res.stdout_lines is search('{{ barman_home }}')
+      - barman_show_server_res.stdout_lines is search(barman_home)
     fail_msg: "{{ barman_home }} directory was not configured correctly"
     success_msg: "{{ barman_home }} directory was configured correctly"
   run_once: true

--- a/roles/setup_barmanserver/tasks/validate_setup_barmanserver.yml
+++ b/roles/setup_barmanserver/tasks/validate_setup_barmanserver.yml
@@ -8,7 +8,7 @@
 - name: Check that all required barman packages have been installed
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[item] }} is defined"
+      - ansible_facts.packages[item] is defined
     fail_msg: "Package {{ item }} has not been installed."
     success_msg: "Package {{ item }} has been installed."
   loop:

--- a/roles/setup_dbt2/tasks/validate_setup_dbt2.yml
+++ b/roles/setup_dbt2/tasks/validate_setup_dbt2.yml
@@ -18,7 +18,7 @@
 - name: Check that all packages in dbt2_db_pkg_list has been installed
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[package] }} is defined"
+      - ansible_facts.packages[package] is defined
     fail_msg: "Package {{ package }} has not been installed."
     success_msg: "Package {{ package }} has been installed."
   loop: "{{ dbt2_db_pkg_list }}"

--- a/roles/setup_dbt2_client/tasks/validate_setup_dbt2_client.yml
+++ b/roles/setup_dbt2_client/tasks/validate_setup_dbt2_client.yml
@@ -11,7 +11,7 @@
 - name: Check that all packages in dbt2_client_pkg_list has been installed
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[package] }} is defined"
+      - ansible_facts.packages[package] is defined
     fail_msg: "Package {{ package }} has not been installed."
     success_msg: "Package {{ package }} has been installed."
   loop: "{{ dbt2_client_pkg_list }}"

--- a/roles/setup_dbt2_driver/tasks/validate_setup_dbt2_driver.yml
+++ b/roles/setup_dbt2_driver/tasks/validate_setup_dbt2_driver.yml
@@ -11,7 +11,7 @@
 - name: Check that all packages in dbt2_driver_pkg_list has been installed
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[package] }} is defined"
+      - ansible_facts.packages[package] is defined
     fail_msg: "Package {{ package }} has not been installed."
     success_msg: "Package {{ package }} has been installed."
   loop: "{{ dbt2_driver_pkg_list }}"

--- a/roles/setup_dbt3/tasks/validate_setup_dbt3.yml
+++ b/roles/setup_dbt3/tasks/validate_setup_dbt3.yml
@@ -11,7 +11,7 @@
 - name: Check that all packages in dbt3_db_pkg_list has been installed
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[package] }} is defined"
+      - ansible_facts.packages[package] is defined
     fail_msg: "Package {{ package }} has not been installed."
     success_msg: "Package {{ package }} has been installed."
   loop: "{{ dbt3_db_pkg_list }}"

--- a/roles/setup_dbt7/tasks/validate_setup_dbt7.yml
+++ b/roles/setup_dbt7/tasks/validate_setup_dbt7.yml
@@ -11,7 +11,7 @@
 - name: Check that all packages in dbt7_db_pkg_list has been installed
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[package] }} is defined"
+      - ansible_facts.packages[package] is defined
     fail_msg: "Package {{ package }} has not been installed."
     success_msg: "Package {{ package }} has been installed."
   loop: "{{ dbt7_db_pkg_list }}"

--- a/roles/setup_efm/tasks/validate_setup_efm.yml
+++ b/roles/setup_efm/tasks/validate_setup_efm.yml
@@ -55,7 +55,7 @@
 - name: Check that all required packages have been installed on RedHat
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[item] }} is defined"
+      - ansible_facts.packages[item] is defined
     fail_msg: "Package {{ item }} has not been installed."
     success_msg: "Package {{ item }} has been installed."
   loop:
@@ -66,7 +66,7 @@
 - name: Check that all required packages have been installed on Debian
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[item] }} is defined"
+      - ansible_facts.packages[item] is defined
     fail_msg: "Package {{ item }} has not been installed."
     success_msg: "Package {{ item }} has been installed."
   loop:

--- a/roles/setup_pemserver/tasks/validate_setup_pemserver.yml
+++ b/roles/setup_pemserver/tasks/validate_setup_pemserver.yml
@@ -67,7 +67,7 @@
 - name: Check that all required packages have been installed
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[item] }} is defined"
+      - ansible_facts.packages[item] is defined
     fail_msg: "Package {{ item }} has not been installed."
     success_msg: "Package {{ item }} has been installed."
   loop: "{{ pem_server_packages }}"

--- a/roles/setup_pgpool2/tasks/validate_setup_pgpool2.yml
+++ b/roles/setup_pgpool2/tasks/validate_setup_pgpool2.yml
@@ -55,7 +55,7 @@
 - name: Check that all required pgpool2 packages have been installed
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts.packages[package] }} is defined"
+      - ansible_facts.packages[package] is defined
     fail_msg: "Package {{ package }} has not been installed."
     success_msg: "Package {{ package }} has been installed."
   loop: "{{ pgpool2_packages_check }}"


### PR DESCRIPTION
This addresses a fatal error in newer Ansible versions caused by a warning stating that "conditional statements should not include jinja2 templating". This warning leads to the fatal error stating that the conditional check is marked as unsafe.

This patch removes the jinja templating from the strings and also removes the strings themselves, leaving the bare predicate.