### PR TITLE
Add minimum EFM PgPool integration values

### DIFF
--- a/roles/setup_efm/defaults/main.yml
+++ b/roles/setup_efm/defaults/main.yml
@@ -108,6 +108,8 @@ pcp_passfile_owner: "efm"
 pcp_passfile_group: "efm"
 pcp_passfile_mode: "0600"
 pgpool2_pcp_port: 9898
+efm_pgpool2_lb_attach: "{{ efm_bin_path }}/pcp_attach_all.sh %h %t"
+efm_pgpool2_lb_detach: ""
 
 supported_os:
   - CentOS7

--- a/roles/setup_efm/tasks/efm_configure.yml
+++ b/roles/setup_efm/tasks/efm_configure.yml
@@ -45,7 +45,7 @@
       - {name: custom.monitor.interval, value: "5"}
       - {name: custom.monitor.safe.mode, value: "true"}
       - {name: custom.monitor.timeout, value: "10"}
-      - {name: pgpool.enable, value: "{{ efm_pgpool2_integration|lower }}"}
+      - {name: pgpool.enable, value: "{{ efm_pgpool2_integration | lower }}"}
       - {name: pgpool.bin, value: "{{ pgpool2_bin_path }}"}
       - {name: pcp.user, value: "{{ pcp_admin_user }}"}
       - {name: pcp.host, value: "{{ pgpool2_vip }}"}

--- a/roles/setup_efm/tasks/efm_configure.yml
+++ b/roles/setup_efm/tasks/efm_configure.yml
@@ -40,12 +40,20 @@
 - name: Prepare parameters for PgPoolII integration
   ansible.builtin.set_fact:
     efm_lb_parameters:
-      - {name: script.load.balancer.attach, value: "{{ efm_bin_path }}/pcp_attach_all.sh %h %t"}
       - {name: auto.resume.period, value: "5"}
       - {name: script.custom.monitor, value: "{{ efm_bin_path }}/pg_pcp_health.sh"}
       - {name: custom.monitor.interval, value: "5"}
       - {name: custom.monitor.safe.mode, value: "true"}
       - {name: custom.monitor.timeout, value: "10"}
+      - {name: detach.on.agent.failure, value: "{{ detach_on_agent_failure|lower }}"}
+      - {name: pgpool.enable, value: "{{ efm_pgpool2_integration|lower }}"}
+      - {name: pgpool.bin, value: "{{ pgpool2_bin_path }}"}
+      - {name: pcp.user, value: "{{ pcp_admin_user }}"}
+      - {name: pcp.host, value: "{{ pgpool2_vip }}"}
+      - {name: pcp.port, value: "{{ pgpool2_pcp_port }}"}
+      - {name: pcp.pass.file, value: "{{ pcp_passfile }}"}
+      - {name: script.load.balancer.attach, value: "{{ efm_pgpool2_lb_attach }}"}
+      - {name: script.load.balancer.detach, value: "{{ efm_pgpool2_lb_detach }}"}
   when:
     - efm_pgpool2_integration
 

--- a/roles/setup_efm/tasks/efm_configure.yml
+++ b/roles/setup_efm/tasks/efm_configure.yml
@@ -45,7 +45,6 @@
       - {name: custom.monitor.interval, value: "5"}
       - {name: custom.monitor.safe.mode, value: "true"}
       - {name: custom.monitor.timeout, value: "10"}
-      - {name: detach.on.agent.failure, value: "{{ detach_on_agent_failure|lower }}"}
       - {name: pgpool.enable, value: "{{ efm_pgpool2_integration|lower }}"}
       - {name: pgpool.bin, value: "{{ pgpool2_bin_path }}"}
       - {name: pcp.user, value: "{{ pcp_admin_user }}"}


### PR DESCRIPTION
At the moment there is an option to enable EFM PgPool integration, but the integration is incomplete as it does not include the minimum parameters required by EFM to complete the integration. As such, the flag is currently not viable, even though it exists.

This patch fixes this by making use of existing variables to populate the configuration when the flag is enabled, and allows for the attach and detach scripts to be made configurable.