### PR TITLE
Prevent firewall.d removal

### DIFF
--- a/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
@@ -15,7 +15,6 @@
   ansible.builtin.package:
     name:
       - python-pycurl
-      - libselinux-python
       - python2-psycopg2
       - python-ipaddress
     state: absent
@@ -26,7 +25,6 @@
   ansible.builtin.package:
     name:
       - python3-pycurl
-      - python3-libselinux
       - python3-psycopg2
     state: absent
   become: true


### PR DESCRIPTION
When removing python3-SELinux package the firewalld package is removed too. there is a dependency with the firewalld package