### PR TITLE
Make PgPool PCP package name configurable on RHEL

### DIFF
--- a/roles/setup_pgpool2/tasks/pgpool2_install.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_install.yml
@@ -29,7 +29,7 @@
 
 - name: Install pgpool-II-pcp package on RedHat
   ansible.builtin.package:
-    name: "pgpool-II-pcp"
+    name: "{{ pgpool2_pcp_package_name }}"
     state: present
   when:
     - ansible_os_family == 'RedHat'

--- a/roles/setup_pgpool2/vars/PG_RedHat.yml
+++ b/roles/setup_pgpool2/vars/PG_RedHat.yml
@@ -2,6 +2,7 @@
 pgpool2_version: 4.3
 # We don't have the choice of the version with community PostgreSQL
 pgpool2_package_name: "pgpool-II"
+pgpool2_pcp_package_name: "pgpool-II-pcp"
 pgpool2_configuration_file: "/etc/pgpool-II/pgpool.conf"
 pgpool2_pool_passwd_file: "/etc/pgpool-II/pool_passwd"
 pgpool2_user: "postgres"


### PR DESCRIPTION
At the moment, the PgPool package can be specified manually, but the corresponding pcp package on RHEL cannot. This patch allows for that, keeping the existing defaults. A patch is not needed for EPAS, as it does not make use of such a package.